### PR TITLE
Add now mandatory MONGODB_ADMIN_PASSWORD

### DIFF
--- a/eap/eap6-mongodb-sti.json
+++ b/eap/eap6-mongodb-sti.json
@@ -76,6 +76,12 @@
             "value": "root"
         },
         {
+            "description": "Database admin password",
+            "name": "DB_ADMIN_PASSWORD",
+            "from": "[a-zA-Z0-9]{8}",
+            "generate": "expression"
+        },
+        {
             "description": "The name of the secret containing the keystore file",
             "name": "EAP_HTTPS_SECRET",
             "value": "eap-app-secret"
@@ -402,6 +408,10 @@
                                         "value": "${DB_DATABASE}"
                                     },
                                     {
+                                        "name": "DB_ADMIN_PASSWORD",
+                                        "value": "${DB_ADMIN_PASSWORD}"
+                                    },
+                                    {
                                         "name": "OPENSHIFT_DNS_PING_SERVICE_NAME",
                                         "value": "${APPLICATION_NAME}-ping"
                                     },
@@ -505,6 +515,10 @@
                                     {
                                         "name": "MONGODB_DATABASE",
                                         "value": "${DB_DATABASE}"
+                                    },
+                                    {
+                                        "name": "MONGODB_ADMIN_PASSWORD",
+                                        "value": "${DB_ADMIN_PASSWORD}"
                                     }
                                 ]
                             }

--- a/webserver/jws-tomcat7-mongodb-sti.json
+++ b/webserver/jws-tomcat7-mongodb-sti.json
@@ -94,6 +94,12 @@
             "description": "Database name",
             "name": "DB_DATABASE",
             "value": "root"
+        },
+        {
+            "description": "Database admin password",
+            "name": "DB_ADMIN_PASSWORD",
+            "from": "[a-zA-Z0-9]{8}",
+            "generate": "expression"
         }
     ],
     "objects": [
@@ -362,6 +368,10 @@
                                         "value": "${DB_DATABASE}"
                                     },
                                     {
+                                        "name": "DB_ADMIN_PASSWORD",
+                                        "value": "${DB_ADMIN_PASSWORD}"
+                                    },
+                                    {
                                         "name": "JWS_HTTPS_CERTIFICATE_DIR",
                                         "value": "/etc/jws-secret-volume"
                                     },
@@ -457,6 +467,10 @@
                                     {
                                         "name": "MONGODB_DATABASE",
                                         "value": "${DB_DATABASE}"
+                                    },
+                                    {
+                                        "name": "MONGODB_ADMIN_PASSWORD",
+                                        "value": "${DB_ADMIN_PASSWORD}"
                                     }
                                 ]
                             }

--- a/webserver/jws-tomcat8-mongodb-sti.json
+++ b/webserver/jws-tomcat8-mongodb-sti.json
@@ -91,6 +91,12 @@
             "generate": "expression"
         },
         {
+            "description": "Database admin password",
+            "name": "DB_ADMIN_PASSWORD",
+            "from": "[a-zA-Z0-9]{8}",
+            "generate": "expression"
+        },
+        {
             "description": "Database name",
             "name": "DB_DATABASE",
             "value": "root"
@@ -362,6 +368,10 @@
                                         "value": "${DB_DATABASE}"
                                     },
                                     {
+                                        "name": "DB_ADMIN_PASSWORD",
+                                        "value": "${DB_ADMIN_PASSWORD}"
+                                    },
+                                    {
                                         "name": "JWS_HTTPS_CERTIFICATE_DIR",
                                         "value": "/etc/jws-secret-volume"
                                     },
@@ -457,6 +467,10 @@
                                     {
                                         "name": "MONGODB_DATABASE",
                                         "value": "${DB_DATABASE}"
+                                    },
+                                    {
+                                        "name": "MONGODB_ADMIN_PASSWORD",
+                                        "value": "${DB_ADMIN_PASSWORD}"
                                     }
                                 ]
                             }


### PR DESCRIPTION
Ever since https://github.com/openshift/mongodb/pull/31 was merged, the mongo image
requires that you specify the admin password.

@kconner