### PR TITLE
Add a 'user' prefix for usernames in templates

### DIFF
--- a/amq/amq6.json
+++ b/amq/amq6.json
@@ -24,7 +24,7 @@
         {
             "description": "Broker user name",
             "name": "MQ_USERNAME",
-            "from": "[a-zA-Z0-9]{8}",
+            "from": "user[a-zA-Z0-9]{3}",
             "generate": "expression"
         },
         {

--- a/eap/eap6-amq-sti.json
+++ b/eap/eap6-amq-sti.json
@@ -66,7 +66,7 @@
         {
             "description": "Broker user name",
             "name": "MQ_USERNAME",
-            "from": "[a-zA-Z0-9]{8}",
+            "from": "user[a-zA-Z0-9]{3}",
             "generate": "expression"
         },
         {

--- a/eap/eap6-mongodb-sti.json
+++ b/eap/eap6-mongodb-sti.json
@@ -77,7 +77,7 @@
         {
             "description": "Database user name",
             "name": "DB_USERNAME",
-            "from": "[a-zA-Z0-9]{8}",
+            "from": "user[a-zA-Z0-9]{3}",
             "generate": "expression"
         },
         {

--- a/eap/eap6-mysql-sti.json
+++ b/eap/eap6-mysql-sti.json
@@ -77,7 +77,7 @@
         {
             "description": "Database user name",
             "name": "DB_USERNAME",
-            "from": "[a-zA-Z0-9]{8}",
+            "from": "user[a-zA-Z0-9]{3}",
             "generate": "expression"
         },
         {

--- a/eap/eap6-postgresql-sti.json
+++ b/eap/eap6-postgresql-sti.json
@@ -77,7 +77,7 @@
         {
             "description": "Database user name",
             "name": "DB_USERNAME",
-            "from": "[a-zA-Z0-9]{8}",
+            "from": "user[a-zA-Z0-9]{3}",
             "generate": "expression"
         },
         {

--- a/webserver/jws-tomcat7-mongodb-sti.json
+++ b/webserver/jws-tomcat7-mongodb-sti.json
@@ -81,7 +81,7 @@
         {
             "description": "Database user name",
             "name": "DB_USERNAME",
-            "from": "[a-zA-Z0-9]{8}",
+            "from": "user[a-zA-Z0-9]{3}",
             "generate": "expression"
         },
         {

--- a/webserver/jws-tomcat7-mysql-sti.json
+++ b/webserver/jws-tomcat7-mysql-sti.json
@@ -81,7 +81,7 @@
         {
             "description": "Database user name",
             "name": "DB_USERNAME",
-            "from": "[a-zA-Z0-9]{8}",
+            "from": "user[a-zA-Z0-9]{3}",
             "generate": "expression"
         },
         {

--- a/webserver/jws-tomcat7-postgresql-sti.json
+++ b/webserver/jws-tomcat7-postgresql-sti.json
@@ -81,7 +81,7 @@
         {
             "description": "Database user name",
             "name": "DB_USERNAME",
-            "from": "[a-zA-Z0-9]{8}",
+            "from": "user[a-zA-Z0-9]{3}",
             "generate": "expression"
         },
         {

--- a/webserver/jws-tomcat8-mongodb-sti.json
+++ b/webserver/jws-tomcat8-mongodb-sti.json
@@ -81,7 +81,7 @@
         {
             "description": "Database user name",
             "name": "DB_USERNAME",
-            "from": "[a-zA-Z0-9]{8}",
+            "from": "user[a-zA-Z0-9]{3}",
             "generate": "expression"
         },
         {

--- a/webserver/jws-tomcat8-mysql-sti.json
+++ b/webserver/jws-tomcat8-mysql-sti.json
@@ -81,7 +81,7 @@
         {
             "description": "Database user name",
             "name": "DB_USERNAME",
-            "from": "[a-zA-Z0-9]{8}",
+            "from": "user[a-zA-Z0-9]{3}",
             "generate": "expression"
         },
         {

--- a/webserver/jws-tomcat8-postgresql-sti.json
+++ b/webserver/jws-tomcat8-postgresql-sti.json
@@ -81,7 +81,7 @@
         {
             "description": "Database user name",
             "name": "DB_USERNAME",
-            "from": "[a-zA-Z0-9]{8}",
+            "from": "user[a-zA-Z0-9]{3}",
             "generate": "expression"
         },
         {


### PR DESCRIPTION
Using '[a-zA-Z0-9]{8}' expressions can occasionally generate
usernames beginning with a digit, which is often forbidden.