### PR TITLE
Import Kyle's doc-generation script + generated docs

### DIFF
--- a/docs/gen_template_docs.py
+++ b/docs/gen_template_docs.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python
+# gen_template_doc.py
+# Kyle Liberti <kliberti@redhat.com> 
+# ver:  Python 3
+# Desc: Generates application-template documentation by cloning application-template 
+#       repository, then translating information from template JSON files into 
+#       template asciidoctor files, and stores them in the a directory(Specified by
+#       TEMPLATE_DOCS variable).
+# 
+# Notes: NEEDS TO BE CLEANED UP
+
+import json
+import os
+import sys
+import string
+
+GIT_REPO = "https://github.com/jboss-openshift/application-templates.git"
+REPO_NAME = "application-templates/"
+TEMPLATE_DOCS = "docs/templates/"
+APPLICATION_DIRECTORIES = ("amq","eap","webserver")
+ignore_dirs = ['docs', '.git', 'secrets']
+
+LINKS =  {"jboss-eap6-openshift:${EAP_RELEASE}":                "../../eap/eap-openshift{outfilesuffix}[`jboss-eap-6/eap-openshift`]", \
+          "jboss-webserver3-tomcat7-openshift:${JWS_RELEASE}":  "../../webserver/tomcat7-openshift{outfilesuffix}[`jboss-webserver/tomcat7-openshift`]", \
+          "jboss-webserver3-tomcat8-openshift:${JWS_RELEASE}":  "../../webserver/tomcat8-openshift{outfilesuffix}[`jboss-webserver/tomcat8-openshift`]"};
+
+PARAMETER_VALUES = {"APPLICATION_HOSTNAME": "secure-app.test.router.default.local", \
+                   "GIT_URI": "`https://github.com/jboss-openshift/openshift-examples.git", \
+                   "GIT_REF": "master", \
+                   "GIT_CONTEXT_DIR": "helloworld", \
+                   "GITHUB_TRIGGER_SECRET": "secret101", \
+                   "GENERIC_TRIGGER_SECRET": "secret101"}
+
+def generate_templates():
+    for directory in set(os.listdir('.')) - set(ignore_dirs):
+        if not os.path.isdir(directory):
+            continue
+
+        if not os.path.exists(TEMPLATE_DOCS + directory):
+           os.makedirs(TEMPLATE_DOCS + directory)
+
+        for template in os.listdir(directory):
+            with open(directory + "/" + template) as data_file:
+                data = json.load(data_file)
+
+                # Presently we can't generate documentation for the 'secrets' templates
+                if not 'labels' in data:
+                    sys.stderr.write("no labels for template %s, can't generate documentation\n"%\
+                        (directory + "/" + template))
+                    continue
+
+                template_doc = TEMPLATE_DOCS + directory + "/" + data["labels"]["template"] + ".adoc"
+
+                with open(template_doc, "w") as text_file:
+                    text_file.write(createTemplate(data))
+
+def createTemplate(data):
+    template = string.Template(open('docs/template.adoc.in').read())
+    return template.substitute (
+        template         = data['labels']['template'],
+        description      = data['metadata']['annotations']['description'],
+        parametertable   = createParameterTable(data),
+        servicetable     = createObjectTable(data,"Service"),
+        routetable       = createObjectTable(data, "Route"),
+        buildconfigtable = createObjectTable(data,"BuildConfig"),
+        triggertable     = createDeployConfigTable(data, "triggers"),
+        replicatable     = createDeployConfigTable(data, "replicas"),
+        serviceacctable  = createDeployConfigTable(data, "serviceAccount"),
+        imagetable       = createContainerTable(data, "image"),
+        readinesstable   = createContainerTable(data,"readinessProbe"),
+        portstable       = createContainerTable(data,"ports"),
+        envtable         = createContainerTable(data, "env"),
+        volumestable     = createDeployConfigTable(data,"volumes"),
+        persistenttable  = createObjectTable(data,"PersistentVolumeClaim"),
+        templateabbrev   = data['labels']['template'][0:3],
+    )
+
+def buildRow(columns):
+   return ("\n|" + " | ".join([" `" + col + "` " for col in columns])).replace("`--`", "--")
+
+def getVolumePurpose(name):
+   name = name.split("-")
+   if("certificate" in name or "keystore" in name or "secret" in name):
+      return "ssl certs"
+   elif("amq" in name):
+      return "kahadb"
+   elif("pvol" in name):
+      return name[1]
+   else:
+      return "--"
+   
+# Used for getting image enviorment variables into parameters table and parameter
+# descriptions into image environment table 
+def getVariableInfo(data, name, value):
+   for d in data:
+      if(d["name"] == name or name[1:] in d["name"] or d["name"][1:] in name):
+         return d[value]
+   if(value == "value" and name in PARAMETER_VALUES.keys()):
+         return PARAMETER_VALUES[name]
+   else:
+      return "--"
+
+def createParameterTable(data):
+   text = ""
+   for param in data["parameters"]:
+      deploy = [d["spec"]["template"]["spec"]["containers"][0]["env"] for d in data["objects"] if d["kind"] == "DeploymentConfig"]
+      environment = [item for sublist in deploy for item in sublist]
+      envVar = getVariableInfo(environment, param["name"], "name")
+      value = param["value"] if param.get("value") else getVariableInfo(environment, param["name"], "value")
+      columns = [param["name"], envVar, param["description"], value]
+      text += buildRow(columns)
+   return text
+
+def createObjectTable(data, tableKind):
+   text = ""
+   columns =[]
+   for obj in data["objects"]:
+      if obj["kind"] ==  'Service' and tableKind == 'Service':
+         columns = [obj["metadata"]["name"], str(obj["spec"]["ports"][0]["port"]), obj["metadata"]["annotations"]["description"] ]
+      elif obj["kind"] ==  'Route' and tableKind == 'Route':
+         if(obj["spec"].get("tls")):
+            columns = [obj["id"], ("TLS "+ obj["spec"]["tls"]["termination"]), obj["spec"]["host"]]
+         else:
+            columns = [obj["id"], "none", obj["spec"]["host"]]
+      elif obj["kind"] ==  'BuildConfig' and tableKind == 'BuildConfig':
+         sti = obj["spec"]["strategy"]["sourceStrategy"]["from"]["name"]
+         columns = [sti," link:" + LINKS[sti], obj["spec"]["output"]["to"]["name"], ", ".join({x["type"] for x in obj["spec"]["triggers"] }) ]
+      elif obj["kind"] ==  'PersistentVolumeClaim' and tableKind == 'PersistentVolumeClaim':
+         columns = [obj["metadata"]["name"], obj["spec"]["accessModes"][0]]
+      if(obj["kind"] == tableKind):
+         text += buildRow(columns)
+   return text
+
+def createDeployConfigTable(data, table):
+   text = ""
+   deploymentConfig = (obj for obj in data["objects"] if obj["kind"] == "DeploymentConfig")
+   for obj in deploymentConfig: 
+      columns = []
+      deployment = obj["metadata"]["name"]
+      spec = obj["spec"]
+      template = spec["template"]["spec"]
+      if(template.get(table) or spec.get(table)):
+          if table == "triggers":
+             columns = [deployment, spec["triggers"][0]["type"] ]
+          elif table == "replicas":
+             columns = [deployment, str(spec["replicas"]) ]
+          elif table == "serviceAccount":
+                columns = [deployment, template["serviceAccount"]]
+          elif table == "volumes":
+                volumeMount = obj["spec"]["template"]["spec"]["containers"][0]["volumeMounts"][0]
+                name = template["volumes"][0]["name"]
+                readOnly = str(volumeMount["readOnly"]) if "readOnly" in volumeMount else "false"
+                columns = [deployment, name, volumeMount["mountPath"], getVolumePurpose(name), readOnly]
+          text += buildRow(columns)
+   return text
+
+def createContainerTable(data, table):
+   text = ""
+   deploymentConfig = (obj for obj in data["objects"] if obj["kind"] == "DeploymentConfig")
+   for obj in deploymentConfig:
+      columns = []
+      deployment = obj["metadata"]["name"]
+      container = obj["spec"]["template"]["spec"]["containers"][0]
+      if table == "image":
+         columns = [deployment, container["image"]]
+         text += buildRow(columns)
+      elif table == "readinessProbe": #abstract out
+         if container.get("readinessProbe"):
+            text += ("\n====== " + deployment + "\n----\n" \
+            + ("\n\n").join(container["readinessProbe"]["exec"]["command"]) \
+            + "\n----\n")
+      elif table == "ports":
+         text += "\n." + str(len(container["ports"])) + "+| `" + deployment + "`"
+         ports = container["ports"]
+         for p in ports:
+            columns = ["name", "containerPort", "protocol"]
+            columns = [str(p[col]) if p.get(col) else "--" for col in columns]
+            text += buildRow(columns)
+      elif table == "env":
+         environment = container["env"]
+         text += "\n." + str(len(environment)) + "+| `" + deployment + "`"
+         for env in environment:
+            columns = [env["name"], getVariableInfo(data["parameters"], env["name"], "description"), env["value"]]
+            text += buildRow(columns)
+   return text
+
+fullname = {
+    "amq":       "JBoss A-MQ",
+    "eap":       "JBoss EAP",
+    "webserver": "JBoss Web Server"
+}
+
+def generate_index():
+    """Generates an index page for the template documentation."""
+    with open('docs/templates/index.adoc','w') as fh:
+        # page header
+        fh.write(open('docs/index.adoc.in').read())
+
+        for directory in set(os.listdir('.')) - set(ignore_dirs):
+            if not os.path.isdir(directory):
+                continue
+            # section header
+            fh.write('\n== %s\n\n' % fullname.get(directory, directory))
+            # links
+            for template in [ os.path.splitext(x)[0] for x in  os.listdir(directory) ]:
+                fh.write("* link:./%s/%s.adoc[%s]\n" % (directory, template, template))
+
+if __name__ == "__main__":
+    # expects to be run from the root of the repository
+    if os.path.basename(os.getcwd()) == "docs":
+        os.chdir('..')
+    generate_templates()
+    generate_index()

--- a/docs/index.adoc.in
+++ b/docs/index.adoc.in
@@ -1,0 +1,9 @@
+= Application Templates
+
+This project contains OpenShift v3 application templates which support applications based on JBoss Middleware products.
+Source can be found https://github.com/jboss-openshift/application-templates/tree/master[here].
+
+:icons: font
+:toc: macro
+
+toc::[levels=1]

--- a/docs/template.adoc.in
+++ b/docs/template.adoc.in
@@ -1,0 +1,145 @@
+= $template
+
+$description
+
+toc::[levels=2]
+
+== Parameters
+
+Templates allow you to define parameters which take on a value. That value is then substituted wherever the parameter is referenced.
+References can be defined in any text field in the objects list field. Refer to the
+https://docs.openshift.org/latest/architecture/core_concepts/templates.html#parameters[Openshift documentation] for more information.
+
+|=======================================================================
+|Variable name |Image Environment Variable |Description |Example value
+$parametertable
+|=======================================================================
+
+== Objects
+
+The CLI supports various object types. A list of these object types as well as their abbreviations
+can be found in the https://docs.openshift.org/latest/cli_reference/basic_cli_operations.html#object-types[Openshift documentation].
+
+=== Services
+
+A service is an abstraction which defines a logical set of pods and a policy by which to access them. Refer to the
+https://cloud.google.com/container-engine/docs/services/[container-engine documentation] for more information.
+
+|=============
+|Service        |Port  | Description
+$servicetable
+|=============
+
+=== Routes
+
+A route is a way to expose a service by giving it an externally-reachable hostname such as `www.example.com`. A defined route and the endpoints
+identified by its service can be consumed by a router to provide named connectivity from external clients to your applications. Each route consists
+of a route name, service selector, and (optionally) security configuration. Refer to the
+https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html[Openshift documentation] for more information.
+
+|=============
+| Service    | Security | Hostname
+$routetable
+|=============
+
+=== Build Configurations
+
+A `buildConfig` describes a single build definition and a set of triggers for when a new build should be created.
+A `buildConfig` is a REST object, which can be used in a POST to the API server to create a new instance. Refer to
+the https://docs.openshift.com/enterprise/3.0/dev_guide/builds.html#defining-a-buildconfig[Openshift documentation]
+for more information.
+
+|=============
+| STI image  | link | Build output | BuildTriggers and Settings
+$buildconfigtable
+|=============
+
+=== Deployment Configurations
+
+A deployment in OpenShift is a replication controller based on a user defined template called a deployment configuration. Deployments are created manually or in response to triggered events.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/deployments.html#creating-a-deployment-configuration[Openshift documentation] for more information.
+
+==== Triggers
+
+A trigger drives the creation of new deployments in response to events, both inside and outside OpenShift. Refer to the
+https://access.redhat.com/beta/documentation/en/openshift-enterprise-30-developer-guide#triggers[Openshift documentation] for more information.
+
+|============
+|Deployment | Triggers
+$triggertable
+|============
+
+==== Replicas
+
+A replication controller ensures that a specified number of pod "replicas" are running at any one time.
+If there are too many, the replication controller kills some pods. If there are too few, it starts more.
+Refer to the https://cloud.google.com/container-engine/docs/replicationcontrollers/[container-engine documentation]
+for more information.
+
+|============
+|Deployment | Replicas
+$replicatable
+|============
+
+==== Pod Template
+
+===== Service Accounts
+
+Service accounts are API objects that exist within each project. They can be created or deleted like any other API object. Refer to the
+https://docs.openshift.com/enterprise/3.0/dev_guide/service_accounts.html#managing-service-accounts[Openshift documentation] for more
+information.
+
+|============
+|Deployment | Service Account
+$serviceacctable
+|============
+
+===== Image
+
+|============
+|Deployment | Image
+$imagetable
+|============
+
+===== Readiness Probe
+
+$readinesstable
+
+===== Exposed Ports
+
+|=============
+|Deployments | Name  | Port  | Protocol
+$portstable
+|=============
+
+===== Image Environment Variables
+
+|=======================================================================
+|Deployment |Variable name |Description |Example value
+$envtable
+|=======================================================================
+
+=====  Volumes
+
+|=============
+|Deployment |Name  | mountPath | Purpose | readOnly 
+$volumestable
+|=============
+
+=== External Dependencies
+
+==== Volume Claims
+
+A `PersistentVolume` object is a storage resource in an OpenShift cluster. Storage is provisioned by an administrator
+by creating `PersistentVolume` objects from sources such as GCE Persistent Disks, AWS Elastic Block Stores (EBS), and NFS mounts.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/persistent_volumes.html#overview[Openshift documentation] for
+more information.
+
+|=============
+|Name | Access Mode
+$persistenttable
+|=============
+
+==== Secrets 
+
+This template requires https://github.com/jboss-openshift/application-templates/blob/master/secrets/$templateabbrev-app-secrets.json[$templateabbrev-app-secrets.json] to be installed for the application to run.

--- a/docs/templates/amq/amq6-persistent.adoc
+++ b/docs/templates/amq/amq6-persistent.adoc
@@ -1,0 +1,200 @@
+= amq6-persistent
+
+Application template for ActiveMQ brokers using persistent storage.
+
+toc::[levels=2]
+
+== Parameters
+
+Templates allow you to define parameters which take on a value. That value is then substituted wherever the parameter is referenced.
+References can be defined in any text field in the objects list field. Refer to the
+https://docs.openshift.org/latest/architecture/core_concepts/templates.html#parameters[Openshift documentation] for more information.
+
+|=======================================================================
+|Variable name |Image Environment Variable |Description |Example value
+
+| `AMQ_RELEASE`  |  --  |  `ActiveMQ Release version, e.g. 6.2, etc.`  |  `6.2` 
+| `APPLICATION_NAME`  |  --  |  `The name for the application.`  |  `broker` 
+| `MQ_PROTOCOL`  |  `AMQ_PROTOCOLS`  |  `Protocol to configure.  Only openwire is supported by EAP.  amqp, amqp+ssl, mqtt, stomp, stomp+ssl, and ssl are not supported by EAP`  |  `openwire` 
+| `MQ_QUEUES`  |  `AMQ_QUEUES`  |  `Queue names`  |  `${MQ_QUEUES}` 
+| `MQ_TOPICS`  |  `AMQ_TOPICS`  |  `Topic names`  |  `${MQ_TOPICS}` 
+| `VOLUME_CAPACITY`  |  --  |  `Size of persistent storage for database volume.`  |  `512Mi` 
+| `MQ_USERNAME`  |  `AMQ_USER`  |  `Broker user name`  |  `${MQ_USERNAME}` 
+| `MQ_PASSWORD`  |  `AMQ_PASSWORD`  |  `Broker user password`  |  `${MQ_PASSWORD}` 
+| `AMQ_ADMIN_USERNAME`  |  `AMQ_ADMIN_USERNAME`  |  `ActiveMQ Admin User`  |  `${AMQ_ADMIN_USERNAME}` 
+| `AMQ_ADMIN_PASSWORD`  |  `AMQ_ADMIN_PASSWORD`  |  `ActiveMQ Admin Password`  |  `${AMQ_ADMIN_PASSWORD}` 
+| `AMQ_SECRET`  |  --  |  `Name of a secret containing SSL related files`  |  `amq-app-secret` 
+| `AMQ_TRUSTSTORE`  |  `AMQ_TRUSTSTORE`  |  `SSL trust store filename`  |  `broker.ts` 
+| `AMQ_KEYSTORE`  |  `AMQ_KEYSTORE_TRUSTSTORE_DIR`  |  `SSL key store filename`  |  `broker.ks` 
+| `IMAGE_STREAM_NAMESPACE`  |  --  |  `Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.`  |  `openshift` 
+|=======================================================================
+
+== Objects
+
+The CLI supports various object types. A list of these object types as well as their abbreviations
+can be found in the https://docs.openshift.org/latest/cli_reference/basic_cli_operations.html#object-types[Openshift documentation].
+
+=== Services
+
+A service is an abstraction which defines a logical set of pods and a policy by which to access them. Refer to the
+https://cloud.google.com/container-engine/docs/services/[container-engine documentation] for more information.
+
+|=============
+|Service        |Port  | Description
+
+| `${APPLICATION_NAME}-amq-amqp`  |  `5672`  |  `The broker's amqp port.` 
+| `${APPLICATION_NAME}-amq-amqp-ssl`  |  `5671`  |  `The broker's amqp ssl port.` 
+| `${APPLICATION_NAME}-amq-mqtt`  |  `1883`  |  `The broker's mqtt port.` 
+| `${APPLICATION_NAME}-amq-stomp`  |  `61613`  |  `The broker's stomp port.` 
+| `${APPLICATION_NAME}-amq-stomp-ssl`  |  `61612`  |  `The broker's stomp ssl port.` 
+| `${APPLICATION_NAME}-amq-tcp`  |  `61616`  |  `The broker's tcp (openwire) port.` 
+| `${APPLICATION_NAME}-amq-tcp-ssl`  |  `61617`  |  `The broker's tcp ssl (openwire) port.` 
+|=============
+
+=== Routes
+
+A route is a way to expose a service by giving it an externally-reachable hostname such as `www.example.com`. A defined route and the endpoints
+identified by its service can be consumed by a router to provide named connectivity from external clients to your applications. Each route consists
+of a route name, service selector, and (optionally) security configuration. Refer to the
+https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html[Openshift documentation] for more information.
+
+|=============
+| Service    | Security | Hostname
+
+|=============
+
+=== Build Configurations
+
+A `buildConfig` describes a single build definition and a set of triggers for when a new build should be created.
+A `buildConfig` is a REST object, which can be used in a POST to the API server to create a new instance. Refer to
+the https://docs.openshift.com/enterprise/3.0/dev_guide/builds.html#defining-a-buildconfig[Openshift documentation]
+for more information.
+
+|=============
+| STI image  | link | Build output | BuildTriggers and Settings
+
+|=============
+
+=== Deployment Configurations
+
+A deployment in OpenShift is a replication controller based on a user defined template called a deployment configuration. Deployments are created manually or in response to triggered events.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/deployments.html#creating-a-deployment-configuration[Openshift documentation] for more information.
+
+==== Triggers
+
+A trigger drives the creation of new deployments in response to events, both inside and outside OpenShift. Refer to the
+https://access.redhat.com/beta/documentation/en/openshift-enterprise-30-developer-guide#triggers[Openshift documentation] for more information.
+
+|============
+|Deployment | Triggers
+
+| `${APPLICATION_NAME}-amq`  |  `ImageChange` 
+|============
+
+==== Replicas
+
+A replication controller ensures that a specified number of pod "replicas" are running at any one time.
+If there are too many, the replication controller kills some pods. If there are too few, it starts more.
+Refer to the https://cloud.google.com/container-engine/docs/replicationcontrollers/[container-engine documentation]
+for more information.
+
+|============
+|Deployment | Replicas
+
+| `${APPLICATION_NAME}-amq`  |  `1` 
+|============
+
+==== Pod Template
+
+===== Service Accounts
+
+Service accounts are API objects that exist within each project. They can be created or deleted like any other API object. Refer to the
+https://docs.openshift.com/enterprise/3.0/dev_guide/service_accounts.html#managing-service-accounts[Openshift documentation] for more
+information.
+
+|============
+|Deployment | Service Account
+
+| `${APPLICATION_NAME}-amq`  |  `amq-service-account` 
+|============
+
+===== Image
+
+|============
+|Deployment | Image
+
+| `${APPLICATION_NAME}-amq`  |  `jboss-amq-6` 
+|============
+
+===== Readiness Probe
+
+
+====== ${APPLICATION_NAME}-amq
+----
+/bin/bash
+
+-c
+
+curl -s -L -u ${AMQ_ADMIN_USERNAME}:${AMQ_ADMIN_PASSWORD} 'http://localhost:8161/hawtio/jolokia/read/org.apache.activemq:type=Broker,brokerName=*,service=Health/CurrentStatus' | grep -q '"CurrentStatus" *: *"Good"'
+----
+
+
+===== Exposed Ports
+
+|=============
+|Deployments | Name  | Port  | Protocol
+
+.7+| `${APPLICATION_NAME}-amq`
+| `amqp`  |  `5672`  |  `TCP` 
+| `amqp-ssl`  |  `5671`  |  `TCP` 
+| `mqtt`  |  `1883`  |  `TCP` 
+| `stomp`  |  `61613`  |  `TCP` 
+| `stomp-ssl`  |  `61612`  |  `TCP` 
+| `tcp`  |  `61616`  |  `TCP` 
+| `tcp-ssl`  |  `61617`  |  `TCP` 
+|=============
+
+===== Image Environment Variables
+
+|=======================================================================
+|Deployment |Variable name |Description |Example value
+
+.10+| `${APPLICATION_NAME}-amq`
+| `AMQ_USER`  |  `Broker user name`  |  `${MQ_USERNAME}` 
+| `AMQ_PASSWORD`  |  `Broker user password`  |  `${MQ_PASSWORD}` 
+| `AMQ_PROTOCOLS`  |  `Protocol to configure.  Only openwire is supported by EAP.  amqp, amqp+ssl, mqtt, stomp, stomp+ssl, and ssl are not supported by EAP`  |  `${MQ_PROTOCOL}` 
+| `AMQ_QUEUES`  |  `Queue names`  |  `${MQ_QUEUES}` 
+| `AMQ_TOPICS`  |  `Topic names`  |  `${MQ_TOPICS}` 
+| `AMQ_ADMIN_USERNAME`  |  `ActiveMQ Admin User`  |  `${AMQ_ADMIN_USERNAME}` 
+| `AMQ_ADMIN_PASSWORD`  |  `ActiveMQ Admin Password`  |  `${AMQ_ADMIN_PASSWORD}` 
+| `AMQ_KEYSTORE_TRUSTSTORE_DIR`  |  `SSL key store filename`  |  `/etc/amq-secret-volume` 
+| `AMQ_TRUSTSTORE`  |  `SSL trust store filename`  |  `${AMQ_TRUSTSTORE}` 
+| `AMQ_KEYSTORE`  |  `SSL key store filename`  |  `${AMQ_KEYSTORE}` 
+|=======================================================================
+
+=====  Volumes
+
+|=============
+|Deployment |Name  | mountPath | Purpose | readOnly 
+
+| `${APPLICATION_NAME}-amq`  |  `broker-secret-volume`  |  `/etc/amq-secret-volume`  |  `ssl certs`  |  `True` 
+|=============
+
+=== External Dependencies
+
+==== Volume Claims
+
+A `PersistentVolume` object is a storage resource in an OpenShift cluster. Storage is provisioned by an administrator
+by creating `PersistentVolume` objects from sources such as GCE Persistent Disks, AWS Elastic Block Stores (EBS), and NFS mounts.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/persistent_volumes.html#overview[Openshift documentation] for
+more information.
+
+|=============
+|Name | Access Mode
+
+| `${APPLICATION_NAME}-amq-claim`  |  `ReadWriteOnce` 
+|=============
+
+==== Secrets 
+
+This template requires https://github.com/jboss-openshift/application-templates/blob/master/secrets/amq-app-secrets.json[amq-app-secrets.json] to be installed for the application to run.

--- a/docs/templates/amq/amq6.adoc
+++ b/docs/templates/amq/amq6.adoc
@@ -1,0 +1,199 @@
+= amq6
+
+Application template for ActiveMQ brokers.
+
+toc::[levels=2]
+
+== Parameters
+
+Templates allow you to define parameters which take on a value. That value is then substituted wherever the parameter is referenced.
+References can be defined in any text field in the objects list field. Refer to the
+https://docs.openshift.org/latest/architecture/core_concepts/templates.html#parameters[Openshift documentation] for more information.
+
+|=======================================================================
+|Variable name |Image Environment Variable |Description |Example value
+
+| `AMQ_RELEASE`  |  --  |  `ActiveMQ Release version, e.g. 6.2, etc.`  |  `6.2` 
+| `APPLICATION_NAME`  |  --  |  `The name for the application.`  |  `broker` 
+| `MQ_PROTOCOL`  |  `AMQ_PROTOCOLS`  |  `Protocol to configure.  Only openwire is supported by EAP.  amqp, amqp+ssl, mqtt, stomp, stomp+ssl, and ssl are not supported by EAP`  |  `openwire` 
+| `MQ_QUEUES`  |  `AMQ_QUEUES`  |  `Queue names`  |  `${MQ_QUEUES}` 
+| `MQ_TOPICS`  |  `AMQ_TOPICS`  |  `Topic names`  |  `${MQ_TOPICS}` 
+| `MQ_USERNAME`  |  `AMQ_USER`  |  `Broker user name`  |  `${MQ_USERNAME}` 
+| `MQ_PASSWORD`  |  `AMQ_PASSWORD`  |  `Broker user password`  |  `${MQ_PASSWORD}` 
+| `AMQ_ADMIN_USERNAME`  |  `AMQ_ADMIN_USERNAME`  |  `ActiveMQ Admin User`  |  `${AMQ_ADMIN_USERNAME}` 
+| `AMQ_ADMIN_PASSWORD`  |  `AMQ_ADMIN_PASSWORD`  |  `ActiveMQ Admin Password`  |  `${AMQ_ADMIN_PASSWORD}` 
+| `AMQ_SECRET`  |  --  |  `Name of a secret containing SSL related files`  |  `amq-app-secret` 
+| `AMQ_TRUSTSTORE`  |  `AMQ_TRUSTSTORE`  |  `SSL trust store filename`  |  `broker.ts` 
+| `AMQ_KEYSTORE`  |  `AMQ_KEYSTORE_TRUSTSTORE_DIR`  |  `SSL key store filename`  |  `broker.ks` 
+| `IMAGE_STREAM_NAMESPACE`  |  --  |  `Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.`  |  `openshift` 
+|=======================================================================
+
+== Objects
+
+The CLI supports various object types. A list of these object types as well as their abbreviations
+can be found in the https://docs.openshift.org/latest/cli_reference/basic_cli_operations.html#object-types[Openshift documentation].
+
+=== Services
+
+A service is an abstraction which defines a logical set of pods and a policy by which to access them. Refer to the
+https://cloud.google.com/container-engine/docs/services/[container-engine documentation] for more information.
+
+|=============
+|Service        |Port  | Description
+
+| `${APPLICATION_NAME}-amq-amqp`  |  `5672`  |  `The broker's amqp port.` 
+| `${APPLICATION_NAME}-amq-amqp-ssl`  |  `5671`  |  `The broker's amqp ssl port.` 
+| `${APPLICATION_NAME}-amq-mqtt`  |  `1883`  |  `The broker's mqtt port.` 
+| `${APPLICATION_NAME}-amq-stomp`  |  `61613`  |  `The broker's stomp port.` 
+| `${APPLICATION_NAME}-amq-stomp-ssl`  |  `61612`  |  `The broker's stomp ssl port.` 
+| `${APPLICATION_NAME}-amq-tcp`  |  `61616`  |  `The broker's tcp (openwire) port.` 
+| `${APPLICATION_NAME}-amq-tcp-ssl`  |  `61617`  |  `The broker's tcp ssl (openwire) port.` 
+|=============
+
+=== Routes
+
+A route is a way to expose a service by giving it an externally-reachable hostname such as `www.example.com`. A defined route and the endpoints
+identified by its service can be consumed by a router to provide named connectivity from external clients to your applications. Each route consists
+of a route name, service selector, and (optionally) security configuration. Refer to the
+https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html[Openshift documentation] for more information.
+
+|=============
+| Service    | Security | Hostname
+
+|=============
+
+=== Build Configurations
+
+A `buildConfig` describes a single build definition and a set of triggers for when a new build should be created.
+A `buildConfig` is a REST object, which can be used in a POST to the API server to create a new instance. Refer to
+the https://docs.openshift.com/enterprise/3.0/dev_guide/builds.html#defining-a-buildconfig[Openshift documentation]
+for more information.
+
+|=============
+| STI image  | link | Build output | BuildTriggers and Settings
+
+|=============
+
+=== Deployment Configurations
+
+A deployment in OpenShift is a replication controller based on a user defined template called a deployment configuration. Deployments are created manually or in response to triggered events.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/deployments.html#creating-a-deployment-configuration[Openshift documentation] for more information.
+
+==== Triggers
+
+A trigger drives the creation of new deployments in response to events, both inside and outside OpenShift. Refer to the
+https://access.redhat.com/beta/documentation/en/openshift-enterprise-30-developer-guide#triggers[Openshift documentation] for more information.
+
+|============
+|Deployment | Triggers
+
+| `${APPLICATION_NAME}-amq`  |  `ImageChange` 
+|============
+
+==== Replicas
+
+A replication controller ensures that a specified number of pod "replicas" are running at any one time.
+If there are too many, the replication controller kills some pods. If there are too few, it starts more.
+Refer to the https://cloud.google.com/container-engine/docs/replicationcontrollers/[container-engine documentation]
+for more information.
+
+|============
+|Deployment | Replicas
+
+| `${APPLICATION_NAME}-amq`  |  `1` 
+|============
+
+==== Pod Template
+
+===== Service Accounts
+
+Service accounts are API objects that exist within each project. They can be created or deleted like any other API object. Refer to the
+https://docs.openshift.com/enterprise/3.0/dev_guide/service_accounts.html#managing-service-accounts[Openshift documentation] for more
+information.
+
+|============
+|Deployment | Service Account
+
+| `${APPLICATION_NAME}-amq`  |  `amq-service-account` 
+|============
+
+===== Image
+
+|============
+|Deployment | Image
+
+| `${APPLICATION_NAME}-amq`  |  `jboss-amq-6` 
+|============
+
+===== Readiness Probe
+
+
+====== ${APPLICATION_NAME}-amq
+----
+/bin/bash
+
+-c
+
+curl -s -L -u ${AMQ_ADMIN_USERNAME}:${AMQ_ADMIN_PASSWORD} 'http://localhost:8161/hawtio/jolokia/read/org.apache.activemq:type=Broker,brokerName=*,service=Health/CurrentStatus' | grep -q '"CurrentStatus" *: *"Good"'
+----
+
+
+===== Exposed Ports
+
+|=============
+|Deployments | Name  | Port  | Protocol
+
+.7+| `${APPLICATION_NAME}-amq`
+| `amqp`  |  `5672`  |  `TCP` 
+| `amqp-ssl`  |  `5671`  |  `TCP` 
+| `mqtt`  |  `1883`  |  `TCP` 
+| `stomp`  |  `61613`  |  `TCP` 
+| `stomp-ssl`  |  `61612`  |  `TCP` 
+| `tcp`  |  `61616`  |  `TCP` 
+| `tcp-ssl`  |  `61617`  |  `TCP` 
+|=============
+
+===== Image Environment Variables
+
+|=======================================================================
+|Deployment |Variable name |Description |Example value
+
+.11+| `${APPLICATION_NAME}-amq`
+| `AMQ_USER`  |  `Broker user name`  |  `${MQ_USERNAME}` 
+| `AMQ_PASSWORD`  |  `Broker user password`  |  `${MQ_PASSWORD}` 
+| `AMQ_PROTOCOLS`  |  `Protocol to configure.  Only openwire is supported by EAP.  amqp, amqp+ssl, mqtt, stomp, stomp+ssl, and ssl are not supported by EAP`  |  `${MQ_PROTOCOL}` 
+| `AMQ_QUEUES`  |  `Queue names`  |  `${MQ_QUEUES}` 
+| `AMQ_TOPICS`  |  `Topic names`  |  `${MQ_TOPICS}` 
+| `AMQ_ADMIN_USERNAME`  |  `ActiveMQ Admin User`  |  `${AMQ_ADMIN_USERNAME}` 
+| `AMQ_ADMIN_PASSWORD`  |  `ActiveMQ Admin Password`  |  `${AMQ_ADMIN_PASSWORD}` 
+| `AMQ_MESH_SERVICE_NAME`  |  --  |  `${APPLICATION_NAME}-amq-tcp` 
+| `AMQ_KEYSTORE_TRUSTSTORE_DIR`  |  `SSL key store filename`  |  `/etc/amq-secret-volume` 
+| `AMQ_TRUSTSTORE`  |  `SSL trust store filename`  |  `${AMQ_TRUSTSTORE}` 
+| `AMQ_KEYSTORE`  |  `SSL key store filename`  |  `${AMQ_KEYSTORE}` 
+|=======================================================================
+
+=====  Volumes
+
+|=============
+|Deployment |Name  | mountPath | Purpose | readOnly 
+
+| `${APPLICATION_NAME}-amq`  |  `broker-secret-volume`  |  `/etc/amq-secret-volume`  |  `ssl certs`  |  `True` 
+|=============
+
+=== External Dependencies
+
+==== Volume Claims
+
+A `PersistentVolume` object is a storage resource in an OpenShift cluster. Storage is provisioned by an administrator
+by creating `PersistentVolume` objects from sources such as GCE Persistent Disks, AWS Elastic Block Stores (EBS), and NFS mounts.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/persistent_volumes.html#overview[Openshift documentation] for
+more information.
+
+|=============
+|Name | Access Mode
+
+|=============
+
+==== Secrets 
+
+This template requires https://github.com/jboss-openshift/application-templates/blob/master/secrets/amq-app-secrets.json[amq-app-secrets.json] to be installed for the application to run.

--- a/docs/templates/eap/eap6-amq-persistent-sti.adoc
+++ b/docs/templates/eap/eap6-amq-persistent-sti.adoc
@@ -1,0 +1,237 @@
+= eap6-amq-persistent-sti
+
+Application template for EAP 6 A-MQ applications with persistent storage built using STI.
+
+toc::[levels=2]
+
+== Parameters
+
+Templates allow you to define parameters which take on a value. That value is then substituted wherever the parameter is referenced.
+References can be defined in any text field in the objects list field. Refer to the
+https://docs.openshift.org/latest/architecture/core_concepts/templates.html#parameters[Openshift documentation] for more information.
+
+|=======================================================================
+|Variable name |Image Environment Variable |Description |Example value
+
+| `EAP_RELEASE`  |  --  |  `EAP Release version, e.g. 6.4, etc.`  |  `6.4` 
+| `AMQ_RELEASE`  |  --  |  `ActiveMQ Release version, e.g. 6.2, etc.`  |  `6.2` 
+| `APPLICATION_NAME`  |  --  |  `The name for the application.`  |  `eap-app` 
+| `APPLICATION_HOSTNAME`  |  --  |  `Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>`  |  `secure-app.test.router.default.local` 
+| `GIT_URI`  |  --  |  `Git source URI for application`  |  ``https://github.com/jboss-openshift/openshift-examples.git` 
+| `GIT_REF`  |  --  |  `Git branch/tag reference`  |  `master` 
+| `GIT_CONTEXT_DIR`  |  --  |  `Path within Git project to build; empty for root project directory.`  |  `helloworld` 
+| `VOLUME_CAPACITY`  |  --  |  `Size of persistent storage for database volume.`  |  `512Mi` 
+| `MQ_JNDI`  |  `MQ_JNDI`  |  `JNDI name for connection factory used by applications to connect to the broker, e.g. java:/ConnectionFactory`  |  `java:/ConnectionFactory` 
+| `MQ_PROTOCOL`  |  `MQ_PROTOCOL`  |  `Protocol to configure.  Only openwire is supported by EAP.  amqp, amqp+ssl, mqtt, stomp, stomp+ssl, and ssl are not supported by EAP`  |  `openwire` 
+| `MQ_QUEUES`  |  `MQ_QUEUES`  |  `Queue names`  |  `${MQ_QUEUES}` 
+| `MQ_TOPICS`  |  `MQ_TOPICS`  |  `Topic names`  |  `${MQ_TOPICS}` 
+| `EAP_HTTPS_SECRET`  |  --  |  `The name of the secret containing the keystore file`  |  `eap-app-secret` 
+| `EAP_HTTPS_KEYSTORE`  |  `EAP_HTTPS_KEYSTORE_DIR`  |  `The name of the keystore file within the secret`  |  `keystore.jks` 
+| `EAP_HTTPS_NAME`  |  `EAP_HTTPS_NAME`  |  `The name associated with the server certificate`  |  `${EAP_HTTPS_NAME}` 
+| `EAP_HTTPS_PASSWORD`  |  `EAP_HTTPS_PASSWORD`  |  `The password for the keystore and certificate`  |  `${EAP_HTTPS_PASSWORD}` 
+| `MQ_USERNAME`  |  `MQ_USERNAME`  |  `Broker user name`  |  `${MQ_USERNAME}` 
+| `MQ_PASSWORD`  |  `MQ_PASSWORD`  |  `Broker user password`  |  `${MQ_PASSWORD}` 
+| `AMQ_ADMIN_USERNAME`  |  `AMQ_ADMIN_USERNAME`  |  `ActiveMQ Admin User`  |  `${AMQ_ADMIN_USERNAME}` 
+| `AMQ_ADMIN_PASSWORD`  |  `AMQ_ADMIN_PASSWORD`  |  `ActiveMQ Admin Password`  |  `${AMQ_ADMIN_PASSWORD}` 
+| `GITHUB_TRIGGER_SECRET`  |  --  |  `GitHub trigger secret`  |  `secret101` 
+| `GENERIC_TRIGGER_SECRET`  |  --  |  `Generic build trigger secret`  |  `secret101` 
+| `IMAGE_STREAM_NAMESPACE`  |  --  |  `Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.`  |  `openshift` 
+|=======================================================================
+
+== Objects
+
+The CLI supports various object types. A list of these object types as well as their abbreviations
+can be found in the https://docs.openshift.org/latest/cli_reference/basic_cli_operations.html#object-types[Openshift documentation].
+
+=== Services
+
+A service is an abstraction which defines a logical set of pods and a policy by which to access them. Refer to the
+https://cloud.google.com/container-engine/docs/services/[container-engine documentation] for more information.
+
+|=============
+|Service        |Port  | Description
+
+| `${APPLICATION_NAME}`  |  `8080`  |  `The web server's http port.` 
+| `secure-${APPLICATION_NAME}`  |  `8443`  |  `The web server's https port.` 
+| `${APPLICATION_NAME}-ping`  |  `8888`  |  `Ping service for clustered applications.` 
+| `${APPLICATION_NAME}-amq-tcp`  |  `61616`  |  `The broker's tcp (openwire) port.` 
+|=============
+
+=== Routes
+
+A route is a way to expose a service by giving it an externally-reachable hostname such as `www.example.com`. A defined route and the endpoints
+identified by its service can be consumed by a router to provide named connectivity from external clients to your applications. Each route consists
+of a route name, service selector, and (optionally) security configuration. Refer to the
+https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html[Openshift documentation] for more information.
+
+|=============
+| Service    | Security | Hostname
+
+| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+|=============
+
+=== Build Configurations
+
+A `buildConfig` describes a single build definition and a set of triggers for when a new build should be created.
+A `buildConfig` is a REST object, which can be used in a POST to the API server to create a new instance. Refer to
+the https://docs.openshift.com/enterprise/3.0/dev_guide/builds.html#defining-a-buildconfig[Openshift documentation]
+for more information.
+
+|=============
+| STI image  | link | Build output | BuildTriggers and Settings
+
+| `jboss-eap6-openshift:${EAP_RELEASE}`  |  ` link:../../eap/eap-openshift{outfilesuffix}[`jboss-eap-6/eap-openshift`]`  |  `${APPLICATION_NAME}:latest`  |  `Generic, GitHub, ImageChange` 
+|=============
+
+=== Deployment Configurations
+
+A deployment in OpenShift is a replication controller based on a user defined template called a deployment configuration. Deployments are created manually or in response to triggered events.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/deployments.html#creating-a-deployment-configuration[Openshift documentation] for more information.
+
+==== Triggers
+
+A trigger drives the creation of new deployments in response to events, both inside and outside OpenShift. Refer to the
+https://access.redhat.com/beta/documentation/en/openshift-enterprise-30-developer-guide#triggers[Openshift documentation] for more information.
+
+|============
+|Deployment | Triggers
+
+| `${APPLICATION_NAME}`  |  `ImageChange` 
+| `${APPLICATION_NAME}-amq`  |  `ImageChange` 
+|============
+
+==== Replicas
+
+A replication controller ensures that a specified number of pod "replicas" are running at any one time.
+If there are too many, the replication controller kills some pods. If there are too few, it starts more.
+Refer to the https://cloud.google.com/container-engine/docs/replicationcontrollers/[container-engine documentation]
+for more information.
+
+|============
+|Deployment | Replicas
+
+| `${APPLICATION_NAME}`  |  `1` 
+| `${APPLICATION_NAME}-amq`  |  `1` 
+|============
+
+==== Pod Template
+
+===== Service Accounts
+
+Service accounts are API objects that exist within each project. They can be created or deleted like any other API object. Refer to the
+https://docs.openshift.com/enterprise/3.0/dev_guide/service_accounts.html#managing-service-accounts[Openshift documentation] for more
+information.
+
+|============
+|Deployment | Service Account
+
+| `${APPLICATION_NAME}`  |  `eap-service-account` 
+|============
+
+===== Image
+
+|============
+|Deployment | Image
+
+| `${APPLICATION_NAME}`  |  `${APPLICATION_NAME}` 
+| `${APPLICATION_NAME}-amq`  |  `jboss-amq-6` 
+|============
+
+===== Readiness Probe
+
+
+====== ${APPLICATION_NAME}
+----
+/bin/bash
+
+-c
+
+/opt/eap/bin/readinessProbe.sh
+----
+
+====== ${APPLICATION_NAME}-amq
+----
+/bin/bash
+
+-c
+
+curl -s -L -u ${AMQ_ADMIN_USERNAME}:${AMQ_ADMIN_PASSWORD} 'http://localhost:8161/hawtio/jolokia/read/org.apache.activemq:type=Broker,brokerName=*,service=Health/CurrentStatus' | grep -q '"CurrentStatus" *: *"Good"'
+----
+
+
+===== Exposed Ports
+
+|=============
+|Deployments | Name  | Port  | Protocol
+
+.3+| `${APPLICATION_NAME}`
+| `http`  |  `8080`  |  `TCP` 
+| `https`  |  `8443`  |  `TCP` 
+| `ping`  |  `8888`  |  `TCP` 
+.7+| `${APPLICATION_NAME}-amq`
+| `amqp`  |  `5672`  |  `TCP` 
+| `amqp-ssl`  |  `5671`  |  `TCP` 
+| `mqtt`  |  `1883`  |  `TCP` 
+| `stomp`  |  `61613`  |  `TCP` 
+| `stomp-ssl`  |  `61612`  |  `TCP` 
+| `tcp`  |  `61616`  |  `TCP` 
+| `tcp-ssl`  |  `61617`  |  `TCP` 
+|=============
+
+===== Image Environment Variables
+
+|=======================================================================
+|Deployment |Variable name |Description |Example value
+
+.13+| `${APPLICATION_NAME}`
+| `MQ_SERVICE_PREFIX_MAPPING`  |  --  |  `${APPLICATION_NAME}-amq=MQ` 
+| `MQ_JNDI`  |  `JNDI name for connection factory used by applications to connect to the broker, e.g. java:/ConnectionFactory`  |  `${MQ_JNDI}` 
+| `MQ_USERNAME`  |  `Broker user name`  |  `${MQ_USERNAME}` 
+| `MQ_PASSWORD`  |  `Broker user password`  |  `${MQ_PASSWORD}` 
+| `MQ_PROTOCOL`  |  `Protocol to configure.  Only openwire is supported by EAP.  amqp, amqp+ssl, mqtt, stomp, stomp+ssl, and ssl are not supported by EAP`  |  `tcp` 
+| `MQ_QUEUES`  |  `Queue names`  |  `${MQ_QUEUES}` 
+| `MQ_TOPICS`  |  `Topic names`  |  `${MQ_TOPICS}` 
+| `OPENSHIFT_DNS_PING_SERVICE_NAME`  |  --  |  `${APPLICATION_NAME}-ping` 
+| `OPENSHIFT_DNS_PING_SERVICE_PORT`  |  --  |  `8888` 
+| `EAP_HTTPS_KEYSTORE_DIR`  |  `The name of the keystore file within the secret`  |  `/etc/eap-secret-volume` 
+| `EAP_HTTPS_KEYSTORE`  |  `The name of the keystore file within the secret`  |  `${EAP_HTTPS_KEYSTORE}` 
+| `EAP_HTTPS_NAME`  |  `The name associated with the server certificate`  |  `${EAP_HTTPS_NAME}` 
+| `EAP_HTTPS_PASSWORD`  |  `The password for the keystore and certificate`  |  `${EAP_HTTPS_PASSWORD}` 
+.7+| `${APPLICATION_NAME}-amq`
+| `AMQ_USER`  |  `Broker user name`  |  `${MQ_USERNAME}` 
+| `AMQ_PASSWORD`  |  `Broker user password`  |  `${MQ_PASSWORD}` 
+| `AMQ_PROTOCOLS`  |  `Protocol to configure.  Only openwire is supported by EAP.  amqp, amqp+ssl, mqtt, stomp, stomp+ssl, and ssl are not supported by EAP`  |  `${MQ_PROTOCOL}` 
+| `AMQ_QUEUES`  |  `Queue names`  |  `${MQ_QUEUES}` 
+| `AMQ_TOPICS`  |  `Topic names`  |  `${MQ_TOPICS}` 
+| `AMQ_ADMIN_USERNAME`  |  `ActiveMQ Admin User`  |  `${AMQ_ADMIN_USERNAME}` 
+| `AMQ_ADMIN_PASSWORD`  |  `ActiveMQ Admin Password`  |  `${AMQ_ADMIN_PASSWORD}` 
+|=======================================================================
+
+=====  Volumes
+
+|=============
+|Deployment |Name  | mountPath | Purpose | readOnly 
+
+| `${APPLICATION_NAME}`  |  `eap-keystore-volume`  |  `/etc/eap-secret-volume`  |  `ssl certs`  |  `True` 
+| `${APPLICATION_NAME}-amq`  |  `${APPLICATION_NAME}-amq-pvol`  |  `/opt/amq/data/kahadb`  |  `kahadb`  |  `false` 
+|=============
+
+=== External Dependencies
+
+==== Volume Claims
+
+A `PersistentVolume` object is a storage resource in an OpenShift cluster. Storage is provisioned by an administrator
+by creating `PersistentVolume` objects from sources such as GCE Persistent Disks, AWS Elastic Block Stores (EBS), and NFS mounts.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/persistent_volumes.html#overview[Openshift documentation] for
+more information.
+
+|=============
+|Name | Access Mode
+
+| `${APPLICATION_NAME}-amq-claim`  |  `ReadWriteOnce` 
+|=============
+
+==== Secrets 
+
+This template requires https://github.com/jboss-openshift/application-templates/blob/master/secrets/eap-app-secrets.json[eap-app-secrets.json] to be installed for the application to run.

--- a/docs/templates/eap/eap6-amq-sti.adoc
+++ b/docs/templates/eap/eap6-amq-sti.adoc
@@ -1,0 +1,234 @@
+= eap6-amq-sti
+
+Application template for EAP 6 A-MQ applications built using STI.
+
+toc::[levels=2]
+
+== Parameters
+
+Templates allow you to define parameters which take on a value. That value is then substituted wherever the parameter is referenced.
+References can be defined in any text field in the objects list field. Refer to the
+https://docs.openshift.org/latest/architecture/core_concepts/templates.html#parameters[Openshift documentation] for more information.
+
+|=======================================================================
+|Variable name |Image Environment Variable |Description |Example value
+
+| `EAP_RELEASE`  |  --  |  `EAP Release version, e.g. 6.4, etc.`  |  `6.4` 
+| `AMQ_RELEASE`  |  --  |  `ActiveMQ Release version, e.g. 6.2, etc.`  |  `6.2` 
+| `APPLICATION_NAME`  |  --  |  `The name for the application.`  |  `eap-app` 
+| `APPLICATION_HOSTNAME`  |  --  |  `Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>`  |  `secure-app.test.router.default.local` 
+| `GIT_URI`  |  --  |  `Git source URI for application`  |  ``https://github.com/jboss-openshift/openshift-examples.git` 
+| `GIT_REF`  |  --  |  `Git branch/tag reference`  |  `master` 
+| `GIT_CONTEXT_DIR`  |  --  |  `Path within Git project to build; empty for root project directory.`  |  `helloworld` 
+| `MQ_JNDI`  |  `MQ_JNDI`  |  `JNDI name for connection factory used by applications to connect to the broker, e.g. java:/ConnectionFactory`  |  `java:/ConnectionFactory` 
+| `MQ_PROTOCOL`  |  `MQ_PROTOCOL`  |  `Protocol to configure.  Only openwire is supported by EAP.  amqp, amqp+ssl, mqtt, stomp, stomp+ssl, and ssl are not supported by EAP`  |  `openwire` 
+| `MQ_QUEUES`  |  `MQ_QUEUES`  |  `Queue names`  |  `${MQ_QUEUES}` 
+| `MQ_TOPICS`  |  `MQ_TOPICS`  |  `Topic names`  |  `${MQ_TOPICS}` 
+| `EAP_HTTPS_SECRET`  |  --  |  `The name of the secret containing the keystore file`  |  `eap-app-secret` 
+| `EAP_HTTPS_KEYSTORE`  |  `EAP_HTTPS_KEYSTORE_DIR`  |  `The name of the keystore file within the secret`  |  `keystore.jks` 
+| `EAP_HTTPS_NAME`  |  `EAP_HTTPS_NAME`  |  `The name associated with the server certificate`  |  `${EAP_HTTPS_NAME}` 
+| `EAP_HTTPS_PASSWORD`  |  `EAP_HTTPS_PASSWORD`  |  `The password for the keystore and certificate`  |  `${EAP_HTTPS_PASSWORD}` 
+| `MQ_USERNAME`  |  `MQ_USERNAME`  |  `Broker user name`  |  `${MQ_USERNAME}` 
+| `MQ_PASSWORD`  |  `MQ_PASSWORD`  |  `Broker user password`  |  `${MQ_PASSWORD}` 
+| `AMQ_ADMIN_USERNAME`  |  `AMQ_ADMIN_USERNAME`  |  `ActiveMQ Admin User`  |  `${AMQ_ADMIN_USERNAME}` 
+| `AMQ_ADMIN_PASSWORD`  |  `AMQ_ADMIN_PASSWORD`  |  `ActiveMQ Admin Password`  |  `${AMQ_ADMIN_PASSWORD}` 
+| `GITHUB_TRIGGER_SECRET`  |  --  |  `GitHub trigger secret`  |  `secret101` 
+| `GENERIC_TRIGGER_SECRET`  |  --  |  `Generic build trigger secret`  |  `secret101` 
+| `IMAGE_STREAM_NAMESPACE`  |  --  |  `Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.`  |  `openshift` 
+|=======================================================================
+
+== Objects
+
+The CLI supports various object types. A list of these object types as well as their abbreviations
+can be found in the https://docs.openshift.org/latest/cli_reference/basic_cli_operations.html#object-types[Openshift documentation].
+
+=== Services
+
+A service is an abstraction which defines a logical set of pods and a policy by which to access them. Refer to the
+https://cloud.google.com/container-engine/docs/services/[container-engine documentation] for more information.
+
+|=============
+|Service        |Port  | Description
+
+| `${APPLICATION_NAME}`  |  `8080`  |  `The web server's http port.` 
+| `secure-${APPLICATION_NAME}`  |  `8443`  |  `The web server's https port.` 
+| `${APPLICATION_NAME}-ping`  |  `8888`  |  `Ping service for clustered applications.` 
+| `${APPLICATION_NAME}-amq-tcp`  |  `61616`  |  `The broker's tcp (openwire) port.` 
+|=============
+
+=== Routes
+
+A route is a way to expose a service by giving it an externally-reachable hostname such as `www.example.com`. A defined route and the endpoints
+identified by its service can be consumed by a router to provide named connectivity from external clients to your applications. Each route consists
+of a route name, service selector, and (optionally) security configuration. Refer to the
+https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html[Openshift documentation] for more information.
+
+|=============
+| Service    | Security | Hostname
+
+| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+|=============
+
+=== Build Configurations
+
+A `buildConfig` describes a single build definition and a set of triggers for when a new build should be created.
+A `buildConfig` is a REST object, which can be used in a POST to the API server to create a new instance. Refer to
+the https://docs.openshift.com/enterprise/3.0/dev_guide/builds.html#defining-a-buildconfig[Openshift documentation]
+for more information.
+
+|=============
+| STI image  | link | Build output | BuildTriggers and Settings
+
+| `jboss-eap6-openshift:${EAP_RELEASE}`  |  ` link:../../eap/eap-openshift{outfilesuffix}[`jboss-eap-6/eap-openshift`]`  |  `${APPLICATION_NAME}:latest`  |  `Generic, GitHub, ImageChange` 
+|=============
+
+=== Deployment Configurations
+
+A deployment in OpenShift is a replication controller based on a user defined template called a deployment configuration. Deployments are created manually or in response to triggered events.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/deployments.html#creating-a-deployment-configuration[Openshift documentation] for more information.
+
+==== Triggers
+
+A trigger drives the creation of new deployments in response to events, both inside and outside OpenShift. Refer to the
+https://access.redhat.com/beta/documentation/en/openshift-enterprise-30-developer-guide#triggers[Openshift documentation] for more information.
+
+|============
+|Deployment | Triggers
+
+| `${APPLICATION_NAME}`  |  `ImageChange` 
+| `${APPLICATION_NAME}-amq`  |  `ImageChange` 
+|============
+
+==== Replicas
+
+A replication controller ensures that a specified number of pod "replicas" are running at any one time.
+If there are too many, the replication controller kills some pods. If there are too few, it starts more.
+Refer to the https://cloud.google.com/container-engine/docs/replicationcontrollers/[container-engine documentation]
+for more information.
+
+|============
+|Deployment | Replicas
+
+| `${APPLICATION_NAME}`  |  `1` 
+| `${APPLICATION_NAME}-amq`  |  `1` 
+|============
+
+==== Pod Template
+
+===== Service Accounts
+
+Service accounts are API objects that exist within each project. They can be created or deleted like any other API object. Refer to the
+https://docs.openshift.com/enterprise/3.0/dev_guide/service_accounts.html#managing-service-accounts[Openshift documentation] for more
+information.
+
+|============
+|Deployment | Service Account
+
+| `${APPLICATION_NAME}`  |  `eap-service-account` 
+|============
+
+===== Image
+
+|============
+|Deployment | Image
+
+| `${APPLICATION_NAME}`  |  `${APPLICATION_NAME}` 
+| `${APPLICATION_NAME}-amq`  |  `jboss-amq-6` 
+|============
+
+===== Readiness Probe
+
+
+====== ${APPLICATION_NAME}
+----
+/bin/bash
+
+-c
+
+/opt/eap/bin/readinessProbe.sh
+----
+
+====== ${APPLICATION_NAME}-amq
+----
+/bin/bash
+
+-c
+
+curl -s -L -u ${AMQ_ADMIN_USERNAME}:${AMQ_ADMIN_PASSWORD} 'http://localhost:8161/hawtio/jolokia/read/org.apache.activemq:type=Broker,brokerName=*,service=Health/CurrentStatus' | grep -q '"CurrentStatus" *: *"Good"'
+----
+
+
+===== Exposed Ports
+
+|=============
+|Deployments | Name  | Port  | Protocol
+
+.3+| `${APPLICATION_NAME}`
+| `http`  |  `8080`  |  `TCP` 
+| `https`  |  `8443`  |  `TCP` 
+| `ping`  |  `8888`  |  `TCP` 
+.7+| `${APPLICATION_NAME}-amq`
+| `amqp`  |  `5672`  |  `TCP` 
+| `amqp-ssl`  |  `5671`  |  `TCP` 
+| `mqtt`  |  `1883`  |  `TCP` 
+| `stomp`  |  `61613`  |  `TCP` 
+| `stomp-ssl`  |  `61612`  |  `TCP` 
+| `tcp`  |  `61616`  |  `TCP` 
+| `tcp-ssl`  |  `61617`  |  `TCP` 
+|=============
+
+===== Image Environment Variables
+
+|=======================================================================
+|Deployment |Variable name |Description |Example value
+
+.13+| `${APPLICATION_NAME}`
+| `MQ_SERVICE_PREFIX_MAPPING`  |  --  |  `${APPLICATION_NAME}-amq=MQ` 
+| `MQ_JNDI`  |  `JNDI name for connection factory used by applications to connect to the broker, e.g. java:/ConnectionFactory`  |  `${MQ_JNDI}` 
+| `MQ_USERNAME`  |  `Broker user name`  |  `${MQ_USERNAME}` 
+| `MQ_PASSWORD`  |  `Broker user password`  |  `${MQ_PASSWORD}` 
+| `MQ_PROTOCOL`  |  `Protocol to configure.  Only openwire is supported by EAP.  amqp, amqp+ssl, mqtt, stomp, stomp+ssl, and ssl are not supported by EAP`  |  `tcp` 
+| `MQ_QUEUES`  |  `Queue names`  |  `${MQ_QUEUES}` 
+| `MQ_TOPICS`  |  `Topic names`  |  `${MQ_TOPICS}` 
+| `OPENSHIFT_DNS_PING_SERVICE_NAME`  |  --  |  `${APPLICATION_NAME}-ping` 
+| `OPENSHIFT_DNS_PING_SERVICE_PORT`  |  --  |  `8888` 
+| `EAP_HTTPS_KEYSTORE_DIR`  |  `The name of the keystore file within the secret`  |  `/etc/eap-secret-volume` 
+| `EAP_HTTPS_KEYSTORE`  |  `The name of the keystore file within the secret`  |  `${EAP_HTTPS_KEYSTORE}` 
+| `EAP_HTTPS_NAME`  |  `The name associated with the server certificate`  |  `${EAP_HTTPS_NAME}` 
+| `EAP_HTTPS_PASSWORD`  |  `The password for the keystore and certificate`  |  `${EAP_HTTPS_PASSWORD}` 
+.7+| `${APPLICATION_NAME}-amq`
+| `AMQ_USER`  |  `Broker user name`  |  `${MQ_USERNAME}` 
+| `AMQ_PASSWORD`  |  `Broker user password`  |  `${MQ_PASSWORD}` 
+| `AMQ_PROTOCOLS`  |  `Protocol to configure.  Only openwire is supported by EAP.  amqp, amqp+ssl, mqtt, stomp, stomp+ssl, and ssl are not supported by EAP`  |  `${MQ_PROTOCOL}` 
+| `AMQ_QUEUES`  |  `Queue names`  |  `${MQ_QUEUES}` 
+| `AMQ_TOPICS`  |  `Topic names`  |  `${MQ_TOPICS}` 
+| `AMQ_ADMIN_USERNAME`  |  `ActiveMQ Admin User`  |  `${AMQ_ADMIN_USERNAME}` 
+| `AMQ_ADMIN_PASSWORD`  |  `ActiveMQ Admin Password`  |  `${AMQ_ADMIN_PASSWORD}` 
+|=======================================================================
+
+=====  Volumes
+
+|=============
+|Deployment |Name  | mountPath | Purpose | readOnly 
+
+| `${APPLICATION_NAME}`  |  `eap-keystore-volume`  |  `/etc/eap-secret-volume`  |  `ssl certs`  |  `True` 
+|=============
+
+=== External Dependencies
+
+==== Volume Claims
+
+A `PersistentVolume` object is a storage resource in an OpenShift cluster. Storage is provisioned by an administrator
+by creating `PersistentVolume` objects from sources such as GCE Persistent Disks, AWS Elastic Block Stores (EBS), and NFS mounts.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/persistent_volumes.html#overview[Openshift documentation] for
+more information.
+
+|=============
+|Name | Access Mode
+
+|=============
+
+==== Secrets 
+
+This template requires https://github.com/jboss-openshift/application-templates/blob/master/secrets/eap-app-secrets.json[eap-app-secrets.json] to be installed for the application to run.

--- a/docs/templates/eap/eap6-basic-sti.adoc
+++ b/docs/templates/eap/eap6-basic-sti.adoc
@@ -1,0 +1,182 @@
+= eap6-basic-sti
+
+Application template for EAP 6 applications built using STI.
+
+toc::[levels=2]
+
+== Parameters
+
+Templates allow you to define parameters which take on a value. That value is then substituted wherever the parameter is referenced.
+References can be defined in any text field in the objects list field. Refer to the
+https://docs.openshift.org/latest/architecture/core_concepts/templates.html#parameters[Openshift documentation] for more information.
+
+|=======================================================================
+|Variable name |Image Environment Variable |Description |Example value
+
+| `EAP_RELEASE`  |  --  |  `EAP Release version, e.g. 6.4, etc.`  |  `6.4` 
+| `APPLICATION_NAME`  |  --  |  `The name for the application.`  |  `eap-app` 
+| `APPLICATION_HOSTNAME`  |  --  |  `Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>`  |  `secure-app.test.router.default.local` 
+| `GIT_URI`  |  --  |  `Git source URI for application`  |  `https://github.com/jboss-developer/jboss-eap-quickstarts` 
+| `GIT_REF`  |  --  |  `Git branch/tag reference`  |  `6.4.x` 
+| `GIT_CONTEXT_DIR`  |  --  |  `Path within Git project to build; empty for root project directory.`  |  `kitchensink` 
+| `HORNETQ_QUEUES`  |  `HORNETQ_QUEUES`  |  `Queue names`  |  `${HORNETQ_QUEUES}` 
+| `HORNETQ_TOPICS`  |  `HORNETQ_TOPICS`  |  `Topic names`  |  `${HORNETQ_TOPICS}` 
+| `HORNETQ_CLUSTER_PASSWORD`  |  `HORNETQ_CLUSTER_PASSWORD`  |  `HornetQ cluster admin password`  |  `${HORNETQ_CLUSTER_PASSWORD}` 
+| `GITHUB_TRIGGER_SECRET`  |  --  |  `GitHub trigger secret`  |  `secret101` 
+| `GENERIC_TRIGGER_SECRET`  |  --  |  `Generic build trigger secret`  |  `secret101` 
+| `IMAGE_STREAM_NAMESPACE`  |  --  |  `Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.`  |  `openshift` 
+|=======================================================================
+
+== Objects
+
+The CLI supports various object types. A list of these object types as well as their abbreviations
+can be found in the https://docs.openshift.org/latest/cli_reference/basic_cli_operations.html#object-types[Openshift documentation].
+
+=== Services
+
+A service is an abstraction which defines a logical set of pods and a policy by which to access them. Refer to the
+https://cloud.google.com/container-engine/docs/services/[container-engine documentation] for more information.
+
+|=============
+|Service        |Port  | Description
+
+| `${APPLICATION_NAME}`  |  `8080`  |  `The web server's http port.` 
+| `${APPLICATION_NAME}-ping`  |  `8888`  |  `Ping service for clustered applications.` 
+|=============
+
+=== Routes
+
+A route is a way to expose a service by giving it an externally-reachable hostname such as `www.example.com`. A defined route and the endpoints
+identified by its service can be consumed by a router to provide named connectivity from external clients to your applications. Each route consists
+of a route name, service selector, and (optionally) security configuration. Refer to the
+https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html[Openshift documentation] for more information.
+
+|=============
+| Service    | Security | Hostname
+
+| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+|=============
+
+=== Build Configurations
+
+A `buildConfig` describes a single build definition and a set of triggers for when a new build should be created.
+A `buildConfig` is a REST object, which can be used in a POST to the API server to create a new instance. Refer to
+the https://docs.openshift.com/enterprise/3.0/dev_guide/builds.html#defining-a-buildconfig[Openshift documentation]
+for more information.
+
+|=============
+| STI image  | link | Build output | BuildTriggers and Settings
+
+| `jboss-eap6-openshift:${EAP_RELEASE}`  |  ` link:../../eap/eap-openshift{outfilesuffix}[`jboss-eap-6/eap-openshift`]`  |  `${APPLICATION_NAME}:latest`  |  `Generic, GitHub, ImageChange` 
+|=============
+
+=== Deployment Configurations
+
+A deployment in OpenShift is a replication controller based on a user defined template called a deployment configuration. Deployments are created manually or in response to triggered events.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/deployments.html#creating-a-deployment-configuration[Openshift documentation] for more information.
+
+==== Triggers
+
+A trigger drives the creation of new deployments in response to events, both inside and outside OpenShift. Refer to the
+https://access.redhat.com/beta/documentation/en/openshift-enterprise-30-developer-guide#triggers[Openshift documentation] for more information.
+
+|============
+|Deployment | Triggers
+
+| `${APPLICATION_NAME}`  |  `ImageChange` 
+|============
+
+==== Replicas
+
+A replication controller ensures that a specified number of pod "replicas" are running at any one time.
+If there are too many, the replication controller kills some pods. If there are too few, it starts more.
+Refer to the https://cloud.google.com/container-engine/docs/replicationcontrollers/[container-engine documentation]
+for more information.
+
+|============
+|Deployment | Replicas
+
+| `${APPLICATION_NAME}`  |  `1` 
+|============
+
+==== Pod Template
+
+===== Service Accounts
+
+Service accounts are API objects that exist within each project. They can be created or deleted like any other API object. Refer to the
+https://docs.openshift.com/enterprise/3.0/dev_guide/service_accounts.html#managing-service-accounts[Openshift documentation] for more
+information.
+
+|============
+|Deployment | Service Account
+
+|============
+
+===== Image
+
+|============
+|Deployment | Image
+
+| `${APPLICATION_NAME}`  |  `${APPLICATION_NAME}` 
+|============
+
+===== Readiness Probe
+
+
+====== ${APPLICATION_NAME}
+----
+/bin/bash
+
+-c
+
+/opt/eap/bin/readinessProbe.sh
+----
+
+
+===== Exposed Ports
+
+|=============
+|Deployments | Name  | Port  | Protocol
+
+.2+| `${APPLICATION_NAME}`
+| `http`  |  `8080`  |  `TCP` 
+| `ping`  |  `8888`  |  `TCP` 
+|=============
+
+===== Image Environment Variables
+
+|=======================================================================
+|Deployment |Variable name |Description |Example value
+
+.5+| `${APPLICATION_NAME}`
+| `OPENSHIFT_DNS_PING_SERVICE_NAME`  |  --  |  `${APPLICATION_NAME}-ping` 
+| `OPENSHIFT_DNS_PING_SERVICE_PORT`  |  --  |  `8888` 
+| `HORNETQ_CLUSTER_PASSWORD`  |  `HornetQ cluster admin password`  |  `${HORNETQ_CLUSTER_PASSWORD}` 
+| `HORNETQ_QUEUES`  |  `Queue names`  |  `${HORNETQ_QUEUES}` 
+| `HORNETQ_TOPICS`  |  `Topic names`  |  `${HORNETQ_TOPICS}` 
+|=======================================================================
+
+=====  Volumes
+
+|=============
+|Deployment |Name  | mountPath | Purpose | readOnly 
+
+|=============
+
+=== External Dependencies
+
+==== Volume Claims
+
+A `PersistentVolume` object is a storage resource in an OpenShift cluster. Storage is provisioned by an administrator
+by creating `PersistentVolume` objects from sources such as GCE Persistent Disks, AWS Elastic Block Stores (EBS), and NFS mounts.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/persistent_volumes.html#overview[Openshift documentation] for
+more information.
+
+|=============
+|Name | Access Mode
+
+|=============
+
+==== Secrets 
+
+This template requires https://github.com/jboss-openshift/application-templates/blob/master/secrets/eap-app-secrets.json[eap-app-secrets.json] to be installed for the application to run.

--- a/docs/templates/eap/eap6-https-sti.adoc
+++ b/docs/templates/eap/eap6-https-sti.adoc
@@ -1,0 +1,195 @@
+= eap6-https-sti
+
+Application template for EAP 6 applications built using STI.
+
+toc::[levels=2]
+
+== Parameters
+
+Templates allow you to define parameters which take on a value. That value is then substituted wherever the parameter is referenced.
+References can be defined in any text field in the objects list field. Refer to the
+https://docs.openshift.org/latest/architecture/core_concepts/templates.html#parameters[Openshift documentation] for more information.
+
+|=======================================================================
+|Variable name |Image Environment Variable |Description |Example value
+
+| `EAP_RELEASE`  |  --  |  `EAP Release version, e.g. 6.4, etc.`  |  `6.4` 
+| `APPLICATION_NAME`  |  --  |  `The name for the application.`  |  `eap-app` 
+| `APPLICATION_HOSTNAME`  |  --  |  `Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>`  |  `secure-app.test.router.default.local` 
+| `GIT_URI`  |  --  |  `Git source URI for application`  |  `https://github.com/jboss-developer/jboss-eap-quickstarts` 
+| `GIT_REF`  |  --  |  `Git branch/tag reference`  |  `6.4.x` 
+| `GIT_CONTEXT_DIR`  |  --  |  `Path within Git project to build; empty for root project directory.`  |  `kitchensink` 
+| `HORNETQ_QUEUES`  |  `HORNETQ_QUEUES`  |  `Queue names`  |  `${HORNETQ_QUEUES}` 
+| `HORNETQ_TOPICS`  |  `HORNETQ_TOPICS`  |  `Topic names`  |  `${HORNETQ_TOPICS}` 
+| `EAP_HTTPS_SECRET`  |  --  |  `The name of the secret containing the keystore file`  |  `eap-app-secret` 
+| `EAP_HTTPS_KEYSTORE`  |  `EAP_HTTPS_KEYSTORE_DIR`  |  `The name of the keystore file within the secret`  |  `keystore.jks` 
+| `EAP_HTTPS_NAME`  |  `EAP_HTTPS_NAME`  |  `The name associated with the server certificate`  |  `${EAP_HTTPS_NAME}` 
+| `EAP_HTTPS_PASSWORD`  |  `EAP_HTTPS_PASSWORD`  |  `The password for the keystore and certificate`  |  `${EAP_HTTPS_PASSWORD}` 
+| `HORNETQ_CLUSTER_PASSWORD`  |  `HORNETQ_CLUSTER_PASSWORD`  |  `HornetQ cluster admin password`  |  `${HORNETQ_CLUSTER_PASSWORD}` 
+| `GITHUB_TRIGGER_SECRET`  |  --  |  `GitHub trigger secret`  |  `secret101` 
+| `GENERIC_TRIGGER_SECRET`  |  --  |  `Generic build trigger secret`  |  `secret101` 
+| `IMAGE_STREAM_NAMESPACE`  |  --  |  `Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.`  |  `openshift` 
+|=======================================================================
+
+== Objects
+
+The CLI supports various object types. A list of these object types as well as their abbreviations
+can be found in the https://docs.openshift.org/latest/cli_reference/basic_cli_operations.html#object-types[Openshift documentation].
+
+=== Services
+
+A service is an abstraction which defines a logical set of pods and a policy by which to access them. Refer to the
+https://cloud.google.com/container-engine/docs/services/[container-engine documentation] for more information.
+
+|=============
+|Service        |Port  | Description
+
+| `${APPLICATION_NAME}`  |  `8080`  |  `The web server's http port.` 
+| `secure-${APPLICATION_NAME}`  |  `8443`  |  `The web server's https port.` 
+| `${APPLICATION_NAME}-ping`  |  `8888`  |  `Ping service for clustered applications.` 
+|=============
+
+=== Routes
+
+A route is a way to expose a service by giving it an externally-reachable hostname such as `www.example.com`. A defined route and the endpoints
+identified by its service can be consumed by a router to provide named connectivity from external clients to your applications. Each route consists
+of a route name, service selector, and (optionally) security configuration. Refer to the
+https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html[Openshift documentation] for more information.
+
+|=============
+| Service    | Security | Hostname
+
+| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+|=============
+
+=== Build Configurations
+
+A `buildConfig` describes a single build definition and a set of triggers for when a new build should be created.
+A `buildConfig` is a REST object, which can be used in a POST to the API server to create a new instance. Refer to
+the https://docs.openshift.com/enterprise/3.0/dev_guide/builds.html#defining-a-buildconfig[Openshift documentation]
+for more information.
+
+|=============
+| STI image  | link | Build output | BuildTriggers and Settings
+
+| `jboss-eap6-openshift:${EAP_RELEASE}`  |  ` link:../../eap/eap-openshift{outfilesuffix}[`jboss-eap-6/eap-openshift`]`  |  `${APPLICATION_NAME}:latest`  |  `Generic, GitHub, ImageChange` 
+|=============
+
+=== Deployment Configurations
+
+A deployment in OpenShift is a replication controller based on a user defined template called a deployment configuration. Deployments are created manually or in response to triggered events.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/deployments.html#creating-a-deployment-configuration[Openshift documentation] for more information.
+
+==== Triggers
+
+A trigger drives the creation of new deployments in response to events, both inside and outside OpenShift. Refer to the
+https://access.redhat.com/beta/documentation/en/openshift-enterprise-30-developer-guide#triggers[Openshift documentation] for more information.
+
+|============
+|Deployment | Triggers
+
+| `${APPLICATION_NAME}`  |  `ImageChange` 
+|============
+
+==== Replicas
+
+A replication controller ensures that a specified number of pod "replicas" are running at any one time.
+If there are too many, the replication controller kills some pods. If there are too few, it starts more.
+Refer to the https://cloud.google.com/container-engine/docs/replicationcontrollers/[container-engine documentation]
+for more information.
+
+|============
+|Deployment | Replicas
+
+| `${APPLICATION_NAME}`  |  `1` 
+|============
+
+==== Pod Template
+
+===== Service Accounts
+
+Service accounts are API objects that exist within each project. They can be created or deleted like any other API object. Refer to the
+https://docs.openshift.com/enterprise/3.0/dev_guide/service_accounts.html#managing-service-accounts[Openshift documentation] for more
+information.
+
+|============
+|Deployment | Service Account
+
+| `${APPLICATION_NAME}`  |  `eap-service-account` 
+|============
+
+===== Image
+
+|============
+|Deployment | Image
+
+| `${APPLICATION_NAME}`  |  `${APPLICATION_NAME}` 
+|============
+
+===== Readiness Probe
+
+
+====== ${APPLICATION_NAME}
+----
+/bin/bash
+
+-c
+
+/opt/eap/bin/readinessProbe.sh
+----
+
+
+===== Exposed Ports
+
+|=============
+|Deployments | Name  | Port  | Protocol
+
+.3+| `${APPLICATION_NAME}`
+| `http`  |  `8080`  |  `TCP` 
+| `https`  |  `8443`  |  `TCP` 
+| `ping`  |  `8888`  |  `TCP` 
+|=============
+
+===== Image Environment Variables
+
+|=======================================================================
+|Deployment |Variable name |Description |Example value
+
+.9+| `${APPLICATION_NAME}`
+| `OPENSHIFT_DNS_PING_SERVICE_NAME`  |  --  |  `${APPLICATION_NAME}-ping` 
+| `OPENSHIFT_DNS_PING_SERVICE_PORT`  |  --  |  `8888` 
+| `EAP_HTTPS_KEYSTORE_DIR`  |  `The name of the keystore file within the secret`  |  `/etc/eap-secret-volume` 
+| `EAP_HTTPS_KEYSTORE`  |  `The name of the keystore file within the secret`  |  `${EAP_HTTPS_KEYSTORE}` 
+| `EAP_HTTPS_NAME`  |  `The name associated with the server certificate`  |  `${EAP_HTTPS_NAME}` 
+| `EAP_HTTPS_PASSWORD`  |  `The password for the keystore and certificate`  |  `${EAP_HTTPS_PASSWORD}` 
+| `HORNETQ_CLUSTER_PASSWORD`  |  `HornetQ cluster admin password`  |  `${HORNETQ_CLUSTER_PASSWORD}` 
+| `HORNETQ_QUEUES`  |  `Queue names`  |  `${HORNETQ_QUEUES}` 
+| `HORNETQ_TOPICS`  |  `Topic names`  |  `${HORNETQ_TOPICS}` 
+|=======================================================================
+
+=====  Volumes
+
+|=============
+|Deployment |Name  | mountPath | Purpose | readOnly 
+
+| `${APPLICATION_NAME}`  |  `eap-keystore-volume`  |  `/etc/eap-secret-volume`  |  `ssl certs`  |  `True` 
+|=============
+
+=== External Dependencies
+
+==== Volume Claims
+
+A `PersistentVolume` object is a storage resource in an OpenShift cluster. Storage is provisioned by an administrator
+by creating `PersistentVolume` objects from sources such as GCE Persistent Disks, AWS Elastic Block Stores (EBS), and NFS mounts.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/persistent_volumes.html#overview[Openshift documentation] for
+more information.
+
+|=============
+|Name | Access Mode
+
+|=============
+
+==== Secrets 
+
+This template requires https://github.com/jboss-openshift/application-templates/blob/master/secrets/eap-app-secrets.json[eap-app-secrets.json] to be installed for the application to run.

--- a/docs/templates/eap/eap6-mongodb-persistent-sti.adoc
+++ b/docs/templates/eap/eap6-mongodb-persistent-sti.adoc
@@ -1,0 +1,232 @@
+= eap6-mongodb-persistent-sti
+
+Application template for EAP 6 MongDB applications with persistent storage built using STI.
+
+toc::[levels=2]
+
+== Parameters
+
+Templates allow you to define parameters which take on a value. That value is then substituted wherever the parameter is referenced.
+References can be defined in any text field in the objects list field. Refer to the
+https://docs.openshift.org/latest/architecture/core_concepts/templates.html#parameters[Openshift documentation] for more information.
+
+|=======================================================================
+|Variable name |Image Environment Variable |Description |Example value
+
+| `EAP_RELEASE`  |  --  |  `EAP Release version, e.g. 6.4, etc.`  |  `6.4` 
+| `APPLICATION_NAME`  |  --  |  `The name for the application.`  |  `eap-app` 
+| `APPLICATION_HOSTNAME`  |  --  |  `Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>`  |  `secure-app.test.router.default.local` 
+| `GIT_URI`  |  --  |  `Git source URI for application`  |  ``https://github.com/jboss-openshift/openshift-examples.git` 
+| `GIT_REF`  |  --  |  `Git branch/tag reference`  |  `master` 
+| `GIT_CONTEXT_DIR`  |  --  |  `Path within Git project to build; empty for root project directory.`  |  `helloworld` 
+| `DB_JNDI`  |  `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb`  |  `${DB_JNDI}` 
+| `DB_DATABASE`  |  `DB_DATABASE`  |  `Database name`  |  `root` 
+| `VOLUME_CAPACITY`  |  --  |  `Size of persistent storage for database volume.`  |  `512Mi` 
+| `HORNETQ_QUEUES`  |  `HORNETQ_QUEUES`  |  `Queue names`  |  `${HORNETQ_QUEUES}` 
+| `HORNETQ_TOPICS`  |  `HORNETQ_TOPICS`  |  `Topic names`  |  `${HORNETQ_TOPICS}` 
+| `EAP_HTTPS_SECRET`  |  --  |  `The name of the secret containing the keystore file`  |  `eap-app-secret` 
+| `EAP_HTTPS_KEYSTORE`  |  `EAP_HTTPS_KEYSTORE_DIR`  |  `The name of the keystore file within the secret`  |  `keystore.jks` 
+| `EAP_HTTPS_NAME`  |  `EAP_HTTPS_NAME`  |  `The name associated with the server certificate`  |  `${EAP_HTTPS_NAME}` 
+| `EAP_HTTPS_PASSWORD`  |  `EAP_HTTPS_PASSWORD`  |  `The password for the keystore and certificate`  |  `${EAP_HTTPS_PASSWORD}` 
+| `DB_MIN_POOL_SIZE`  |  `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `MONGODB_NOPREALLOC`  |  `MONGODB_NOPREALLOC`  |  `Disable data file preallocation.`  |  `${MONGODB_NOPREALLOC}` 
+| `MONGODB_SMALLFILES`  |  `MONGODB_SMALLFILES`  |  `Set MongoDB to use a smaller default data file size.`  |  `${MONGODB_SMALLFILES}` 
+| `MONGODB_QUIET`  |  `MONGODB_QUIET`  |  `Runs MongoDB in a quiet mode that attempts to limit the amount of output.`  |  `${MONGODB_QUIET}` 
+| `HORNETQ_CLUSTER_PASSWORD`  |  `HORNETQ_CLUSTER_PASSWORD`  |  `HornetQ cluster admin password`  |  `${HORNETQ_CLUSTER_PASSWORD}` 
+| `DB_USERNAME`  |  `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `DB_ADMIN_PASSWORD`  |  `DB_ADMIN_PASSWORD`  |  `Database admin password`  |  `${DB_ADMIN_PASSWORD}` 
+| `GITHUB_TRIGGER_SECRET`  |  --  |  `GitHub trigger secret`  |  `secret101` 
+| `GENERIC_TRIGGER_SECRET`  |  --  |  `Generic build trigger secret`  |  `secret101` 
+| `IMAGE_STREAM_NAMESPACE`  |  --  |  `Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.`  |  `openshift` 
+|=======================================================================
+
+== Objects
+
+The CLI supports various object types. A list of these object types as well as their abbreviations
+can be found in the https://docs.openshift.org/latest/cli_reference/basic_cli_operations.html#object-types[Openshift documentation].
+
+=== Services
+
+A service is an abstraction which defines a logical set of pods and a policy by which to access them. Refer to the
+https://cloud.google.com/container-engine/docs/services/[container-engine documentation] for more information.
+
+|=============
+|Service        |Port  | Description
+
+| `${APPLICATION_NAME}`  |  `8080`  |  `The web server's http port.` 
+| `secure-${APPLICATION_NAME}`  |  `8443`  |  `The web server's https port.` 
+| `${APPLICATION_NAME}-ping`  |  `8888`  |  `Ping service for clustered applications.` 
+| `${APPLICATION_NAME}-mongodb`  |  `27017`  |  `The database server's port.` 
+|=============
+
+=== Routes
+
+A route is a way to expose a service by giving it an externally-reachable hostname such as `www.example.com`. A defined route and the endpoints
+identified by its service can be consumed by a router to provide named connectivity from external clients to your applications. Each route consists
+of a route name, service selector, and (optionally) security configuration. Refer to the
+https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html[Openshift documentation] for more information.
+
+|=============
+| Service    | Security | Hostname
+
+| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+|=============
+
+=== Build Configurations
+
+A `buildConfig` describes a single build definition and a set of triggers for when a new build should be created.
+A `buildConfig` is a REST object, which can be used in a POST to the API server to create a new instance. Refer to
+the https://docs.openshift.com/enterprise/3.0/dev_guide/builds.html#defining-a-buildconfig[Openshift documentation]
+for more information.
+
+|=============
+| STI image  | link | Build output | BuildTriggers and Settings
+
+| `jboss-eap6-openshift:${EAP_RELEASE}`  |  ` link:../../eap/eap-openshift{outfilesuffix}[`jboss-eap-6/eap-openshift`]`  |  `${APPLICATION_NAME}:latest`  |  `Generic, GitHub, ImageChange` 
+|=============
+
+=== Deployment Configurations
+
+A deployment in OpenShift is a replication controller based on a user defined template called a deployment configuration. Deployments are created manually or in response to triggered events.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/deployments.html#creating-a-deployment-configuration[Openshift documentation] for more information.
+
+==== Triggers
+
+A trigger drives the creation of new deployments in response to events, both inside and outside OpenShift. Refer to the
+https://access.redhat.com/beta/documentation/en/openshift-enterprise-30-developer-guide#triggers[Openshift documentation] for more information.
+
+|============
+|Deployment | Triggers
+
+| `${APPLICATION_NAME}`  |  `ImageChange` 
+| `${APPLICATION_NAME}-mongodb`  |  `ImageChange` 
+|============
+
+==== Replicas
+
+A replication controller ensures that a specified number of pod "replicas" are running at any one time.
+If there are too many, the replication controller kills some pods. If there are too few, it starts more.
+Refer to the https://cloud.google.com/container-engine/docs/replicationcontrollers/[container-engine documentation]
+for more information.
+
+|============
+|Deployment | Replicas
+
+| `${APPLICATION_NAME}`  |  `1` 
+| `${APPLICATION_NAME}-mongodb`  |  `1` 
+|============
+
+==== Pod Template
+
+===== Service Accounts
+
+Service accounts are API objects that exist within each project. They can be created or deleted like any other API object. Refer to the
+https://docs.openshift.com/enterprise/3.0/dev_guide/service_accounts.html#managing-service-accounts[Openshift documentation] for more
+information.
+
+|============
+|Deployment | Service Account
+
+| `${APPLICATION_NAME}`  |  `eap-service-account` 
+|============
+
+===== Image
+
+|============
+|Deployment | Image
+
+| `${APPLICATION_NAME}`  |  `${APPLICATION_NAME}` 
+| `${APPLICATION_NAME}-mongodb`  |  `mongodb` 
+|============
+
+===== Readiness Probe
+
+
+====== ${APPLICATION_NAME}
+----
+/bin/bash
+
+-c
+
+/opt/eap/bin/readinessProbe.sh
+----
+
+
+===== Exposed Ports
+
+|=============
+|Deployments | Name  | Port  | Protocol
+
+.3+| `${APPLICATION_NAME}`
+| `http`  |  `8080`  |  `TCP` 
+| `https`  |  `8443`  |  `TCP` 
+| `ping`  |  `8888`  |  `TCP` 
+.1+| `${APPLICATION_NAME}-mongodb`
+| --  |  `27017`  |  `TCP` 
+|=============
+
+===== Image Environment Variables
+
+|=======================================================================
+|Deployment |Variable name |Description |Example value
+
+.18+| `${APPLICATION_NAME}`
+| `DB_SERVICE_PREFIX_MAPPING`  |  --  |  `${APPLICATION_NAME}-mongodb=DB` 
+| `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb`  |  `${DB_JNDI}` 
+| `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `DB_DATABASE`  |  `Database name`  |  `${DB_DATABASE}` 
+| `DB_ADMIN_PASSWORD`  |  `Database admin password`  |  `${DB_ADMIN_PASSWORD}` 
+| `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `OPENSHIFT_DNS_PING_SERVICE_NAME`  |  --  |  `${APPLICATION_NAME}-ping` 
+| `OPENSHIFT_DNS_PING_SERVICE_PORT`  |  --  |  `8888` 
+| `EAP_HTTPS_KEYSTORE_DIR`  |  `The name of the keystore file within the secret`  |  `/etc/eap-secret-volume` 
+| `EAP_HTTPS_KEYSTORE`  |  `The name of the keystore file within the secret`  |  `${EAP_HTTPS_KEYSTORE}` 
+| `EAP_HTTPS_NAME`  |  `The name associated with the server certificate`  |  `${EAP_HTTPS_NAME}` 
+| `EAP_HTTPS_PASSWORD`  |  `The password for the keystore and certificate`  |  `${EAP_HTTPS_PASSWORD}` 
+| `HORNETQ_CLUSTER_PASSWORD`  |  `HornetQ cluster admin password`  |  `${HORNETQ_CLUSTER_PASSWORD}` 
+| `HORNETQ_QUEUES`  |  `Queue names`  |  `${HORNETQ_QUEUES}` 
+| `HORNETQ_TOPICS`  |  `Topic names`  |  `${HORNETQ_TOPICS}` 
+.7+| `${APPLICATION_NAME}-mongodb`
+| `MONGODB_USER`  |  --  |  `${DB_USERNAME}` 
+| `MONGODB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `MONGODB_DATABASE`  |  `Database name`  |  `${DB_DATABASE}` 
+| `MONGODB_ADMIN_PASSWORD`  |  `Database admin password`  |  `${DB_ADMIN_PASSWORD}` 
+| `MONGODB_NOPREALLOC`  |  `Disable data file preallocation.`  |  `${MONGODB_NOPREALLOC}` 
+| `MONGODB_SMALLFILES`  |  `Set MongoDB to use a smaller default data file size.`  |  `${MONGODB_SMALLFILES}` 
+| `MONGODB_QUIET`  |  `Runs MongoDB in a quiet mode that attempts to limit the amount of output.`  |  `${MONGODB_QUIET}` 
+|=======================================================================
+
+=====  Volumes
+
+|=============
+|Deployment |Name  | mountPath | Purpose | readOnly 
+
+| `${APPLICATION_NAME}`  |  `eap-keystore-volume`  |  `/etc/eap-secret-volume`  |  `ssl certs`  |  `True` 
+| `${APPLICATION_NAME}-mongodb`  |  `${APPLICATION_NAME}-mongodb-pvol`  |  `/var/lib/mongodb/data`  |  `mongodb`  |  `false` 
+|=============
+
+=== External Dependencies
+
+==== Volume Claims
+
+A `PersistentVolume` object is a storage resource in an OpenShift cluster. Storage is provisioned by an administrator
+by creating `PersistentVolume` objects from sources such as GCE Persistent Disks, AWS Elastic Block Stores (EBS), and NFS mounts.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/persistent_volumes.html#overview[Openshift documentation] for
+more information.
+
+|=============
+|Name | Access Mode
+
+| `${APPLICATION_NAME}-mongodb-claim`  |  `ReadWriteOnce` 
+|=============
+
+==== Secrets 
+
+This template requires https://github.com/jboss-openshift/application-templates/blob/master/secrets/eap-app-secrets.json[eap-app-secrets.json] to be installed for the application to run.

--- a/docs/templates/eap/eap6-mongodb-sti.adoc
+++ b/docs/templates/eap/eap6-mongodb-sti.adoc
@@ -1,0 +1,229 @@
+= eap6-mongodb-sti
+
+Application template for EAP 6 MongDB applications built using STI.
+
+toc::[levels=2]
+
+== Parameters
+
+Templates allow you to define parameters which take on a value. That value is then substituted wherever the parameter is referenced.
+References can be defined in any text field in the objects list field. Refer to the
+https://docs.openshift.org/latest/architecture/core_concepts/templates.html#parameters[Openshift documentation] for more information.
+
+|=======================================================================
+|Variable name |Image Environment Variable |Description |Example value
+
+| `EAP_RELEASE`  |  --  |  `EAP Release version, e.g. 6.4, etc.`  |  `6.4` 
+| `APPLICATION_NAME`  |  --  |  `The name for the application.`  |  `eap-app` 
+| `APPLICATION_HOSTNAME`  |  --  |  `Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>`  |  `secure-app.test.router.default.local` 
+| `GIT_URI`  |  --  |  `Git source URI for application`  |  ``https://github.com/jboss-openshift/openshift-examples.git` 
+| `GIT_REF`  |  --  |  `Git branch/tag reference`  |  `master` 
+| `GIT_CONTEXT_DIR`  |  --  |  `Path within Git project to build; empty for root project directory.`  |  `helloworld` 
+| `DB_JNDI`  |  `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb`  |  `${DB_JNDI}` 
+| `DB_DATABASE`  |  `DB_DATABASE`  |  `Database name`  |  `root` 
+| `HORNETQ_QUEUES`  |  `HORNETQ_QUEUES`  |  `Queue names`  |  `${HORNETQ_QUEUES}` 
+| `HORNETQ_TOPICS`  |  `HORNETQ_TOPICS`  |  `Topic names`  |  `${HORNETQ_TOPICS}` 
+| `EAP_HTTPS_SECRET`  |  --  |  `The name of the secret containing the keystore file`  |  `eap-app-secret` 
+| `EAP_HTTPS_KEYSTORE`  |  `EAP_HTTPS_KEYSTORE_DIR`  |  `The name of the keystore file within the secret`  |  `keystore.jks` 
+| `EAP_HTTPS_NAME`  |  `EAP_HTTPS_NAME`  |  `The name associated with the server certificate`  |  `${EAP_HTTPS_NAME}` 
+| `EAP_HTTPS_PASSWORD`  |  `EAP_HTTPS_PASSWORD`  |  `The password for the keystore and certificate`  |  `${EAP_HTTPS_PASSWORD}` 
+| `DB_MIN_POOL_SIZE`  |  `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `MONGODB_NOPREALLOC`  |  `MONGODB_NOPREALLOC`  |  `Disable data file preallocation.`  |  `${MONGODB_NOPREALLOC}` 
+| `MONGODB_SMALLFILES`  |  `MONGODB_SMALLFILES`  |  `Set MongoDB to use a smaller default data file size.`  |  `${MONGODB_SMALLFILES}` 
+| `MONGODB_QUIET`  |  `MONGODB_QUIET`  |  `Runs MongoDB in a quiet mode that attempts to limit the amount of output.`  |  `${MONGODB_QUIET}` 
+| `HORNETQ_CLUSTER_PASSWORD`  |  `HORNETQ_CLUSTER_PASSWORD`  |  `HornetQ cluster admin password`  |  `${HORNETQ_CLUSTER_PASSWORD}` 
+| `DB_USERNAME`  |  `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `DB_ADMIN_PASSWORD`  |  `DB_ADMIN_PASSWORD`  |  `Database admin password`  |  `${DB_ADMIN_PASSWORD}` 
+| `GITHUB_TRIGGER_SECRET`  |  --  |  `GitHub trigger secret`  |  `secret101` 
+| `GENERIC_TRIGGER_SECRET`  |  --  |  `Generic build trigger secret`  |  `secret101` 
+| `IMAGE_STREAM_NAMESPACE`  |  --  |  `Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.`  |  `openshift` 
+|=======================================================================
+
+== Objects
+
+The CLI supports various object types. A list of these object types as well as their abbreviations
+can be found in the https://docs.openshift.org/latest/cli_reference/basic_cli_operations.html#object-types[Openshift documentation].
+
+=== Services
+
+A service is an abstraction which defines a logical set of pods and a policy by which to access them. Refer to the
+https://cloud.google.com/container-engine/docs/services/[container-engine documentation] for more information.
+
+|=============
+|Service        |Port  | Description
+
+| `${APPLICATION_NAME}`  |  `8080`  |  `The web server's http port.` 
+| `secure-${APPLICATION_NAME}`  |  `8443`  |  `The web server's https port.` 
+| `${APPLICATION_NAME}-ping`  |  `8888`  |  `Ping service for clustered applications.` 
+| `${APPLICATION_NAME}-mongodb`  |  `27017`  |  `The database server's port.` 
+|=============
+
+=== Routes
+
+A route is a way to expose a service by giving it an externally-reachable hostname such as `www.example.com`. A defined route and the endpoints
+identified by its service can be consumed by a router to provide named connectivity from external clients to your applications. Each route consists
+of a route name, service selector, and (optionally) security configuration. Refer to the
+https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html[Openshift documentation] for more information.
+
+|=============
+| Service    | Security | Hostname
+
+| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+|=============
+
+=== Build Configurations
+
+A `buildConfig` describes a single build definition and a set of triggers for when a new build should be created.
+A `buildConfig` is a REST object, which can be used in a POST to the API server to create a new instance. Refer to
+the https://docs.openshift.com/enterprise/3.0/dev_guide/builds.html#defining-a-buildconfig[Openshift documentation]
+for more information.
+
+|=============
+| STI image  | link | Build output | BuildTriggers and Settings
+
+| `jboss-eap6-openshift:${EAP_RELEASE}`  |  ` link:../../eap/eap-openshift{outfilesuffix}[`jboss-eap-6/eap-openshift`]`  |  `${APPLICATION_NAME}:latest`  |  `Generic, GitHub, ImageChange` 
+|=============
+
+=== Deployment Configurations
+
+A deployment in OpenShift is a replication controller based on a user defined template called a deployment configuration. Deployments are created manually or in response to triggered events.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/deployments.html#creating-a-deployment-configuration[Openshift documentation] for more information.
+
+==== Triggers
+
+A trigger drives the creation of new deployments in response to events, both inside and outside OpenShift. Refer to the
+https://access.redhat.com/beta/documentation/en/openshift-enterprise-30-developer-guide#triggers[Openshift documentation] for more information.
+
+|============
+|Deployment | Triggers
+
+| `${APPLICATION_NAME}`  |  `ImageChange` 
+| `${APPLICATION_NAME}-mongodb`  |  `ImageChange` 
+|============
+
+==== Replicas
+
+A replication controller ensures that a specified number of pod "replicas" are running at any one time.
+If there are too many, the replication controller kills some pods. If there are too few, it starts more.
+Refer to the https://cloud.google.com/container-engine/docs/replicationcontrollers/[container-engine documentation]
+for more information.
+
+|============
+|Deployment | Replicas
+
+| `${APPLICATION_NAME}`  |  `1` 
+| `${APPLICATION_NAME}-mongodb`  |  `1` 
+|============
+
+==== Pod Template
+
+===== Service Accounts
+
+Service accounts are API objects that exist within each project. They can be created or deleted like any other API object. Refer to the
+https://docs.openshift.com/enterprise/3.0/dev_guide/service_accounts.html#managing-service-accounts[Openshift documentation] for more
+information.
+
+|============
+|Deployment | Service Account
+
+| `${APPLICATION_NAME}`  |  `eap-service-account` 
+|============
+
+===== Image
+
+|============
+|Deployment | Image
+
+| `${APPLICATION_NAME}`  |  `${APPLICATION_NAME}` 
+| `${APPLICATION_NAME}-mongodb`  |  `mongodb` 
+|============
+
+===== Readiness Probe
+
+
+====== ${APPLICATION_NAME}
+----
+/bin/bash
+
+-c
+
+/opt/eap/bin/readinessProbe.sh
+----
+
+
+===== Exposed Ports
+
+|=============
+|Deployments | Name  | Port  | Protocol
+
+.3+| `${APPLICATION_NAME}`
+| `http`  |  `8080`  |  `TCP` 
+| `https`  |  `8443`  |  `TCP` 
+| `ping`  |  `8888`  |  `TCP` 
+.1+| `${APPLICATION_NAME}-mongodb`
+| --  |  `27017`  |  `TCP` 
+|=============
+
+===== Image Environment Variables
+
+|=======================================================================
+|Deployment |Variable name |Description |Example value
+
+.18+| `${APPLICATION_NAME}`
+| `DB_SERVICE_PREFIX_MAPPING`  |  --  |  `${APPLICATION_NAME}-mongodb=DB` 
+| `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb`  |  `${DB_JNDI}` 
+| `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `DB_DATABASE`  |  `Database name`  |  `${DB_DATABASE}` 
+| `DB_ADMIN_PASSWORD`  |  `Database admin password`  |  `${DB_ADMIN_PASSWORD}` 
+| `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `OPENSHIFT_DNS_PING_SERVICE_NAME`  |  --  |  `${APPLICATION_NAME}-ping` 
+| `OPENSHIFT_DNS_PING_SERVICE_PORT`  |  --  |  `8888` 
+| `EAP_HTTPS_KEYSTORE_DIR`  |  `The name of the keystore file within the secret`  |  `/etc/eap-secret-volume` 
+| `EAP_HTTPS_KEYSTORE`  |  `The name of the keystore file within the secret`  |  `${EAP_HTTPS_KEYSTORE}` 
+| `EAP_HTTPS_NAME`  |  `The name associated with the server certificate`  |  `${EAP_HTTPS_NAME}` 
+| `EAP_HTTPS_PASSWORD`  |  `The password for the keystore and certificate`  |  `${EAP_HTTPS_PASSWORD}` 
+| `HORNETQ_CLUSTER_PASSWORD`  |  `HornetQ cluster admin password`  |  `${HORNETQ_CLUSTER_PASSWORD}` 
+| `HORNETQ_QUEUES`  |  `Queue names`  |  `${HORNETQ_QUEUES}` 
+| `HORNETQ_TOPICS`  |  `Topic names`  |  `${HORNETQ_TOPICS}` 
+.7+| `${APPLICATION_NAME}-mongodb`
+| `MONGODB_USER`  |  --  |  `${DB_USERNAME}` 
+| `MONGODB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `MONGODB_DATABASE`  |  `Database name`  |  `${DB_DATABASE}` 
+| `MONGODB_ADMIN_PASSWORD`  |  `Database admin password`  |  `${DB_ADMIN_PASSWORD}` 
+| `MONGODB_NOPREALLOC`  |  `Disable data file preallocation.`  |  `${MONGODB_NOPREALLOC}` 
+| `MONGODB_SMALLFILES`  |  `Set MongoDB to use a smaller default data file size.`  |  `${MONGODB_SMALLFILES}` 
+| `MONGODB_QUIET`  |  `Runs MongoDB in a quiet mode that attempts to limit the amount of output.`  |  `${MONGODB_QUIET}` 
+|=======================================================================
+
+=====  Volumes
+
+|=============
+|Deployment |Name  | mountPath | Purpose | readOnly 
+
+| `${APPLICATION_NAME}`  |  `eap-keystore-volume`  |  `/etc/eap-secret-volume`  |  `ssl certs`  |  `True` 
+|=============
+
+=== External Dependencies
+
+==== Volume Claims
+
+A `PersistentVolume` object is a storage resource in an OpenShift cluster. Storage is provisioned by an administrator
+by creating `PersistentVolume` objects from sources such as GCE Persistent Disks, AWS Elastic Block Stores (EBS), and NFS mounts.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/persistent_volumes.html#overview[Openshift documentation] for
+more information.
+
+|=============
+|Name | Access Mode
+
+|=============
+
+==== Secrets 
+
+This template requires https://github.com/jboss-openshift/application-templates/blob/master/secrets/eap-app-secrets.json[eap-app-secrets.json] to be installed for the application to run.

--- a/docs/templates/eap/eap6-mysql-persistent-sti.adoc
+++ b/docs/templates/eap/eap6-mysql-persistent-sti.adoc
@@ -1,0 +1,234 @@
+= eap6-mysql-persistent-sti
+
+Application template for EAP 6 MySQL applications with persistent storage built using STI.
+
+toc::[levels=2]
+
+== Parameters
+
+Templates allow you to define parameters which take on a value. That value is then substituted wherever the parameter is referenced.
+References can be defined in any text field in the objects list field. Refer to the
+https://docs.openshift.org/latest/architecture/core_concepts/templates.html#parameters[Openshift documentation] for more information.
+
+|=======================================================================
+|Variable name |Image Environment Variable |Description |Example value
+
+| `EAP_RELEASE`  |  --  |  `EAP Release version, e.g. 6.4, etc.`  |  `6.4` 
+| `APPLICATION_NAME`  |  --  |  `The name for the application.`  |  `eap-app` 
+| `APPLICATION_HOSTNAME`  |  --  |  `Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>`  |  `secure-app.test.router.default.local` 
+| `GIT_URI`  |  --  |  `Git source URI for application`  |  ``https://github.com/jboss-openshift/openshift-examples.git` 
+| `GIT_REF`  |  --  |  `Git branch/tag reference`  |  `master` 
+| `GIT_CONTEXT_DIR`  |  --  |  `Path within Git project to build; empty for root project directory.`  |  `helloworld` 
+| `DB_JNDI`  |  `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mysql`  |  `${DB_JNDI}` 
+| `DB_DATABASE`  |  `DB_DATABASE`  |  `Database name`  |  `root` 
+| `VOLUME_CAPACITY`  |  --  |  `Size of persistent storage for database volume.`  |  `512Mi` 
+| `HORNETQ_QUEUES`  |  `HORNETQ_QUEUES`  |  `Queue names`  |  `${HORNETQ_QUEUES}` 
+| `HORNETQ_TOPICS`  |  `HORNETQ_TOPICS`  |  `Topic names`  |  `${HORNETQ_TOPICS}` 
+| `EAP_HTTPS_SECRET`  |  --  |  `The name of the secret containing the keystore file`  |  `eap-app-secret` 
+| `EAP_HTTPS_KEYSTORE`  |  `EAP_HTTPS_KEYSTORE_DIR`  |  `The name of the keystore file within the secret`  |  `keystore.jks` 
+| `EAP_HTTPS_NAME`  |  `EAP_HTTPS_NAME`  |  `The name associated with the server certificate`  |  `${EAP_HTTPS_NAME}` 
+| `EAP_HTTPS_PASSWORD`  |  `EAP_HTTPS_PASSWORD`  |  `The password for the keystore and certificate`  |  `${EAP_HTTPS_PASSWORD}` 
+| `DB_MIN_POOL_SIZE`  |  `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `MYSQL_LOWER_CASE_TABLE_NAMES`  |  `MYSQL_LOWER_CASE_TABLE_NAMES`  |  `Sets how the table names are stored and compared.`  |  `${MYSQL_LOWER_CASE_TABLE_NAMES}` 
+| `MYSQL_MAX_CONNECTIONS`  |  `MYSQL_MAX_CONNECTIONS`  |  `The maximum permitted number of simultaneous client connections.`  |  `${MYSQL_MAX_CONNECTIONS}` 
+| `MYSQL_FT_MIN_WORD_LEN`  |  `MYSQL_FT_MIN_WORD_LEN`  |  `The minimum length of the word to be included in a FULLTEXT index.`  |  `${MYSQL_FT_MIN_WORD_LEN}` 
+| `MYSQL_FT_MAX_WORD_LEN`  |  `MYSQL_FT_MAX_WORD_LEN`  |  `The maximum length of the word to be included in a FULLTEXT index.`  |  `${MYSQL_FT_MAX_WORD_LEN}` 
+| `MYSQL_AIO`  |  `MYSQL_AIO`  |  `Controls the innodb_use_native_aio setting value if the native AIO is broken.`  |  `${MYSQL_AIO}` 
+| `HORNETQ_CLUSTER_PASSWORD`  |  `HORNETQ_CLUSTER_PASSWORD`  |  `HornetQ cluster admin password`  |  `${HORNETQ_CLUSTER_PASSWORD}` 
+| `DB_USERNAME`  |  `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `GITHUB_TRIGGER_SECRET`  |  --  |  `GitHub trigger secret`  |  `secret101` 
+| `GENERIC_TRIGGER_SECRET`  |  --  |  `Generic build trigger secret`  |  `secret101` 
+| `IMAGE_STREAM_NAMESPACE`  |  --  |  `Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.`  |  `openshift` 
+|=======================================================================
+
+== Objects
+
+The CLI supports various object types. A list of these object types as well as their abbreviations
+can be found in the https://docs.openshift.org/latest/cli_reference/basic_cli_operations.html#object-types[Openshift documentation].
+
+=== Services
+
+A service is an abstraction which defines a logical set of pods and a policy by which to access them. Refer to the
+https://cloud.google.com/container-engine/docs/services/[container-engine documentation] for more information.
+
+|=============
+|Service        |Port  | Description
+
+| `${APPLICATION_NAME}`  |  `8080`  |  `The web server's http port.` 
+| `secure-${APPLICATION_NAME}`  |  `8443`  |  `The web server's https port.` 
+| `${APPLICATION_NAME}-ping`  |  `8888`  |  `Ping service for clustered applications.` 
+| `${APPLICATION_NAME}-mysql`  |  `3306`  |  `The database server's port.` 
+|=============
+
+=== Routes
+
+A route is a way to expose a service by giving it an externally-reachable hostname such as `www.example.com`. A defined route and the endpoints
+identified by its service can be consumed by a router to provide named connectivity from external clients to your applications. Each route consists
+of a route name, service selector, and (optionally) security configuration. Refer to the
+https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html[Openshift documentation] for more information.
+
+|=============
+| Service    | Security | Hostname
+
+| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+|=============
+
+=== Build Configurations
+
+A `buildConfig` describes a single build definition and a set of triggers for when a new build should be created.
+A `buildConfig` is a REST object, which can be used in a POST to the API server to create a new instance. Refer to
+the https://docs.openshift.com/enterprise/3.0/dev_guide/builds.html#defining-a-buildconfig[Openshift documentation]
+for more information.
+
+|=============
+| STI image  | link | Build output | BuildTriggers and Settings
+
+| `jboss-eap6-openshift:${EAP_RELEASE}`  |  ` link:../../eap/eap-openshift{outfilesuffix}[`jboss-eap-6/eap-openshift`]`  |  `${APPLICATION_NAME}:latest`  |  `Generic, GitHub, ImageChange` 
+|=============
+
+=== Deployment Configurations
+
+A deployment in OpenShift is a replication controller based on a user defined template called a deployment configuration. Deployments are created manually or in response to triggered events.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/deployments.html#creating-a-deployment-configuration[Openshift documentation] for more information.
+
+==== Triggers
+
+A trigger drives the creation of new deployments in response to events, both inside and outside OpenShift. Refer to the
+https://access.redhat.com/beta/documentation/en/openshift-enterprise-30-developer-guide#triggers[Openshift documentation] for more information.
+
+|============
+|Deployment | Triggers
+
+| `${APPLICATION_NAME}`  |  `ImageChange` 
+| `${APPLICATION_NAME}-mysql`  |  `ImageChange` 
+|============
+
+==== Replicas
+
+A replication controller ensures that a specified number of pod "replicas" are running at any one time.
+If there are too many, the replication controller kills some pods. If there are too few, it starts more.
+Refer to the https://cloud.google.com/container-engine/docs/replicationcontrollers/[container-engine documentation]
+for more information.
+
+|============
+|Deployment | Replicas
+
+| `${APPLICATION_NAME}`  |  `1` 
+| `${APPLICATION_NAME}-mysql`  |  `1` 
+|============
+
+==== Pod Template
+
+===== Service Accounts
+
+Service accounts are API objects that exist within each project. They can be created or deleted like any other API object. Refer to the
+https://docs.openshift.com/enterprise/3.0/dev_guide/service_accounts.html#managing-service-accounts[Openshift documentation] for more
+information.
+
+|============
+|Deployment | Service Account
+
+| `${APPLICATION_NAME}`  |  `eap-service-account` 
+|============
+
+===== Image
+
+|============
+|Deployment | Image
+
+| `${APPLICATION_NAME}`  |  `${APPLICATION_NAME}` 
+| `${APPLICATION_NAME}-mysql`  |  `mysql` 
+|============
+
+===== Readiness Probe
+
+
+====== ${APPLICATION_NAME}
+----
+/bin/bash
+
+-c
+
+/opt/eap/bin/readinessProbe.sh
+----
+
+
+===== Exposed Ports
+
+|=============
+|Deployments | Name  | Port  | Protocol
+
+.3+| `${APPLICATION_NAME}`
+| `http`  |  `8080`  |  `TCP` 
+| `https`  |  `8443`  |  `TCP` 
+| `ping`  |  `8888`  |  `TCP` 
+.1+| `${APPLICATION_NAME}-mysql`
+| --  |  `3306`  |  `TCP` 
+|=============
+
+===== Image Environment Variables
+
+|=======================================================================
+|Deployment |Variable name |Description |Example value
+
+.18+| `${APPLICATION_NAME}`
+| `DB_SERVICE_PREFIX_MAPPING`  |  --  |  `${APPLICATION_NAME}-mysql=DB` 
+| `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mysql`  |  `${DB_JNDI}` 
+| `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `DB_DATABASE`  |  `Database name`  |  `${DB_DATABASE}` 
+| `TX_DATABASE_PREFIX_MAPPING`  |  --  |  `${APPLICATION_NAME}-mysql=DB` 
+| `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `OPENSHIFT_DNS_PING_SERVICE_NAME`  |  --  |  `${APPLICATION_NAME}-ping` 
+| `OPENSHIFT_DNS_PING_SERVICE_PORT`  |  --  |  `8888` 
+| `EAP_HTTPS_KEYSTORE_DIR`  |  `The name of the keystore file within the secret`  |  `/etc/eap-secret-volume` 
+| `EAP_HTTPS_KEYSTORE`  |  `The name of the keystore file within the secret`  |  `${EAP_HTTPS_KEYSTORE}` 
+| `EAP_HTTPS_NAME`  |  `The name associated with the server certificate`  |  `${EAP_HTTPS_NAME}` 
+| `EAP_HTTPS_PASSWORD`  |  `The password for the keystore and certificate`  |  `${EAP_HTTPS_PASSWORD}` 
+| `HORNETQ_CLUSTER_PASSWORD`  |  `HornetQ cluster admin password`  |  `${HORNETQ_CLUSTER_PASSWORD}` 
+| `HORNETQ_QUEUES`  |  `Queue names`  |  `${HORNETQ_QUEUES}` 
+| `HORNETQ_TOPICS`  |  `Topic names`  |  `${HORNETQ_TOPICS}` 
+.8+| `${APPLICATION_NAME}-mysql`
+| `MYSQL_USER`  |  --  |  `${DB_USERNAME}` 
+| `MYSQL_PASSWORD`  |  --  |  `${DB_PASSWORD}` 
+| `MYSQL_DATABASE`  |  --  |  `${DB_DATABASE}` 
+| `MYSQL_LOWER_CASE_TABLE_NAMES`  |  `Sets how the table names are stored and compared.`  |  `${MYSQL_LOWER_CASE_TABLE_NAMES}` 
+| `MYSQL_MAX_CONNECTIONS`  |  `The maximum permitted number of simultaneous client connections.`  |  `${MYSQL_MAX_CONNECTIONS}` 
+| `MYSQL_FT_MIN_WORD_LEN`  |  `The minimum length of the word to be included in a FULLTEXT index.`  |  `${MYSQL_FT_MIN_WORD_LEN}` 
+| `MYSQL_FT_MAX_WORD_LEN`  |  `The maximum length of the word to be included in a FULLTEXT index.`  |  `${MYSQL_FT_MAX_WORD_LEN}` 
+| `MYSQL_AIO`  |  `Controls the innodb_use_native_aio setting value if the native AIO is broken.`  |  `${MYSQL_AIO}` 
+|=======================================================================
+
+=====  Volumes
+
+|=============
+|Deployment |Name  | mountPath | Purpose | readOnly 
+
+| `${APPLICATION_NAME}`  |  `eap-keystore-volume`  |  `/etc/eap-secret-volume`  |  `ssl certs`  |  `True` 
+| `${APPLICATION_NAME}-mysql`  |  `${APPLICATION_NAME}-mysql-pvol`  |  `/var/lib/mysql/data`  |  `mysql`  |  `false` 
+|=============
+
+=== External Dependencies
+
+==== Volume Claims
+
+A `PersistentVolume` object is a storage resource in an OpenShift cluster. Storage is provisioned by an administrator
+by creating `PersistentVolume` objects from sources such as GCE Persistent Disks, AWS Elastic Block Stores (EBS), and NFS mounts.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/persistent_volumes.html#overview[Openshift documentation] for
+more information.
+
+|=============
+|Name | Access Mode
+
+| `${APPLICATION_NAME}-mysql-claim`  |  `ReadWriteOnce` 
+|=============
+
+==== Secrets 
+
+This template requires https://github.com/jboss-openshift/application-templates/blob/master/secrets/eap-app-secrets.json[eap-app-secrets.json] to be installed for the application to run.

--- a/docs/templates/eap/eap6-mysql-sti.adoc
+++ b/docs/templates/eap/eap6-mysql-sti.adoc
@@ -1,0 +1,231 @@
+= eap6-mysql-sti
+
+Application template for EAP 6 MySQL applications built using STI.
+
+toc::[levels=2]
+
+== Parameters
+
+Templates allow you to define parameters which take on a value. That value is then substituted wherever the parameter is referenced.
+References can be defined in any text field in the objects list field. Refer to the
+https://docs.openshift.org/latest/architecture/core_concepts/templates.html#parameters[Openshift documentation] for more information.
+
+|=======================================================================
+|Variable name |Image Environment Variable |Description |Example value
+
+| `EAP_RELEASE`  |  --  |  `EAP Release version, e.g. 6.4, etc.`  |  `6.4` 
+| `APPLICATION_NAME`  |  --  |  `The name for the application.`  |  `eap-app` 
+| `APPLICATION_HOSTNAME`  |  --  |  `Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>`  |  `secure-app.test.router.default.local` 
+| `GIT_URI`  |  --  |  `Git source URI for application`  |  ``https://github.com/jboss-openshift/openshift-examples.git` 
+| `GIT_REF`  |  --  |  `Git branch/tag reference`  |  `master` 
+| `GIT_CONTEXT_DIR`  |  --  |  `Path within Git project to build; empty for root project directory.`  |  `helloworld` 
+| `DB_JNDI`  |  `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mysql`  |  `${DB_JNDI}` 
+| `DB_DATABASE`  |  `DB_DATABASE`  |  `Database name`  |  `root` 
+| `HORNETQ_QUEUES`  |  `HORNETQ_QUEUES`  |  `Queue names`  |  `${HORNETQ_QUEUES}` 
+| `HORNETQ_TOPICS`  |  `HORNETQ_TOPICS`  |  `Topic names`  |  `${HORNETQ_TOPICS}` 
+| `EAP_HTTPS_SECRET`  |  --  |  `The name of the secret containing the keystore file`  |  `eap-app-secret` 
+| `EAP_HTTPS_KEYSTORE`  |  `EAP_HTTPS_KEYSTORE_DIR`  |  `The name of the keystore file within the secret`  |  `keystore.jks` 
+| `EAP_HTTPS_NAME`  |  `EAP_HTTPS_NAME`  |  `The name associated with the server certificate`  |  `${EAP_HTTPS_NAME}` 
+| `EAP_HTTPS_PASSWORD`  |  `EAP_HTTPS_PASSWORD`  |  `The password for the keystore and certificate`  |  `${EAP_HTTPS_PASSWORD}` 
+| `DB_MIN_POOL_SIZE`  |  `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `MYSQL_LOWER_CASE_TABLE_NAMES`  |  `MYSQL_LOWER_CASE_TABLE_NAMES`  |  `Sets how the table names are stored and compared.`  |  `${MYSQL_LOWER_CASE_TABLE_NAMES}` 
+| `MYSQL_MAX_CONNECTIONS`  |  `MYSQL_MAX_CONNECTIONS`  |  `The maximum permitted number of simultaneous client connections.`  |  `${MYSQL_MAX_CONNECTIONS}` 
+| `MYSQL_FT_MIN_WORD_LEN`  |  `MYSQL_FT_MIN_WORD_LEN`  |  `The minimum length of the word to be included in a FULLTEXT index.`  |  `${MYSQL_FT_MIN_WORD_LEN}` 
+| `MYSQL_FT_MAX_WORD_LEN`  |  `MYSQL_FT_MAX_WORD_LEN`  |  `The maximum length of the word to be included in a FULLTEXT index.`  |  `${MYSQL_FT_MAX_WORD_LEN}` 
+| `MYSQL_AIO`  |  `MYSQL_AIO`  |  `Controls the innodb_use_native_aio setting value if the native AIO is broken.`  |  `${MYSQL_AIO}` 
+| `HORNETQ_CLUSTER_PASSWORD`  |  `HORNETQ_CLUSTER_PASSWORD`  |  `HornetQ cluster admin password`  |  `${HORNETQ_CLUSTER_PASSWORD}` 
+| `DB_USERNAME`  |  `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `GITHUB_TRIGGER_SECRET`  |  --  |  `GitHub trigger secret`  |  `secret101` 
+| `GENERIC_TRIGGER_SECRET`  |  --  |  `Generic build trigger secret`  |  `secret101` 
+| `IMAGE_STREAM_NAMESPACE`  |  --  |  `Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.`  |  `openshift` 
+|=======================================================================
+
+== Objects
+
+The CLI supports various object types. A list of these object types as well as their abbreviations
+can be found in the https://docs.openshift.org/latest/cli_reference/basic_cli_operations.html#object-types[Openshift documentation].
+
+=== Services
+
+A service is an abstraction which defines a logical set of pods and a policy by which to access them. Refer to the
+https://cloud.google.com/container-engine/docs/services/[container-engine documentation] for more information.
+
+|=============
+|Service        |Port  | Description
+
+| `${APPLICATION_NAME}`  |  `8080`  |  `The web server's http port.` 
+| `secure-${APPLICATION_NAME}`  |  `8443`  |  `The web server's https port.` 
+| `${APPLICATION_NAME}-ping`  |  `8888`  |  `Ping service for clustered applications.` 
+| `${APPLICATION_NAME}-mysql`  |  `3306`  |  `The database server's port.` 
+|=============
+
+=== Routes
+
+A route is a way to expose a service by giving it an externally-reachable hostname such as `www.example.com`. A defined route and the endpoints
+identified by its service can be consumed by a router to provide named connectivity from external clients to your applications. Each route consists
+of a route name, service selector, and (optionally) security configuration. Refer to the
+https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html[Openshift documentation] for more information.
+
+|=============
+| Service    | Security | Hostname
+
+| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+|=============
+
+=== Build Configurations
+
+A `buildConfig` describes a single build definition and a set of triggers for when a new build should be created.
+A `buildConfig` is a REST object, which can be used in a POST to the API server to create a new instance. Refer to
+the https://docs.openshift.com/enterprise/3.0/dev_guide/builds.html#defining-a-buildconfig[Openshift documentation]
+for more information.
+
+|=============
+| STI image  | link | Build output | BuildTriggers and Settings
+
+| `jboss-eap6-openshift:${EAP_RELEASE}`  |  ` link:../../eap/eap-openshift{outfilesuffix}[`jboss-eap-6/eap-openshift`]`  |  `${APPLICATION_NAME}:latest`  |  `Generic, GitHub, ImageChange` 
+|=============
+
+=== Deployment Configurations
+
+A deployment in OpenShift is a replication controller based on a user defined template called a deployment configuration. Deployments are created manually or in response to triggered events.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/deployments.html#creating-a-deployment-configuration[Openshift documentation] for more information.
+
+==== Triggers
+
+A trigger drives the creation of new deployments in response to events, both inside and outside OpenShift. Refer to the
+https://access.redhat.com/beta/documentation/en/openshift-enterprise-30-developer-guide#triggers[Openshift documentation] for more information.
+
+|============
+|Deployment | Triggers
+
+| `${APPLICATION_NAME}`  |  `ImageChange` 
+| `${APPLICATION_NAME}-mysql`  |  `ImageChange` 
+|============
+
+==== Replicas
+
+A replication controller ensures that a specified number of pod "replicas" are running at any one time.
+If there are too many, the replication controller kills some pods. If there are too few, it starts more.
+Refer to the https://cloud.google.com/container-engine/docs/replicationcontrollers/[container-engine documentation]
+for more information.
+
+|============
+|Deployment | Replicas
+
+| `${APPLICATION_NAME}`  |  `1` 
+| `${APPLICATION_NAME}-mysql`  |  `1` 
+|============
+
+==== Pod Template
+
+===== Service Accounts
+
+Service accounts are API objects that exist within each project. They can be created or deleted like any other API object. Refer to the
+https://docs.openshift.com/enterprise/3.0/dev_guide/service_accounts.html#managing-service-accounts[Openshift documentation] for more
+information.
+
+|============
+|Deployment | Service Account
+
+| `${APPLICATION_NAME}`  |  `eap-service-account` 
+|============
+
+===== Image
+
+|============
+|Deployment | Image
+
+| `${APPLICATION_NAME}`  |  `${APPLICATION_NAME}` 
+| `${APPLICATION_NAME}-mysql`  |  `mysql` 
+|============
+
+===== Readiness Probe
+
+
+====== ${APPLICATION_NAME}
+----
+/bin/bash
+
+-c
+
+/opt/eap/bin/readinessProbe.sh
+----
+
+
+===== Exposed Ports
+
+|=============
+|Deployments | Name  | Port  | Protocol
+
+.3+| `${APPLICATION_NAME}`
+| `http`  |  `8080`  |  `TCP` 
+| `https`  |  `8443`  |  `TCP` 
+| `ping`  |  `8888`  |  `TCP` 
+.1+| `${APPLICATION_NAME}-mysql`
+| --  |  `3306`  |  `TCP` 
+|=============
+
+===== Image Environment Variables
+
+|=======================================================================
+|Deployment |Variable name |Description |Example value
+
+.18+| `${APPLICATION_NAME}`
+| `DB_SERVICE_PREFIX_MAPPING`  |  --  |  `${APPLICATION_NAME}-mysql=DB` 
+| `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mysql`  |  `${DB_JNDI}` 
+| `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `DB_DATABASE`  |  `Database name`  |  `${DB_DATABASE}` 
+| `TX_DATABASE_PREFIX_MAPPING`  |  --  |  `${APPLICATION_NAME}-mysql=DB` 
+| `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `OPENSHIFT_DNS_PING_SERVICE_NAME`  |  --  |  `${APPLICATION_NAME}-ping` 
+| `OPENSHIFT_DNS_PING_SERVICE_PORT`  |  --  |  `8888` 
+| `EAP_HTTPS_KEYSTORE_DIR`  |  `The name of the keystore file within the secret`  |  `/etc/eap-secret-volume` 
+| `EAP_HTTPS_KEYSTORE`  |  `The name of the keystore file within the secret`  |  `${EAP_HTTPS_KEYSTORE}` 
+| `EAP_HTTPS_NAME`  |  `The name associated with the server certificate`  |  `${EAP_HTTPS_NAME}` 
+| `EAP_HTTPS_PASSWORD`  |  `The password for the keystore and certificate`  |  `${EAP_HTTPS_PASSWORD}` 
+| `HORNETQ_CLUSTER_PASSWORD`  |  `HornetQ cluster admin password`  |  `${HORNETQ_CLUSTER_PASSWORD}` 
+| `HORNETQ_QUEUES`  |  `Queue names`  |  `${HORNETQ_QUEUES}` 
+| `HORNETQ_TOPICS`  |  `Topic names`  |  `${HORNETQ_TOPICS}` 
+.8+| `${APPLICATION_NAME}-mysql`
+| `MYSQL_USER`  |  --  |  `${DB_USERNAME}` 
+| `MYSQL_PASSWORD`  |  --  |  `${DB_PASSWORD}` 
+| `MYSQL_DATABASE`  |  --  |  `${DB_DATABASE}` 
+| `MYSQL_LOWER_CASE_TABLE_NAMES`  |  `Sets how the table names are stored and compared.`  |  `${MYSQL_LOWER_CASE_TABLE_NAMES}` 
+| `MYSQL_MAX_CONNECTIONS`  |  `The maximum permitted number of simultaneous client connections.`  |  `${MYSQL_MAX_CONNECTIONS}` 
+| `MYSQL_FT_MIN_WORD_LEN`  |  `The minimum length of the word to be included in a FULLTEXT index.`  |  `${MYSQL_FT_MIN_WORD_LEN}` 
+| `MYSQL_FT_MAX_WORD_LEN`  |  `The maximum length of the word to be included in a FULLTEXT index.`  |  `${MYSQL_FT_MAX_WORD_LEN}` 
+| `MYSQL_AIO`  |  `Controls the innodb_use_native_aio setting value if the native AIO is broken.`  |  `${MYSQL_AIO}` 
+|=======================================================================
+
+=====  Volumes
+
+|=============
+|Deployment |Name  | mountPath | Purpose | readOnly 
+
+| `${APPLICATION_NAME}`  |  `eap-keystore-volume`  |  `/etc/eap-secret-volume`  |  `ssl certs`  |  `True` 
+|=============
+
+=== External Dependencies
+
+==== Volume Claims
+
+A `PersistentVolume` object is a storage resource in an OpenShift cluster. Storage is provisioned by an administrator
+by creating `PersistentVolume` objects from sources such as GCE Persistent Disks, AWS Elastic Block Stores (EBS), and NFS mounts.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/persistent_volumes.html#overview[Openshift documentation] for
+more information.
+
+|=============
+|Name | Access Mode
+
+|=============
+
+==== Secrets 
+
+This template requires https://github.com/jboss-openshift/application-templates/blob/master/secrets/eap-app-secrets.json[eap-app-secrets.json] to be installed for the application to run.

--- a/docs/templates/eap/eap6-postgresql-persistent-sti.adoc
+++ b/docs/templates/eap/eap6-postgresql-persistent-sti.adoc
@@ -1,0 +1,228 @@
+= eap6-postgresql-persistent-sti
+
+Application template for EAP 6 PostgreSQL applications with persistent storage built using STI.
+
+toc::[levels=2]
+
+== Parameters
+
+Templates allow you to define parameters which take on a value. That value is then substituted wherever the parameter is referenced.
+References can be defined in any text field in the objects list field. Refer to the
+https://docs.openshift.org/latest/architecture/core_concepts/templates.html#parameters[Openshift documentation] for more information.
+
+|=======================================================================
+|Variable name |Image Environment Variable |Description |Example value
+
+| `EAP_RELEASE`  |  --  |  `EAP Release version, e.g. 6.4, etc.`  |  `6.4` 
+| `APPLICATION_NAME`  |  --  |  `The name for the application.`  |  `eap-app` 
+| `APPLICATION_HOSTNAME`  |  --  |  `Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>`  |  `secure-app.test.router.default.local` 
+| `GIT_URI`  |  --  |  `Git source URI for application`  |  ``https://github.com/jboss-openshift/openshift-examples.git` 
+| `GIT_REF`  |  --  |  `Git branch/tag reference`  |  `master` 
+| `GIT_CONTEXT_DIR`  |  --  |  `Path within Git project to build; empty for root project directory.`  |  `helloworld` 
+| `DB_JNDI`  |  `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/postgresql`  |  `${DB_JNDI}` 
+| `DB_DATABASE`  |  `DB_DATABASE`  |  `Database name`  |  `root` 
+| `VOLUME_CAPACITY`  |  --  |  `Size of persistent storage for database volume.`  |  `512Mi` 
+| `HORNETQ_QUEUES`  |  `HORNETQ_QUEUES`  |  `Queue names`  |  `${HORNETQ_QUEUES}` 
+| `HORNETQ_TOPICS`  |  `HORNETQ_TOPICS`  |  `Topic names`  |  `${HORNETQ_TOPICS}` 
+| `EAP_HTTPS_SECRET`  |  --  |  `The name of the secret containing the keystore file`  |  `eap-app-secret` 
+| `EAP_HTTPS_KEYSTORE`  |  `EAP_HTTPS_KEYSTORE_DIR`  |  `The name of the keystore file within the secret`  |  `keystore.jks` 
+| `EAP_HTTPS_NAME`  |  `EAP_HTTPS_NAME`  |  `The name associated with the server certificate`  |  `${EAP_HTTPS_NAME}` 
+| `EAP_HTTPS_PASSWORD`  |  `EAP_HTTPS_PASSWORD`  |  `The password for the keystore and certificate`  |  `${EAP_HTTPS_PASSWORD}` 
+| `DB_MIN_POOL_SIZE`  |  `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `POSTGRESQL_MAX_CONNECTIONS`  |  `POSTGRESQL_MAX_CONNECTIONS`  |  `The maximum number of client connections allowed. This also sets the maximum number of prepared transactions.`  |  `${POSTGRESQL_MAX_CONNECTIONS}` 
+| `POSTGRESQL_SHARED_BUFFERS`  |  `POSTGRESQL_SHARED_BUFFERS`  |  `Configures how much memory is dedicated to PostgreSQL for caching data.`  |  `${POSTGRESQL_SHARED_BUFFERS}` 
+| `HORNETQ_CLUSTER_PASSWORD`  |  `HORNETQ_CLUSTER_PASSWORD`  |  `HornetQ cluster admin password`  |  `${HORNETQ_CLUSTER_PASSWORD}` 
+| `DB_USERNAME`  |  `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `GITHUB_TRIGGER_SECRET`  |  --  |  `GitHub trigger secret`  |  `secret101` 
+| `GENERIC_TRIGGER_SECRET`  |  --  |  `Generic build trigger secret`  |  `secret101` 
+| `IMAGE_STREAM_NAMESPACE`  |  --  |  `Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.`  |  `openshift` 
+|=======================================================================
+
+== Objects
+
+The CLI supports various object types. A list of these object types as well as their abbreviations
+can be found in the https://docs.openshift.org/latest/cli_reference/basic_cli_operations.html#object-types[Openshift documentation].
+
+=== Services
+
+A service is an abstraction which defines a logical set of pods and a policy by which to access them. Refer to the
+https://cloud.google.com/container-engine/docs/services/[container-engine documentation] for more information.
+
+|=============
+|Service        |Port  | Description
+
+| `${APPLICATION_NAME}`  |  `8080`  |  `The web server's http port.` 
+| `secure-${APPLICATION_NAME}`  |  `8443`  |  `The web server's https port.` 
+| `${APPLICATION_NAME}-ping`  |  `8888`  |  `Ping service for clustered applications.` 
+| `${APPLICATION_NAME}-postgresql`  |  `5432`  |  `The database server's port.` 
+|=============
+
+=== Routes
+
+A route is a way to expose a service by giving it an externally-reachable hostname such as `www.example.com`. A defined route and the endpoints
+identified by its service can be consumed by a router to provide named connectivity from external clients to your applications. Each route consists
+of a route name, service selector, and (optionally) security configuration. Refer to the
+https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html[Openshift documentation] for more information.
+
+|=============
+| Service    | Security | Hostname
+
+| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+|=============
+
+=== Build Configurations
+
+A `buildConfig` describes a single build definition and a set of triggers for when a new build should be created.
+A `buildConfig` is a REST object, which can be used in a POST to the API server to create a new instance. Refer to
+the https://docs.openshift.com/enterprise/3.0/dev_guide/builds.html#defining-a-buildconfig[Openshift documentation]
+for more information.
+
+|=============
+| STI image  | link | Build output | BuildTriggers and Settings
+
+| `jboss-eap6-openshift:${EAP_RELEASE}`  |  ` link:../../eap/eap-openshift{outfilesuffix}[`jboss-eap-6/eap-openshift`]`  |  `${APPLICATION_NAME}:latest`  |  `Generic, GitHub, ImageChange` 
+|=============
+
+=== Deployment Configurations
+
+A deployment in OpenShift is a replication controller based on a user defined template called a deployment configuration. Deployments are created manually or in response to triggered events.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/deployments.html#creating-a-deployment-configuration[Openshift documentation] for more information.
+
+==== Triggers
+
+A trigger drives the creation of new deployments in response to events, both inside and outside OpenShift. Refer to the
+https://access.redhat.com/beta/documentation/en/openshift-enterprise-30-developer-guide#triggers[Openshift documentation] for more information.
+
+|============
+|Deployment | Triggers
+
+| `${APPLICATION_NAME}`  |  `ImageChange` 
+| `${APPLICATION_NAME}-postgresql`  |  `ImageChange` 
+|============
+
+==== Replicas
+
+A replication controller ensures that a specified number of pod "replicas" are running at any one time.
+If there are too many, the replication controller kills some pods. If there are too few, it starts more.
+Refer to the https://cloud.google.com/container-engine/docs/replicationcontrollers/[container-engine documentation]
+for more information.
+
+|============
+|Deployment | Replicas
+
+| `${APPLICATION_NAME}`  |  `1` 
+| `${APPLICATION_NAME}-postgresql`  |  `1` 
+|============
+
+==== Pod Template
+
+===== Service Accounts
+
+Service accounts are API objects that exist within each project. They can be created or deleted like any other API object. Refer to the
+https://docs.openshift.com/enterprise/3.0/dev_guide/service_accounts.html#managing-service-accounts[Openshift documentation] for more
+information.
+
+|============
+|Deployment | Service Account
+
+| `${APPLICATION_NAME}`  |  `eap-service-account` 
+|============
+
+===== Image
+
+|============
+|Deployment | Image
+
+| `${APPLICATION_NAME}`  |  `${APPLICATION_NAME}` 
+| `${APPLICATION_NAME}-postgresql`  |  `postgresql` 
+|============
+
+===== Readiness Probe
+
+
+====== ${APPLICATION_NAME}
+----
+/bin/bash
+
+-c
+
+/opt/eap/bin/readinessProbe.sh
+----
+
+
+===== Exposed Ports
+
+|=============
+|Deployments | Name  | Port  | Protocol
+
+.3+| `${APPLICATION_NAME}`
+| `http`  |  `8080`  |  `TCP` 
+| `https`  |  `8443`  |  `TCP` 
+| `ping`  |  `8888`  |  `TCP` 
+.1+| `${APPLICATION_NAME}-postgresql`
+| --  |  `5432`  |  `TCP` 
+|=============
+
+===== Image Environment Variables
+
+|=======================================================================
+|Deployment |Variable name |Description |Example value
+
+.18+| `${APPLICATION_NAME}`
+| `DB_SERVICE_PREFIX_MAPPING`  |  --  |  `${APPLICATION_NAME}-postgresql=DB` 
+| `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/postgresql`  |  `${DB_JNDI}` 
+| `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `DB_DATABASE`  |  `Database name`  |  `${DB_DATABASE}` 
+| `TX_DATABASE_PREFIX_MAPPING`  |  --  |  `${APPLICATION_NAME}-postgresql=DB` 
+| `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `OPENSHIFT_DNS_PING_SERVICE_NAME`  |  --  |  `${APPLICATION_NAME}-ping` 
+| `OPENSHIFT_DNS_PING_SERVICE_PORT`  |  --  |  `8888` 
+| `EAP_HTTPS_KEYSTORE_DIR`  |  `The name of the keystore file within the secret`  |  `/etc/eap-secret-volume` 
+| `EAP_HTTPS_KEYSTORE`  |  `The name of the keystore file within the secret`  |  `${EAP_HTTPS_KEYSTORE}` 
+| `EAP_HTTPS_NAME`  |  `The name associated with the server certificate`  |  `${EAP_HTTPS_NAME}` 
+| `EAP_HTTPS_PASSWORD`  |  `The password for the keystore and certificate`  |  `${EAP_HTTPS_PASSWORD}` 
+| `HORNETQ_CLUSTER_PASSWORD`  |  `HornetQ cluster admin password`  |  `${HORNETQ_CLUSTER_PASSWORD}` 
+| `HORNETQ_QUEUES`  |  `Queue names`  |  `${HORNETQ_QUEUES}` 
+| `HORNETQ_TOPICS`  |  `Topic names`  |  `${HORNETQ_TOPICS}` 
+.5+| `${APPLICATION_NAME}-postgresql`
+| `POSTGRESQL_USER`  |  --  |  `${DB_USERNAME}` 
+| `POSTGRESQL_PASSWORD`  |  --  |  `${DB_PASSWORD}` 
+| `POSTGRESQL_DATABASE`  |  --  |  `${DB_DATABASE}` 
+| `POSTGRESQL_MAX_CONNECTIONS`  |  `The maximum number of client connections allowed. This also sets the maximum number of prepared transactions.`  |  `${POSTGRESQL_MAX_CONNECTIONS}` 
+| `POSTGRESQL_SHARED_BUFFERS`  |  `Configures how much memory is dedicated to PostgreSQL for caching data.`  |  `${POSTGRESQL_SHARED_BUFFERS}` 
+|=======================================================================
+
+=====  Volumes
+
+|=============
+|Deployment |Name  | mountPath | Purpose | readOnly 
+
+| `${APPLICATION_NAME}`  |  `eap-keystore-volume`  |  `/etc/eap-secret-volume`  |  `ssl certs`  |  `True` 
+| `${APPLICATION_NAME}-postgresql`  |  `${APPLICATION_NAME}-postgresql-pvol`  |  `/var/lib/pgsql/data`  |  `postgresql`  |  `false` 
+|=============
+
+=== External Dependencies
+
+==== Volume Claims
+
+A `PersistentVolume` object is a storage resource in an OpenShift cluster. Storage is provisioned by an administrator
+by creating `PersistentVolume` objects from sources such as GCE Persistent Disks, AWS Elastic Block Stores (EBS), and NFS mounts.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/persistent_volumes.html#overview[Openshift documentation] for
+more information.
+
+|=============
+|Name | Access Mode
+
+| `${APPLICATION_NAME}-postgresql-claim`  |  `ReadWriteOnce` 
+|=============
+
+==== Secrets 
+
+This template requires https://github.com/jboss-openshift/application-templates/blob/master/secrets/eap-app-secrets.json[eap-app-secrets.json] to be installed for the application to run.

--- a/docs/templates/eap/eap6-postgresql-sti.adoc
+++ b/docs/templates/eap/eap6-postgresql-sti.adoc
@@ -1,0 +1,225 @@
+= eap6-postgresql-sti
+
+Application template for EAP 6 PostgreSQL applications built using STI.
+
+toc::[levels=2]
+
+== Parameters
+
+Templates allow you to define parameters which take on a value. That value is then substituted wherever the parameter is referenced.
+References can be defined in any text field in the objects list field. Refer to the
+https://docs.openshift.org/latest/architecture/core_concepts/templates.html#parameters[Openshift documentation] for more information.
+
+|=======================================================================
+|Variable name |Image Environment Variable |Description |Example value
+
+| `EAP_RELEASE`  |  --  |  `EAP Release version, e.g. 6.4, etc.`  |  `6.4` 
+| `APPLICATION_NAME`  |  --  |  `The name for the application.`  |  `eap-app` 
+| `APPLICATION_HOSTNAME`  |  --  |  `Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>`  |  `secure-app.test.router.default.local` 
+| `GIT_URI`  |  --  |  `Git source URI for application`  |  ``https://github.com/jboss-openshift/openshift-examples.git` 
+| `GIT_REF`  |  --  |  `Git branch/tag reference`  |  `master` 
+| `GIT_CONTEXT_DIR`  |  --  |  `Path within Git project to build; empty for root project directory.`  |  `helloworld` 
+| `DB_JNDI`  |  `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/postgresql`  |  `${DB_JNDI}` 
+| `DB_DATABASE`  |  `DB_DATABASE`  |  `Database name`  |  `root` 
+| `HORNETQ_QUEUES`  |  `HORNETQ_QUEUES`  |  `Queue names`  |  `${HORNETQ_QUEUES}` 
+| `HORNETQ_TOPICS`  |  `HORNETQ_TOPICS`  |  `Topic names`  |  `${HORNETQ_TOPICS}` 
+| `EAP_HTTPS_SECRET`  |  --  |  `The name of the secret containing the keystore file`  |  `eap-app-secret` 
+| `EAP_HTTPS_KEYSTORE`  |  `EAP_HTTPS_KEYSTORE_DIR`  |  `The name of the keystore file within the secret`  |  `keystore.jks` 
+| `EAP_HTTPS_NAME`  |  `EAP_HTTPS_NAME`  |  `The name associated with the server certificate`  |  `${EAP_HTTPS_NAME}` 
+| `EAP_HTTPS_PASSWORD`  |  `EAP_HTTPS_PASSWORD`  |  `The password for the keystore and certificate`  |  `${EAP_HTTPS_PASSWORD}` 
+| `DB_MIN_POOL_SIZE`  |  `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `POSTGRESQL_MAX_CONNECTIONS`  |  `POSTGRESQL_MAX_CONNECTIONS`  |  `The maximum number of client connections allowed. This also sets the maximum number of prepared transactions.`  |  `${POSTGRESQL_MAX_CONNECTIONS}` 
+| `POSTGRESQL_SHARED_BUFFERS`  |  `POSTGRESQL_SHARED_BUFFERS`  |  `Configures how much memory is dedicated to PostgreSQL for caching data.`  |  `${POSTGRESQL_SHARED_BUFFERS}` 
+| `HORNETQ_CLUSTER_PASSWORD`  |  `HORNETQ_CLUSTER_PASSWORD`  |  `HornetQ cluster admin password`  |  `${HORNETQ_CLUSTER_PASSWORD}` 
+| `DB_USERNAME`  |  `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `GITHUB_TRIGGER_SECRET`  |  --  |  `GitHub trigger secret`  |  `secret101` 
+| `GENERIC_TRIGGER_SECRET`  |  --  |  `Generic build trigger secret`  |  `secret101` 
+| `IMAGE_STREAM_NAMESPACE`  |  --  |  `Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.`  |  `openshift` 
+|=======================================================================
+
+== Objects
+
+The CLI supports various object types. A list of these object types as well as their abbreviations
+can be found in the https://docs.openshift.org/latest/cli_reference/basic_cli_operations.html#object-types[Openshift documentation].
+
+=== Services
+
+A service is an abstraction which defines a logical set of pods and a policy by which to access them. Refer to the
+https://cloud.google.com/container-engine/docs/services/[container-engine documentation] for more information.
+
+|=============
+|Service        |Port  | Description
+
+| `${APPLICATION_NAME}`  |  `8080`  |  `The web server's http port.` 
+| `secure-${APPLICATION_NAME}`  |  `8443`  |  `The web server's https port.` 
+| `${APPLICATION_NAME}-ping`  |  `8888`  |  `Ping service for clustered applications.` 
+| `${APPLICATION_NAME}-postgresql`  |  `5432`  |  `The database server's port.` 
+|=============
+
+=== Routes
+
+A route is a way to expose a service by giving it an externally-reachable hostname such as `www.example.com`. A defined route and the endpoints
+identified by its service can be consumed by a router to provide named connectivity from external clients to your applications. Each route consists
+of a route name, service selector, and (optionally) security configuration. Refer to the
+https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html[Openshift documentation] for more information.
+
+|=============
+| Service    | Security | Hostname
+
+| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+|=============
+
+=== Build Configurations
+
+A `buildConfig` describes a single build definition and a set of triggers for when a new build should be created.
+A `buildConfig` is a REST object, which can be used in a POST to the API server to create a new instance. Refer to
+the https://docs.openshift.com/enterprise/3.0/dev_guide/builds.html#defining-a-buildconfig[Openshift documentation]
+for more information.
+
+|=============
+| STI image  | link | Build output | BuildTriggers and Settings
+
+| `jboss-eap6-openshift:${EAP_RELEASE}`  |  ` link:../../eap/eap-openshift{outfilesuffix}[`jboss-eap-6/eap-openshift`]`  |  `${APPLICATION_NAME}:latest`  |  `Generic, GitHub, ImageChange` 
+|=============
+
+=== Deployment Configurations
+
+A deployment in OpenShift is a replication controller based on a user defined template called a deployment configuration. Deployments are created manually or in response to triggered events.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/deployments.html#creating-a-deployment-configuration[Openshift documentation] for more information.
+
+==== Triggers
+
+A trigger drives the creation of new deployments in response to events, both inside and outside OpenShift. Refer to the
+https://access.redhat.com/beta/documentation/en/openshift-enterprise-30-developer-guide#triggers[Openshift documentation] for more information.
+
+|============
+|Deployment | Triggers
+
+| `${APPLICATION_NAME}`  |  `ImageChange` 
+| `${APPLICATION_NAME}-postgresql`  |  `ImageChange` 
+|============
+
+==== Replicas
+
+A replication controller ensures that a specified number of pod "replicas" are running at any one time.
+If there are too many, the replication controller kills some pods. If there are too few, it starts more.
+Refer to the https://cloud.google.com/container-engine/docs/replicationcontrollers/[container-engine documentation]
+for more information.
+
+|============
+|Deployment | Replicas
+
+| `${APPLICATION_NAME}`  |  `1` 
+| `${APPLICATION_NAME}-postgresql`  |  `1` 
+|============
+
+==== Pod Template
+
+===== Service Accounts
+
+Service accounts are API objects that exist within each project. They can be created or deleted like any other API object. Refer to the
+https://docs.openshift.com/enterprise/3.0/dev_guide/service_accounts.html#managing-service-accounts[Openshift documentation] for more
+information.
+
+|============
+|Deployment | Service Account
+
+| `${APPLICATION_NAME}`  |  `eap-service-account` 
+|============
+
+===== Image
+
+|============
+|Deployment | Image
+
+| `${APPLICATION_NAME}`  |  `${APPLICATION_NAME}` 
+| `${APPLICATION_NAME}-postgresql`  |  `postgresql` 
+|============
+
+===== Readiness Probe
+
+
+====== ${APPLICATION_NAME}
+----
+/bin/bash
+
+-c
+
+/opt/eap/bin/readinessProbe.sh
+----
+
+
+===== Exposed Ports
+
+|=============
+|Deployments | Name  | Port  | Protocol
+
+.3+| `${APPLICATION_NAME}`
+| `http`  |  `8080`  |  `TCP` 
+| `https`  |  `8443`  |  `TCP` 
+| `ping`  |  `8888`  |  `TCP` 
+.1+| `${APPLICATION_NAME}-postgresql`
+| --  |  `5432`  |  `TCP` 
+|=============
+
+===== Image Environment Variables
+
+|=======================================================================
+|Deployment |Variable name |Description |Example value
+
+.18+| `${APPLICATION_NAME}`
+| `DB_SERVICE_PREFIX_MAPPING`  |  --  |  `${APPLICATION_NAME}-postgresql=DB` 
+| `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/postgresql`  |  `${DB_JNDI}` 
+| `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `DB_DATABASE`  |  `Database name`  |  `${DB_DATABASE}` 
+| `TX_DATABASE_PREFIX_MAPPING`  |  --  |  `${APPLICATION_NAME}-postgresql=DB` 
+| `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `OPENSHIFT_DNS_PING_SERVICE_NAME`  |  --  |  `${APPLICATION_NAME}-ping` 
+| `OPENSHIFT_DNS_PING_SERVICE_PORT`  |  --  |  `8888` 
+| `EAP_HTTPS_KEYSTORE_DIR`  |  `The name of the keystore file within the secret`  |  `/etc/eap-secret-volume` 
+| `EAP_HTTPS_KEYSTORE`  |  `The name of the keystore file within the secret`  |  `${EAP_HTTPS_KEYSTORE}` 
+| `EAP_HTTPS_NAME`  |  `The name associated with the server certificate`  |  `${EAP_HTTPS_NAME}` 
+| `EAP_HTTPS_PASSWORD`  |  `The password for the keystore and certificate`  |  `${EAP_HTTPS_PASSWORD}` 
+| `HORNETQ_CLUSTER_PASSWORD`  |  `HornetQ cluster admin password`  |  `${HORNETQ_CLUSTER_PASSWORD}` 
+| `HORNETQ_QUEUES`  |  `Queue names`  |  `${HORNETQ_QUEUES}` 
+| `HORNETQ_TOPICS`  |  `Topic names`  |  `${HORNETQ_TOPICS}` 
+.5+| `${APPLICATION_NAME}-postgresql`
+| `POSTGRESQL_USER`  |  --  |  `${DB_USERNAME}` 
+| `POSTGRESQL_PASSWORD`  |  --  |  `${DB_PASSWORD}` 
+| `POSTGRESQL_DATABASE`  |  --  |  `${DB_DATABASE}` 
+| `POSTGRESQL_MAX_CONNECTIONS`  |  `The maximum number of client connections allowed. This also sets the maximum number of prepared transactions.`  |  `${POSTGRESQL_MAX_CONNECTIONS}` 
+| `POSTGRESQL_SHARED_BUFFERS`  |  `Configures how much memory is dedicated to PostgreSQL for caching data.`  |  `${POSTGRESQL_SHARED_BUFFERS}` 
+|=======================================================================
+
+=====  Volumes
+
+|=============
+|Deployment |Name  | mountPath | Purpose | readOnly 
+
+| `${APPLICATION_NAME}`  |  `eap-keystore-volume`  |  `/etc/eap-secret-volume`  |  `ssl certs`  |  `True` 
+|=============
+
+=== External Dependencies
+
+==== Volume Claims
+
+A `PersistentVolume` object is a storage resource in an OpenShift cluster. Storage is provisioned by an administrator
+by creating `PersistentVolume` objects from sources such as GCE Persistent Disks, AWS Elastic Block Stores (EBS), and NFS mounts.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/persistent_volumes.html#overview[Openshift documentation] for
+more information.
+
+|=============
+|Name | Access Mode
+
+|=============
+
+==== Secrets 
+
+This template requires https://github.com/jboss-openshift/application-templates/blob/master/secrets/eap-app-secrets.json[eap-app-secrets.json] to be installed for the application to run.

--- a/docs/templates/index.adoc
+++ b/docs/templates/index.adoc
@@ -1,0 +1,46 @@
+= Application Templates
+
+This project contains OpenShift v3 application templates which support applications based on JBoss Middleware products.
+Source can be found https://github.com/jboss-openshift/application-templates/tree/master[here].
+
+:icons: font
+:toc: macro
+
+toc::[levels=1]
+
+== JBoss Web Server
+
+* link:./webserver/jws-tomcat7-basic-sti.adoc[jws-tomcat7-basic-sti]
+* link:./webserver/jws-tomcat7-https-sti.adoc[jws-tomcat7-https-sti]
+* link:./webserver/jws-tomcat7-mongodb-persistent-sti.adoc[jws-tomcat7-mongodb-persistent-sti]
+* link:./webserver/jws-tomcat7-mongodb-sti.adoc[jws-tomcat7-mongodb-sti]
+* link:./webserver/jws-tomcat7-mysql-persistent-sti.adoc[jws-tomcat7-mysql-persistent-sti]
+* link:./webserver/jws-tomcat7-mysql-sti.adoc[jws-tomcat7-mysql-sti]
+* link:./webserver/jws-tomcat7-postgresql-persistent-sti.adoc[jws-tomcat7-postgresql-persistent-sti]
+* link:./webserver/jws-tomcat7-postgresql-sti.adoc[jws-tomcat7-postgresql-sti]
+* link:./webserver/jws-tomcat8-basic-sti.adoc[jws-tomcat8-basic-sti]
+* link:./webserver/jws-tomcat8-https-sti.adoc[jws-tomcat8-https-sti]
+* link:./webserver/jws-tomcat8-mongodb-persistent-sti.adoc[jws-tomcat8-mongodb-persistent-sti]
+* link:./webserver/jws-tomcat8-mongodb-sti.adoc[jws-tomcat8-mongodb-sti]
+* link:./webserver/jws-tomcat8-mysql-persistent-sti.adoc[jws-tomcat8-mysql-persistent-sti]
+* link:./webserver/jws-tomcat8-mysql-sti.adoc[jws-tomcat8-mysql-sti]
+* link:./webserver/jws-tomcat8-postgresql-persistent-sti.adoc[jws-tomcat8-postgresql-persistent-sti]
+* link:./webserver/jws-tomcat8-postgresql-sti.adoc[jws-tomcat8-postgresql-sti]
+
+== JBoss A-MQ
+
+* link:./amq/amq6-persistent.adoc[amq6-persistent]
+* link:./amq/amq6.adoc[amq6]
+
+== JBoss EAP
+
+* link:./eap/eap6-amq-persistent-sti.adoc[eap6-amq-persistent-sti]
+* link:./eap/eap6-amq-sti.adoc[eap6-amq-sti]
+* link:./eap/eap6-basic-sti.adoc[eap6-basic-sti]
+* link:./eap/eap6-https-sti.adoc[eap6-https-sti]
+* link:./eap/eap6-mongodb-persistent-sti.adoc[eap6-mongodb-persistent-sti]
+* link:./eap/eap6-mongodb-sti.adoc[eap6-mongodb-sti]
+* link:./eap/eap6-mysql-persistent-sti.adoc[eap6-mysql-persistent-sti]
+* link:./eap/eap6-mysql-sti.adoc[eap6-mysql-sti]
+* link:./eap/eap6-postgresql-persistent-sti.adoc[eap6-postgresql-persistent-sti]
+* link:./eap/eap6-postgresql-sti.adoc[eap6-postgresql-sti]

--- a/docs/templates/webserver/jws-tomcat7-basic-sti.adoc
+++ b/docs/templates/webserver/jws-tomcat7-basic-sti.adoc
@@ -1,0 +1,176 @@
+= jws-tomcat7-basic-sti
+
+Application template for JWS applications built using STI.
+
+toc::[levels=2]
+
+== Parameters
+
+Templates allow you to define parameters which take on a value. That value is then substituted wherever the parameter is referenced.
+References can be defined in any text field in the objects list field. Refer to the
+https://docs.openshift.org/latest/architecture/core_concepts/templates.html#parameters[Openshift documentation] for more information.
+
+|=======================================================================
+|Variable name |Image Environment Variable |Description |Example value
+
+| `JWS_RELEASE`  |  --  |  `JWS Release version, e.g. 3.0, 2.1, etc.`  |  `3.0` 
+| `APPLICATION_NAME`  |  --  |  `The name for the application.`  |  `jws-app` 
+| `APPLICATION_HOSTNAME`  |  --  |  `Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>`  |  `secure-app.test.router.default.local` 
+| `GIT_URI`  |  --  |  `Git source URI for application`  |  ``https://github.com/jboss-openshift/openshift-examples.git` 
+| `GIT_REF`  |  --  |  `Git branch/tag reference`  |  `master` 
+| `GIT_CONTEXT_DIR`  |  --  |  `Path within Git project to build; empty for root project directory.`  |  `helloworld` 
+| `JWS_ADMIN_USERNAME`  |  `JWS_ADMIN_USERNAME`  |  `JWS Admin User`  |  `${JWS_ADMIN_USERNAME}` 
+| `JWS_ADMIN_PASSWORD`  |  `JWS_ADMIN_PASSWORD`  |  `JWS Admin Password`  |  `${JWS_ADMIN_PASSWORD}` 
+| `GITHUB_TRIGGER_SECRET`  |  --  |  `GitHub trigger secret`  |  `secret101` 
+| `GENERIC_TRIGGER_SECRET`  |  --  |  `Generic build trigger secret`  |  `secret101` 
+| `IMAGE_STREAM_NAMESPACE`  |  --  |  `Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.`  |  `openshift` 
+|=======================================================================
+
+== Objects
+
+The CLI supports various object types. A list of these object types as well as their abbreviations
+can be found in the https://docs.openshift.org/latest/cli_reference/basic_cli_operations.html#object-types[Openshift documentation].
+
+=== Services
+
+A service is an abstraction which defines a logical set of pods and a policy by which to access them. Refer to the
+https://cloud.google.com/container-engine/docs/services/[container-engine documentation] for more information.
+
+|=============
+|Service        |Port  | Description
+
+| `${APPLICATION_NAME}`  |  `8080`  |  `The web server's http port.` 
+|=============
+
+=== Routes
+
+A route is a way to expose a service by giving it an externally-reachable hostname such as `www.example.com`. A defined route and the endpoints
+identified by its service can be consumed by a router to provide named connectivity from external clients to your applications. Each route consists
+of a route name, service selector, and (optionally) security configuration. Refer to the
+https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html[Openshift documentation] for more information.
+
+|=============
+| Service    | Security | Hostname
+
+| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+|=============
+
+=== Build Configurations
+
+A `buildConfig` describes a single build definition and a set of triggers for when a new build should be created.
+A `buildConfig` is a REST object, which can be used in a POST to the API server to create a new instance. Refer to
+the https://docs.openshift.com/enterprise/3.0/dev_guide/builds.html#defining-a-buildconfig[Openshift documentation]
+for more information.
+
+|=============
+| STI image  | link | Build output | BuildTriggers and Settings
+
+| `jboss-webserver3-tomcat7-openshift:${JWS_RELEASE}`  |  ` link:../../webserver/tomcat7-openshift{outfilesuffix}[`jboss-webserver/tomcat7-openshift`]`  |  `${APPLICATION_NAME}:latest`  |  `Generic, GitHub, ImageChange` 
+|=============
+
+=== Deployment Configurations
+
+A deployment in OpenShift is a replication controller based on a user defined template called a deployment configuration. Deployments are created manually or in response to triggered events.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/deployments.html#creating-a-deployment-configuration[Openshift documentation] for more information.
+
+==== Triggers
+
+A trigger drives the creation of new deployments in response to events, both inside and outside OpenShift. Refer to the
+https://access.redhat.com/beta/documentation/en/openshift-enterprise-30-developer-guide#triggers[Openshift documentation] for more information.
+
+|============
+|Deployment | Triggers
+
+| `${APPLICATION_NAME}`  |  `ImageChange` 
+|============
+
+==== Replicas
+
+A replication controller ensures that a specified number of pod "replicas" are running at any one time.
+If there are too many, the replication controller kills some pods. If there are too few, it starts more.
+Refer to the https://cloud.google.com/container-engine/docs/replicationcontrollers/[container-engine documentation]
+for more information.
+
+|============
+|Deployment | Replicas
+
+| `${APPLICATION_NAME}`  |  `1` 
+|============
+
+==== Pod Template
+
+===== Service Accounts
+
+Service accounts are API objects that exist within each project. They can be created or deleted like any other API object. Refer to the
+https://docs.openshift.com/enterprise/3.0/dev_guide/service_accounts.html#managing-service-accounts[Openshift documentation] for more
+information.
+
+|============
+|Deployment | Service Account
+
+|============
+
+===== Image
+
+|============
+|Deployment | Image
+
+| `${APPLICATION_NAME}`  |  `${APPLICATION_NAME}` 
+|============
+
+===== Readiness Probe
+
+
+====== ${APPLICATION_NAME}
+----
+/bin/bash
+
+-c
+
+curl -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer&att=stateName' |grep -iq 'stateName *= *STARTED'
+----
+
+
+===== Exposed Ports
+
+|=============
+|Deployments | Name  | Port  | Protocol
+
+.1+| `${APPLICATION_NAME}`
+| `http`  |  `8080`  |  `TCP` 
+|=============
+
+===== Image Environment Variables
+
+|=======================================================================
+|Deployment |Variable name |Description |Example value
+
+.2+| `${APPLICATION_NAME}`
+| `JWS_ADMIN_USERNAME`  |  `JWS Admin User`  |  `${JWS_ADMIN_USERNAME}` 
+| `JWS_ADMIN_PASSWORD`  |  `JWS Admin Password`  |  `${JWS_ADMIN_PASSWORD}` 
+|=======================================================================
+
+=====  Volumes
+
+|=============
+|Deployment |Name  | mountPath | Purpose | readOnly 
+
+|=============
+
+=== External Dependencies
+
+==== Volume Claims
+
+A `PersistentVolume` object is a storage resource in an OpenShift cluster. Storage is provisioned by an administrator
+by creating `PersistentVolume` objects from sources such as GCE Persistent Disks, AWS Elastic Block Stores (EBS), and NFS mounts.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/persistent_volumes.html#overview[Openshift documentation] for
+more information.
+
+|=============
+|Name | Access Mode
+
+|=============
+
+==== Secrets 
+
+This template requires https://github.com/jboss-openshift/application-templates/blob/master/secrets/jws-app-secrets.json[jws-app-secrets.json] to be installed for the application to run.

--- a/docs/templates/webserver/jws-tomcat7-https-sti.adoc
+++ b/docs/templates/webserver/jws-tomcat7-https-sti.adoc
@@ -1,0 +1,189 @@
+= jws-tomcat7-https-sti
+
+Application template for JWS applications built using STI.
+
+toc::[levels=2]
+
+== Parameters
+
+Templates allow you to define parameters which take on a value. That value is then substituted wherever the parameter is referenced.
+References can be defined in any text field in the objects list field. Refer to the
+https://docs.openshift.org/latest/architecture/core_concepts/templates.html#parameters[Openshift documentation] for more information.
+
+|=======================================================================
+|Variable name |Image Environment Variable |Description |Example value
+
+| `JWS_RELEASE`  |  --  |  `JWS Release version, e.g. 3.0, 2.1, etc.`  |  `3.0` 
+| `APPLICATION_NAME`  |  --  |  `The name for the application.`  |  `jws-app` 
+| `APPLICATION_HOSTNAME`  |  --  |  `Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>`  |  `secure-app.test.router.default.local` 
+| `GIT_URI`  |  --  |  `Git source URI for application`  |  ``https://github.com/jboss-openshift/openshift-examples.git` 
+| `GIT_REF`  |  --  |  `Git branch/tag reference`  |  `master` 
+| `GIT_CONTEXT_DIR`  |  --  |  `Path within Git project to build; empty for root project directory.`  |  `helloworld` 
+| `JWS_HTTPS_SECRET`  |  --  |  `The name of the secret containing the certificate files`  |  `jws-app-secret` 
+| `JWS_HTTPS_CERTIFICATE`  |  `JWS_HTTPS_CERTIFICATE_DIR`  |  `The name of the certificate file within the secret`  |  `server.crt` 
+| `JWS_HTTPS_CERTIFICATE_KEY`  |  `JWS_HTTPS_CERTIFICATE`  |  `The name of the certificate key file within the secret`  |  `server.key` 
+| `JWS_HTTPS_CERTIFICATE_PASSWORD`  |  `JWS_HTTPS_CERTIFICATE`  |  `The certificate password`  |  `${JWS_HTTPS_CERTIFICATE}` 
+| `JWS_ADMIN_USERNAME`  |  `JWS_ADMIN_USERNAME`  |  `JWS Admin User`  |  `${JWS_ADMIN_USERNAME}` 
+| `JWS_ADMIN_PASSWORD`  |  `JWS_ADMIN_PASSWORD`  |  `JWS Admin Password`  |  `${JWS_ADMIN_PASSWORD}` 
+| `GITHUB_TRIGGER_SECRET`  |  --  |  `GitHub trigger secret`  |  `secret101` 
+| `GENERIC_TRIGGER_SECRET`  |  --  |  `Generic build trigger secret`  |  `secret101` 
+| `IMAGE_STREAM_NAMESPACE`  |  --  |  `Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.`  |  `openshift` 
+|=======================================================================
+
+== Objects
+
+The CLI supports various object types. A list of these object types as well as their abbreviations
+can be found in the https://docs.openshift.org/latest/cli_reference/basic_cli_operations.html#object-types[Openshift documentation].
+
+=== Services
+
+A service is an abstraction which defines a logical set of pods and a policy by which to access them. Refer to the
+https://cloud.google.com/container-engine/docs/services/[container-engine documentation] for more information.
+
+|=============
+|Service        |Port  | Description
+
+| `${APPLICATION_NAME}`  |  `8080`  |  `The web server's http port.` 
+| `secure-${APPLICATION_NAME}`  |  `8443`  |  `The web server's https port.` 
+|=============
+
+=== Routes
+
+A route is a way to expose a service by giving it an externally-reachable hostname such as `www.example.com`. A defined route and the endpoints
+identified by its service can be consumed by a router to provide named connectivity from external clients to your applications. Each route consists
+of a route name, service selector, and (optionally) security configuration. Refer to the
+https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html[Openshift documentation] for more information.
+
+|=============
+| Service    | Security | Hostname
+
+| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+|=============
+
+=== Build Configurations
+
+A `buildConfig` describes a single build definition and a set of triggers for when a new build should be created.
+A `buildConfig` is a REST object, which can be used in a POST to the API server to create a new instance. Refer to
+the https://docs.openshift.com/enterprise/3.0/dev_guide/builds.html#defining-a-buildconfig[Openshift documentation]
+for more information.
+
+|=============
+| STI image  | link | Build output | BuildTriggers and Settings
+
+| `jboss-webserver3-tomcat7-openshift:${JWS_RELEASE}`  |  ` link:../../webserver/tomcat7-openshift{outfilesuffix}[`jboss-webserver/tomcat7-openshift`]`  |  `${APPLICATION_NAME}:latest`  |  `Generic, GitHub, ImageChange` 
+|=============
+
+=== Deployment Configurations
+
+A deployment in OpenShift is a replication controller based on a user defined template called a deployment configuration. Deployments are created manually or in response to triggered events.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/deployments.html#creating-a-deployment-configuration[Openshift documentation] for more information.
+
+==== Triggers
+
+A trigger drives the creation of new deployments in response to events, both inside and outside OpenShift. Refer to the
+https://access.redhat.com/beta/documentation/en/openshift-enterprise-30-developer-guide#triggers[Openshift documentation] for more information.
+
+|============
+|Deployment | Triggers
+
+| `${APPLICATION_NAME}`  |  `ImageChange` 
+|============
+
+==== Replicas
+
+A replication controller ensures that a specified number of pod "replicas" are running at any one time.
+If there are too many, the replication controller kills some pods. If there are too few, it starts more.
+Refer to the https://cloud.google.com/container-engine/docs/replicationcontrollers/[container-engine documentation]
+for more information.
+
+|============
+|Deployment | Replicas
+
+| `${APPLICATION_NAME}`  |  `1` 
+|============
+
+==== Pod Template
+
+===== Service Accounts
+
+Service accounts are API objects that exist within each project. They can be created or deleted like any other API object. Refer to the
+https://docs.openshift.com/enterprise/3.0/dev_guide/service_accounts.html#managing-service-accounts[Openshift documentation] for more
+information.
+
+|============
+|Deployment | Service Account
+
+| `${APPLICATION_NAME}`  |  `jws-service-account` 
+|============
+
+===== Image
+
+|============
+|Deployment | Image
+
+| `${APPLICATION_NAME}`  |  `${APPLICATION_NAME}` 
+|============
+
+===== Readiness Probe
+
+
+====== ${APPLICATION_NAME}
+----
+/bin/bash
+
+-c
+
+curl -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer&att=stateName' |grep -iq 'stateName *= *STARTED'
+----
+
+
+===== Exposed Ports
+
+|=============
+|Deployments | Name  | Port  | Protocol
+
+.2+| `${APPLICATION_NAME}`
+| `http`  |  `8080`  |  `TCP` 
+| `https`  |  `8443`  |  `TCP` 
+|=============
+
+===== Image Environment Variables
+
+|=======================================================================
+|Deployment |Variable name |Description |Example value
+
+.6+| `${APPLICATION_NAME}`
+| `JWS_HTTPS_CERTIFICATE_DIR`  |  `The name of the certificate file within the secret`  |  `/etc/jws-secret-volume` 
+| `JWS_HTTPS_CERTIFICATE`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE}` 
+| `JWS_HTTPS_CERTIFICATE_KEY`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE_KEY}` 
+| `JWS_HTTPS_CERTIFICATE_PASSWORD`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE_PASSWORD}` 
+| `JWS_ADMIN_USERNAME`  |  `JWS Admin User`  |  `${JWS_ADMIN_USERNAME}` 
+| `JWS_ADMIN_PASSWORD`  |  `JWS Admin Password`  |  `${JWS_ADMIN_PASSWORD}` 
+|=======================================================================
+
+=====  Volumes
+
+|=============
+|Deployment |Name  | mountPath | Purpose | readOnly 
+
+| `${APPLICATION_NAME}`  |  `jws-certificate-volume`  |  `/etc/jws-secret-volume`  |  `ssl certs`  |  `True` 
+|=============
+
+=== External Dependencies
+
+==== Volume Claims
+
+A `PersistentVolume` object is a storage resource in an OpenShift cluster. Storage is provisioned by an administrator
+by creating `PersistentVolume` objects from sources such as GCE Persistent Disks, AWS Elastic Block Stores (EBS), and NFS mounts.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/persistent_volumes.html#overview[Openshift documentation] for
+more information.
+
+|=============
+|Name | Access Mode
+
+|=============
+
+==== Secrets 
+
+This template requires https://github.com/jboss-openshift/application-templates/blob/master/secrets/jws-app-secrets.json[jws-app-secrets.json] to be installed for the application to run.

--- a/docs/templates/webserver/jws-tomcat7-mongodb-persistent-sti.adoc
+++ b/docs/templates/webserver/jws-tomcat7-mongodb-persistent-sti.adoc
@@ -1,0 +1,226 @@
+= jws-tomcat7-mongodb-persistent-sti
+
+Application template for JWS MongoDB applications with persistent storage built using STI.
+
+toc::[levels=2]
+
+== Parameters
+
+Templates allow you to define parameters which take on a value. That value is then substituted wherever the parameter is referenced.
+References can be defined in any text field in the objects list field. Refer to the
+https://docs.openshift.org/latest/architecture/core_concepts/templates.html#parameters[Openshift documentation] for more information.
+
+|=======================================================================
+|Variable name |Image Environment Variable |Description |Example value
+
+| `JWS_RELEASE`  |  --  |  `JWS Release version, e.g. 3.0, 2.1, etc.`  |  `3.0` 
+| `APPLICATION_NAME`  |  --  |  `The name for the application.`  |  `jws-app` 
+| `APPLICATION_HOSTNAME`  |  --  |  `Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>`  |  `secure-app.test.router.default.local` 
+| `GIT_URI`  |  --  |  `Git source URI for application`  |  ``https://github.com/jboss-openshift/openshift-examples.git` 
+| `GIT_REF`  |  --  |  `Git branch/tag reference`  |  `master` 
+| `GIT_CONTEXT_DIR`  |  --  |  `Path within Git project to build; empty for root project directory.`  |  `helloworld` 
+| `DB_JNDI`  |  `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb`  |  `${DB_JNDI}` 
+| `DB_DATABASE`  |  `DB_DATABASE`  |  `Database name`  |  `root` 
+| `VOLUME_CAPACITY`  |  --  |  `Size of persistent storage for database volume.`  |  `512Mi` 
+| `JWS_HTTPS_SECRET`  |  --  |  `The name of the secret containing the certificate files`  |  `jws-app-secret` 
+| `JWS_HTTPS_CERTIFICATE`  |  `JWS_HTTPS_CERTIFICATE_DIR`  |  `The name of the certificate file within the secret`  |  `server.crt` 
+| `JWS_HTTPS_CERTIFICATE_KEY`  |  `JWS_HTTPS_CERTIFICATE`  |  `The name of the certificate key file within the secret`  |  `server.key` 
+| `JWS_HTTPS_CERTIFICATE_PASSWORD`  |  `JWS_HTTPS_CERTIFICATE`  |  `The certificate password`  |  `${JWS_HTTPS_CERTIFICATE}` 
+| `DB_MIN_POOL_SIZE`  |  `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `MONGODB_NOPREALLOC`  |  `MONGODB_NOPREALLOC`  |  `Disable data file preallocation.`  |  `${MONGODB_NOPREALLOC}` 
+| `MONGODB_SMALLFILES`  |  `MONGODB_SMALLFILES`  |  `Set MongoDB to use a smaller default data file size.`  |  `${MONGODB_SMALLFILES}` 
+| `MONGODB_QUIET`  |  `MONGODB_QUIET`  |  `Runs MongoDB in a quiet mode that attempts to limit the amount of output.`  |  `${MONGODB_QUIET}` 
+| `DB_USERNAME`  |  `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `DB_ADMIN_PASSWORD`  |  `DB_ADMIN_PASSWORD`  |  `Database admin password`  |  `${DB_ADMIN_PASSWORD}` 
+| `JWS_ADMIN_USERNAME`  |  `JWS_ADMIN_USERNAME`  |  `JWS Admin User`  |  `${JWS_ADMIN_USERNAME}` 
+| `JWS_ADMIN_PASSWORD`  |  `JWS_ADMIN_PASSWORD`  |  `JWS Admin Password`  |  `${JWS_ADMIN_PASSWORD}` 
+| `GITHUB_TRIGGER_SECRET`  |  --  |  `GitHub trigger secret`  |  `secret101` 
+| `GENERIC_TRIGGER_SECRET`  |  --  |  `Generic build trigger secret`  |  `secret101` 
+| `IMAGE_STREAM_NAMESPACE`  |  --  |  `Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.`  |  `openshift` 
+|=======================================================================
+
+== Objects
+
+The CLI supports various object types. A list of these object types as well as their abbreviations
+can be found in the https://docs.openshift.org/latest/cli_reference/basic_cli_operations.html#object-types[Openshift documentation].
+
+=== Services
+
+A service is an abstraction which defines a logical set of pods and a policy by which to access them. Refer to the
+https://cloud.google.com/container-engine/docs/services/[container-engine documentation] for more information.
+
+|=============
+|Service        |Port  | Description
+
+| `${APPLICATION_NAME}`  |  `8080`  |  `The web server's http port.` 
+| `secure-${APPLICATION_NAME}`  |  `8443`  |  `The web server's https port.` 
+| `${APPLICATION_NAME}-mongodb`  |  `27017`  |  `The database server's port.` 
+|=============
+
+=== Routes
+
+A route is a way to expose a service by giving it an externally-reachable hostname such as `www.example.com`. A defined route and the endpoints
+identified by its service can be consumed by a router to provide named connectivity from external clients to your applications. Each route consists
+of a route name, service selector, and (optionally) security configuration. Refer to the
+https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html[Openshift documentation] for more information.
+
+|=============
+| Service    | Security | Hostname
+
+| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+|=============
+
+=== Build Configurations
+
+A `buildConfig` describes a single build definition and a set of triggers for when a new build should be created.
+A `buildConfig` is a REST object, which can be used in a POST to the API server to create a new instance. Refer to
+the https://docs.openshift.com/enterprise/3.0/dev_guide/builds.html#defining-a-buildconfig[Openshift documentation]
+for more information.
+
+|=============
+| STI image  | link | Build output | BuildTriggers and Settings
+
+| `jboss-webserver3-tomcat7-openshift:${JWS_RELEASE}`  |  ` link:../../webserver/tomcat7-openshift{outfilesuffix}[`jboss-webserver/tomcat7-openshift`]`  |  `${APPLICATION_NAME}:latest`  |  `Generic, GitHub, ImageChange` 
+|=============
+
+=== Deployment Configurations
+
+A deployment in OpenShift is a replication controller based on a user defined template called a deployment configuration. Deployments are created manually or in response to triggered events.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/deployments.html#creating-a-deployment-configuration[Openshift documentation] for more information.
+
+==== Triggers
+
+A trigger drives the creation of new deployments in response to events, both inside and outside OpenShift. Refer to the
+https://access.redhat.com/beta/documentation/en/openshift-enterprise-30-developer-guide#triggers[Openshift documentation] for more information.
+
+|============
+|Deployment | Triggers
+
+| `${APPLICATION_NAME}`  |  `ImageChange` 
+| `${APPLICATION_NAME}-mongodb`  |  `ImageChange` 
+|============
+
+==== Replicas
+
+A replication controller ensures that a specified number of pod "replicas" are running at any one time.
+If there are too many, the replication controller kills some pods. If there are too few, it starts more.
+Refer to the https://cloud.google.com/container-engine/docs/replicationcontrollers/[container-engine documentation]
+for more information.
+
+|============
+|Deployment | Replicas
+
+| `${APPLICATION_NAME}`  |  `1` 
+| `${APPLICATION_NAME}-mongodb`  |  `1` 
+|============
+
+==== Pod Template
+
+===== Service Accounts
+
+Service accounts are API objects that exist within each project. They can be created or deleted like any other API object. Refer to the
+https://docs.openshift.com/enterprise/3.0/dev_guide/service_accounts.html#managing-service-accounts[Openshift documentation] for more
+information.
+
+|============
+|Deployment | Service Account
+
+| `${APPLICATION_NAME}`  |  `jws-service-account` 
+|============
+
+===== Image
+
+|============
+|Deployment | Image
+
+| `${APPLICATION_NAME}`  |  `${APPLICATION_NAME}` 
+| `${APPLICATION_NAME}-mongodb`  |  `mongodb` 
+|============
+
+===== Readiness Probe
+
+
+====== ${APPLICATION_NAME}
+----
+/bin/bash
+
+-c
+
+curl -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer&att=stateName' |grep -iq 'stateName *= *STARTED'
+----
+
+
+===== Exposed Ports
+
+|=============
+|Deployments | Name  | Port  | Protocol
+
+.2+| `${APPLICATION_NAME}`
+| `http`  |  `8080`  |  `TCP` 
+| `https`  |  `8443`  |  `TCP` 
+.1+| `${APPLICATION_NAME}-mongodb`
+| --  |  `27017`  |  `TCP` 
+|=============
+
+===== Image Environment Variables
+
+|=======================================================================
+|Deployment |Variable name |Description |Example value
+
+.15+| `${APPLICATION_NAME}`
+| `DB_SERVICE_PREFIX_MAPPING`  |  --  |  `${APPLICATION_NAME}-mongodb=DB` 
+| `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb`  |  `${DB_JNDI}` 
+| `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `DB_DATABASE`  |  `Database name`  |  `${DB_DATABASE}` 
+| `DB_ADMIN_PASSWORD`  |  `Database admin password`  |  `${DB_ADMIN_PASSWORD}` 
+| `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `JWS_HTTPS_CERTIFICATE_DIR`  |  `The name of the certificate file within the secret`  |  `/etc/jws-secret-volume` 
+| `JWS_HTTPS_CERTIFICATE`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE}` 
+| `JWS_HTTPS_CERTIFICATE_KEY`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE_KEY}` 
+| `JWS_HTTPS_CERTIFICATE_PASSWORD`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE_PASSWORD}` 
+| `JWS_ADMIN_USERNAME`  |  `JWS Admin User`  |  `${JWS_ADMIN_USERNAME}` 
+| `JWS_ADMIN_PASSWORD`  |  `JWS Admin Password`  |  `${JWS_ADMIN_PASSWORD}` 
+.7+| `${APPLICATION_NAME}-mongodb`
+| `MONGODB_USER`  |  --  |  `${DB_USERNAME}` 
+| `MONGODB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `MONGODB_DATABASE`  |  `Database name`  |  `${DB_DATABASE}` 
+| `MONGODB_ADMIN_PASSWORD`  |  `Database admin password`  |  `${DB_ADMIN_PASSWORD}` 
+| `MONGODB_NOPREALLOC`  |  `Disable data file preallocation.`  |  `${MONGODB_NOPREALLOC}` 
+| `MONGODB_SMALLFILES`  |  `Set MongoDB to use a smaller default data file size.`  |  `${MONGODB_SMALLFILES}` 
+| `MONGODB_QUIET`  |  `Runs MongoDB in a quiet mode that attempts to limit the amount of output.`  |  `${MONGODB_QUIET}` 
+|=======================================================================
+
+=====  Volumes
+
+|=============
+|Deployment |Name  | mountPath | Purpose | readOnly 
+
+| `${APPLICATION_NAME}`  |  `jws-certificate-volume`  |  `/etc/jws-secret-volume`  |  `ssl certs`  |  `True` 
+| `${APPLICATION_NAME}-mongodb`  |  `${APPLICATION_NAME}-mongodb-pvol`  |  `/var/lib/mongodb/data`  |  `mongodb`  |  `false` 
+|=============
+
+=== External Dependencies
+
+==== Volume Claims
+
+A `PersistentVolume` object is a storage resource in an OpenShift cluster. Storage is provisioned by an administrator
+by creating `PersistentVolume` objects from sources such as GCE Persistent Disks, AWS Elastic Block Stores (EBS), and NFS mounts.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/persistent_volumes.html#overview[Openshift documentation] for
+more information.
+
+|=============
+|Name | Access Mode
+
+| `${APPLICATION_NAME}-mongodb-claim`  |  `ReadWriteOnce` 
+|=============
+
+==== Secrets 
+
+This template requires https://github.com/jboss-openshift/application-templates/blob/master/secrets/jws-app-secrets.json[jws-app-secrets.json] to be installed for the application to run.

--- a/docs/templates/webserver/jws-tomcat7-mongodb-sti.adoc
+++ b/docs/templates/webserver/jws-tomcat7-mongodb-sti.adoc
@@ -1,0 +1,223 @@
+= jws-tomcat7-mongodb-sti
+
+Application template for JWS MongoDB applications built using STI.
+
+toc::[levels=2]
+
+== Parameters
+
+Templates allow you to define parameters which take on a value. That value is then substituted wherever the parameter is referenced.
+References can be defined in any text field in the objects list field. Refer to the
+https://docs.openshift.org/latest/architecture/core_concepts/templates.html#parameters[Openshift documentation] for more information.
+
+|=======================================================================
+|Variable name |Image Environment Variable |Description |Example value
+
+| `JWS_RELEASE`  |  --  |  `JWS Release version, e.g. 3.0, 2.1, etc.`  |  `3.0` 
+| `APPLICATION_NAME`  |  --  |  `The name for the application.`  |  `jws-app` 
+| `APPLICATION_HOSTNAME`  |  --  |  `Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>`  |  `secure-app.test.router.default.local` 
+| `GIT_URI`  |  --  |  `Git source URI for application`  |  ``https://github.com/jboss-openshift/openshift-examples.git` 
+| `GIT_REF`  |  --  |  `Git branch/tag reference`  |  `master` 
+| `GIT_CONTEXT_DIR`  |  --  |  `Path within Git project to build; empty for root project directory.`  |  `helloworld` 
+| `DB_JNDI`  |  `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb`  |  `${DB_JNDI}` 
+| `DB_DATABASE`  |  `DB_DATABASE`  |  `Database name`  |  `root` 
+| `JWS_HTTPS_SECRET`  |  --  |  `The name of the secret containing the certificate files`  |  `jws-app-secret` 
+| `JWS_HTTPS_CERTIFICATE`  |  `JWS_HTTPS_CERTIFICATE_DIR`  |  `The name of the certificate file within the secret`  |  `server.crt` 
+| `JWS_HTTPS_CERTIFICATE_KEY`  |  `JWS_HTTPS_CERTIFICATE`  |  `The name of the certificate key file within the secret`  |  `server.key` 
+| `JWS_HTTPS_CERTIFICATE_PASSWORD`  |  `JWS_HTTPS_CERTIFICATE`  |  `The certificate password`  |  `${JWS_HTTPS_CERTIFICATE}` 
+| `DB_MIN_POOL_SIZE`  |  `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `MONGODB_NOPREALLOC`  |  `MONGODB_NOPREALLOC`  |  `Disable data file preallocation.`  |  `${MONGODB_NOPREALLOC}` 
+| `MONGODB_SMALLFILES`  |  `MONGODB_SMALLFILES`  |  `Set MongoDB to use a smaller default data file size.`  |  `${MONGODB_SMALLFILES}` 
+| `MONGODB_QUIET`  |  `MONGODB_QUIET`  |  `Runs MongoDB in a quiet mode that attempts to limit the amount of output.`  |  `${MONGODB_QUIET}` 
+| `DB_USERNAME`  |  `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `DB_ADMIN_PASSWORD`  |  `DB_ADMIN_PASSWORD`  |  `Database admin password`  |  `${DB_ADMIN_PASSWORD}` 
+| `JWS_ADMIN_USERNAME`  |  `JWS_ADMIN_USERNAME`  |  `JWS Admin User`  |  `${JWS_ADMIN_USERNAME}` 
+| `JWS_ADMIN_PASSWORD`  |  `JWS_ADMIN_PASSWORD`  |  `JWS Admin Password`  |  `${JWS_ADMIN_PASSWORD}` 
+| `GITHUB_TRIGGER_SECRET`  |  --  |  `GitHub trigger secret`  |  `secret101` 
+| `GENERIC_TRIGGER_SECRET`  |  --  |  `Generic build trigger secret`  |  `secret101` 
+| `IMAGE_STREAM_NAMESPACE`  |  --  |  `Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.`  |  `openshift` 
+|=======================================================================
+
+== Objects
+
+The CLI supports various object types. A list of these object types as well as their abbreviations
+can be found in the https://docs.openshift.org/latest/cli_reference/basic_cli_operations.html#object-types[Openshift documentation].
+
+=== Services
+
+A service is an abstraction which defines a logical set of pods and a policy by which to access them. Refer to the
+https://cloud.google.com/container-engine/docs/services/[container-engine documentation] for more information.
+
+|=============
+|Service        |Port  | Description
+
+| `${APPLICATION_NAME}`  |  `8080`  |  `The web server's http port.` 
+| `secure-${APPLICATION_NAME}`  |  `8443`  |  `The web server's https port.` 
+| `${APPLICATION_NAME}-mongodb`  |  `27017`  |  `The database server's port.` 
+|=============
+
+=== Routes
+
+A route is a way to expose a service by giving it an externally-reachable hostname such as `www.example.com`. A defined route and the endpoints
+identified by its service can be consumed by a router to provide named connectivity from external clients to your applications. Each route consists
+of a route name, service selector, and (optionally) security configuration. Refer to the
+https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html[Openshift documentation] for more information.
+
+|=============
+| Service    | Security | Hostname
+
+| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+|=============
+
+=== Build Configurations
+
+A `buildConfig` describes a single build definition and a set of triggers for when a new build should be created.
+A `buildConfig` is a REST object, which can be used in a POST to the API server to create a new instance. Refer to
+the https://docs.openshift.com/enterprise/3.0/dev_guide/builds.html#defining-a-buildconfig[Openshift documentation]
+for more information.
+
+|=============
+| STI image  | link | Build output | BuildTriggers and Settings
+
+| `jboss-webserver3-tomcat7-openshift:${JWS_RELEASE}`  |  ` link:../../webserver/tomcat7-openshift{outfilesuffix}[`jboss-webserver/tomcat7-openshift`]`  |  `${APPLICATION_NAME}:latest`  |  `Generic, GitHub, ImageChange` 
+|=============
+
+=== Deployment Configurations
+
+A deployment in OpenShift is a replication controller based on a user defined template called a deployment configuration. Deployments are created manually or in response to triggered events.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/deployments.html#creating-a-deployment-configuration[Openshift documentation] for more information.
+
+==== Triggers
+
+A trigger drives the creation of new deployments in response to events, both inside and outside OpenShift. Refer to the
+https://access.redhat.com/beta/documentation/en/openshift-enterprise-30-developer-guide#triggers[Openshift documentation] for more information.
+
+|============
+|Deployment | Triggers
+
+| `${APPLICATION_NAME}`  |  `ImageChange` 
+| `${APPLICATION_NAME}-mongodb`  |  `ImageChange` 
+|============
+
+==== Replicas
+
+A replication controller ensures that a specified number of pod "replicas" are running at any one time.
+If there are too many, the replication controller kills some pods. If there are too few, it starts more.
+Refer to the https://cloud.google.com/container-engine/docs/replicationcontrollers/[container-engine documentation]
+for more information.
+
+|============
+|Deployment | Replicas
+
+| `${APPLICATION_NAME}`  |  `1` 
+| `${APPLICATION_NAME}-mongodb`  |  `1` 
+|============
+
+==== Pod Template
+
+===== Service Accounts
+
+Service accounts are API objects that exist within each project. They can be created or deleted like any other API object. Refer to the
+https://docs.openshift.com/enterprise/3.0/dev_guide/service_accounts.html#managing-service-accounts[Openshift documentation] for more
+information.
+
+|============
+|Deployment | Service Account
+
+| `${APPLICATION_NAME}`  |  `jws-service-account` 
+|============
+
+===== Image
+
+|============
+|Deployment | Image
+
+| `${APPLICATION_NAME}`  |  `${APPLICATION_NAME}` 
+| `${APPLICATION_NAME}-mongodb`  |  `mongodb` 
+|============
+
+===== Readiness Probe
+
+
+====== ${APPLICATION_NAME}
+----
+/bin/bash
+
+-c
+
+curl -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer&att=stateName' |grep -iq 'stateName *= *STARTED'
+----
+
+
+===== Exposed Ports
+
+|=============
+|Deployments | Name  | Port  | Protocol
+
+.2+| `${APPLICATION_NAME}`
+| `http`  |  `8080`  |  `TCP` 
+| `https`  |  `8443`  |  `TCP` 
+.1+| `${APPLICATION_NAME}-mongodb`
+| --  |  `27017`  |  `TCP` 
+|=============
+
+===== Image Environment Variables
+
+|=======================================================================
+|Deployment |Variable name |Description |Example value
+
+.15+| `${APPLICATION_NAME}`
+| `DB_SERVICE_PREFIX_MAPPING`  |  --  |  `${APPLICATION_NAME}-mongodb=DB` 
+| `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb`  |  `${DB_JNDI}` 
+| `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `DB_DATABASE`  |  `Database name`  |  `${DB_DATABASE}` 
+| `DB_ADMIN_PASSWORD`  |  `Database admin password`  |  `${DB_ADMIN_PASSWORD}` 
+| `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `JWS_HTTPS_CERTIFICATE_DIR`  |  `The name of the certificate file within the secret`  |  `/etc/jws-secret-volume` 
+| `JWS_HTTPS_CERTIFICATE`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE}` 
+| `JWS_HTTPS_CERTIFICATE_KEY`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE_KEY}` 
+| `JWS_HTTPS_CERTIFICATE_PASSWORD`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE_PASSWORD}` 
+| `JWS_ADMIN_USERNAME`  |  `JWS Admin User`  |  `${JWS_ADMIN_USERNAME}` 
+| `JWS_ADMIN_PASSWORD`  |  `JWS Admin Password`  |  `${JWS_ADMIN_PASSWORD}` 
+.7+| `${APPLICATION_NAME}-mongodb`
+| `MONGODB_USER`  |  --  |  `${DB_USERNAME}` 
+| `MONGODB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `MONGODB_DATABASE`  |  `Database name`  |  `${DB_DATABASE}` 
+| `MONGODB_ADMIN_PASSWORD`  |  `Database admin password`  |  `${DB_ADMIN_PASSWORD}` 
+| `MONGODB_NOPREALLOC`  |  `Disable data file preallocation.`  |  `${MONGODB_NOPREALLOC}` 
+| `MONGODB_SMALLFILES`  |  `Set MongoDB to use a smaller default data file size.`  |  `${MONGODB_SMALLFILES}` 
+| `MONGODB_QUIET`  |  `Runs MongoDB in a quiet mode that attempts to limit the amount of output.`  |  `${MONGODB_QUIET}` 
+|=======================================================================
+
+=====  Volumes
+
+|=============
+|Deployment |Name  | mountPath | Purpose | readOnly 
+
+| `${APPLICATION_NAME}`  |  `jws-certificate-volume`  |  `/etc/jws-secret-volume`  |  `ssl certs`  |  `True` 
+|=============
+
+=== External Dependencies
+
+==== Volume Claims
+
+A `PersistentVolume` object is a storage resource in an OpenShift cluster. Storage is provisioned by an administrator
+by creating `PersistentVolume` objects from sources such as GCE Persistent Disks, AWS Elastic Block Stores (EBS), and NFS mounts.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/persistent_volumes.html#overview[Openshift documentation] for
+more information.
+
+|=============
+|Name | Access Mode
+
+|=============
+
+==== Secrets 
+
+This template requires https://github.com/jboss-openshift/application-templates/blob/master/secrets/jws-app-secrets.json[jws-app-secrets.json] to be installed for the application to run.

--- a/docs/templates/webserver/jws-tomcat7-mysql-persistent-sti.adoc
+++ b/docs/templates/webserver/jws-tomcat7-mysql-persistent-sti.adoc
@@ -1,0 +1,227 @@
+= jws-tomcat7-mysql-persistent-sti
+
+Application template for JWS MySQL applications with persistent storage built using STI.
+
+toc::[levels=2]
+
+== Parameters
+
+Templates allow you to define parameters which take on a value. That value is then substituted wherever the parameter is referenced.
+References can be defined in any text field in the objects list field. Refer to the
+https://docs.openshift.org/latest/architecture/core_concepts/templates.html#parameters[Openshift documentation] for more information.
+
+|=======================================================================
+|Variable name |Image Environment Variable |Description |Example value
+
+| `JWS_RELEASE`  |  --  |  `JWS Release version, e.g. 3.0, 2.1, etc.`  |  `3.0` 
+| `APPLICATION_NAME`  |  --  |  `The name for the application.`  |  `jws-app` 
+| `APPLICATION_HOSTNAME`  |  --  |  `Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>`  |  `secure-app.test.router.default.local` 
+| `GIT_URI`  |  --  |  `Git source URI for application`  |  ``https://github.com/jboss-openshift/openshift-examples.git` 
+| `GIT_REF`  |  --  |  `Git branch/tag reference`  |  `master` 
+| `GIT_CONTEXT_DIR`  |  --  |  `Path within Git project to build; empty for root project directory.`  |  `helloworld` 
+| `DB_JNDI`  |  `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb`  |  `${DB_JNDI}` 
+| `DB_DATABASE`  |  `DB_DATABASE`  |  `Database name`  |  `root` 
+| `VOLUME_CAPACITY`  |  --  |  `Size of persistent storage for database volume.`  |  `512Mi` 
+| `JWS_HTTPS_SECRET`  |  --  |  `The name of the secret containing the certificate files`  |  `jws-app-secret` 
+| `JWS_HTTPS_CERTIFICATE`  |  `JWS_HTTPS_CERTIFICATE_DIR`  |  `The name of the certificate file within the secret`  |  `server.crt` 
+| `JWS_HTTPS_CERTIFICATE_KEY`  |  `JWS_HTTPS_CERTIFICATE`  |  `The name of the certificate key file within the secret`  |  `server.key` 
+| `JWS_HTTPS_CERTIFICATE_PASSWORD`  |  `JWS_HTTPS_CERTIFICATE`  |  `The certificate password`  |  `${JWS_HTTPS_CERTIFICATE}` 
+| `DB_MIN_POOL_SIZE`  |  `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `MYSQL_LOWER_CASE_TABLE_NAMES`  |  `MYSQL_LOWER_CASE_TABLE_NAMES`  |  `Sets how the table names are stored and compared.`  |  `${MYSQL_LOWER_CASE_TABLE_NAMES}` 
+| `MYSQL_MAX_CONNECTIONS`  |  `MYSQL_MAX_CONNECTIONS`  |  `The maximum permitted number of simultaneous client connections.`  |  `${MYSQL_MAX_CONNECTIONS}` 
+| `MYSQL_FT_MIN_WORD_LEN`  |  `MYSQL_FT_MIN_WORD_LEN`  |  `The minimum length of the word to be included in a FULLTEXT index.`  |  `${MYSQL_FT_MIN_WORD_LEN}` 
+| `MYSQL_FT_MAX_WORD_LEN`  |  `MYSQL_FT_MAX_WORD_LEN`  |  `The maximum length of the word to be included in a FULLTEXT index.`  |  `${MYSQL_FT_MAX_WORD_LEN}` 
+| `MYSQL_AIO`  |  `MYSQL_AIO`  |  `Controls the innodb_use_native_aio setting value if the native AIO is broken.`  |  `${MYSQL_AIO}` 
+| `DB_USERNAME`  |  `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `JWS_ADMIN_USERNAME`  |  `JWS_ADMIN_USERNAME`  |  `JWS Admin User`  |  `${JWS_ADMIN_USERNAME}` 
+| `JWS_ADMIN_PASSWORD`  |  `JWS_ADMIN_PASSWORD`  |  `JWS Admin Password`  |  `${JWS_ADMIN_PASSWORD}` 
+| `GITHUB_TRIGGER_SECRET`  |  --  |  `GitHub trigger secret`  |  `secret101` 
+| `GENERIC_TRIGGER_SECRET`  |  --  |  `Generic build trigger secret`  |  `secret101` 
+| `IMAGE_STREAM_NAMESPACE`  |  --  |  `Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.`  |  `openshift` 
+|=======================================================================
+
+== Objects
+
+The CLI supports various object types. A list of these object types as well as their abbreviations
+can be found in the https://docs.openshift.org/latest/cli_reference/basic_cli_operations.html#object-types[Openshift documentation].
+
+=== Services
+
+A service is an abstraction which defines a logical set of pods and a policy by which to access them. Refer to the
+https://cloud.google.com/container-engine/docs/services/[container-engine documentation] for more information.
+
+|=============
+|Service        |Port  | Description
+
+| `${APPLICATION_NAME}`  |  `8080`  |  `The web server's http port.` 
+| `secure-${APPLICATION_NAME}`  |  `8443`  |  `The web server's https port.` 
+| `${APPLICATION_NAME}-mysql`  |  `3306`  |  `The database server's port.` 
+|=============
+
+=== Routes
+
+A route is a way to expose a service by giving it an externally-reachable hostname such as `www.example.com`. A defined route and the endpoints
+identified by its service can be consumed by a router to provide named connectivity from external clients to your applications. Each route consists
+of a route name, service selector, and (optionally) security configuration. Refer to the
+https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html[Openshift documentation] for more information.
+
+|=============
+| Service    | Security | Hostname
+
+| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+|=============
+
+=== Build Configurations
+
+A `buildConfig` describes a single build definition and a set of triggers for when a new build should be created.
+A `buildConfig` is a REST object, which can be used in a POST to the API server to create a new instance. Refer to
+the https://docs.openshift.com/enterprise/3.0/dev_guide/builds.html#defining-a-buildconfig[Openshift documentation]
+for more information.
+
+|=============
+| STI image  | link | Build output | BuildTriggers and Settings
+
+| `jboss-webserver3-tomcat7-openshift:${JWS_RELEASE}`  |  ` link:../../webserver/tomcat7-openshift{outfilesuffix}[`jboss-webserver/tomcat7-openshift`]`  |  `${APPLICATION_NAME}:latest`  |  `Generic, GitHub, ImageChange` 
+|=============
+
+=== Deployment Configurations
+
+A deployment in OpenShift is a replication controller based on a user defined template called a deployment configuration. Deployments are created manually or in response to triggered events.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/deployments.html#creating-a-deployment-configuration[Openshift documentation] for more information.
+
+==== Triggers
+
+A trigger drives the creation of new deployments in response to events, both inside and outside OpenShift. Refer to the
+https://access.redhat.com/beta/documentation/en/openshift-enterprise-30-developer-guide#triggers[Openshift documentation] for more information.
+
+|============
+|Deployment | Triggers
+
+| `${APPLICATION_NAME}`  |  `ImageChange` 
+| `${APPLICATION_NAME}-mysql`  |  `ImageChange` 
+|============
+
+==== Replicas
+
+A replication controller ensures that a specified number of pod "replicas" are running at any one time.
+If there are too many, the replication controller kills some pods. If there are too few, it starts more.
+Refer to the https://cloud.google.com/container-engine/docs/replicationcontrollers/[container-engine documentation]
+for more information.
+
+|============
+|Deployment | Replicas
+
+| `${APPLICATION_NAME}`  |  `1` 
+| `${APPLICATION_NAME}-mysql`  |  `1` 
+|============
+
+==== Pod Template
+
+===== Service Accounts
+
+Service accounts are API objects that exist within each project. They can be created or deleted like any other API object. Refer to the
+https://docs.openshift.com/enterprise/3.0/dev_guide/service_accounts.html#managing-service-accounts[Openshift documentation] for more
+information.
+
+|============
+|Deployment | Service Account
+
+| `${APPLICATION_NAME}`  |  `jws-service-account` 
+|============
+
+===== Image
+
+|============
+|Deployment | Image
+
+| `${APPLICATION_NAME}`  |  `${APPLICATION_NAME}` 
+| `${APPLICATION_NAME}-mysql`  |  `mysql` 
+|============
+
+===== Readiness Probe
+
+
+====== ${APPLICATION_NAME}
+----
+/bin/bash
+
+-c
+
+curl -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer&att=stateName' |grep -iq 'stateName *= *STARTED'
+----
+
+
+===== Exposed Ports
+
+|=============
+|Deployments | Name  | Port  | Protocol
+
+.2+| `${APPLICATION_NAME}`
+| `http`  |  `8080`  |  `TCP` 
+| `https`  |  `8443`  |  `TCP` 
+.1+| `${APPLICATION_NAME}-mysql`
+| --  |  `3306`  |  `TCP` 
+|=============
+
+===== Image Environment Variables
+
+|=======================================================================
+|Deployment |Variable name |Description |Example value
+
+.14+| `${APPLICATION_NAME}`
+| `DB_SERVICE_PREFIX_MAPPING`  |  --  |  `${APPLICATION_NAME}-mysql=DB` 
+| `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb`  |  `${DB_JNDI}` 
+| `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `DB_DATABASE`  |  `Database name`  |  `${DB_DATABASE}` 
+| `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `JWS_HTTPS_CERTIFICATE_DIR`  |  `The name of the certificate file within the secret`  |  `/etc/jws-secret-volume` 
+| `JWS_HTTPS_CERTIFICATE`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE}` 
+| `JWS_HTTPS_CERTIFICATE_KEY`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE_KEY}` 
+| `JWS_HTTPS_CERTIFICATE_PASSWORD`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE_PASSWORD}` 
+| `JWS_ADMIN_USERNAME`  |  `JWS Admin User`  |  `${JWS_ADMIN_USERNAME}` 
+| `JWS_ADMIN_PASSWORD`  |  `JWS Admin Password`  |  `${JWS_ADMIN_PASSWORD}` 
+.8+| `${APPLICATION_NAME}-mysql`
+| `MYSQL_USER`  |  --  |  `${DB_USERNAME}` 
+| `MYSQL_PASSWORD`  |  --  |  `${DB_PASSWORD}` 
+| `MYSQL_DATABASE`  |  --  |  `${DB_DATABASE}` 
+| `MYSQL_LOWER_CASE_TABLE_NAMES`  |  `Sets how the table names are stored and compared.`  |  `${MYSQL_LOWER_CASE_TABLE_NAMES}` 
+| `MYSQL_MAX_CONNECTIONS`  |  `The maximum permitted number of simultaneous client connections.`  |  `${MYSQL_MAX_CONNECTIONS}` 
+| `MYSQL_FT_MIN_WORD_LEN`  |  `The minimum length of the word to be included in a FULLTEXT index.`  |  `${MYSQL_FT_MIN_WORD_LEN}` 
+| `MYSQL_FT_MAX_WORD_LEN`  |  `The maximum length of the word to be included in a FULLTEXT index.`  |  `${MYSQL_FT_MAX_WORD_LEN}` 
+| `MYSQL_AIO`  |  `Controls the innodb_use_native_aio setting value if the native AIO is broken.`  |  `${MYSQL_AIO}` 
+|=======================================================================
+
+=====  Volumes
+
+|=============
+|Deployment |Name  | mountPath | Purpose | readOnly 
+
+| `${APPLICATION_NAME}`  |  `jws-certificate-volume`  |  `/etc/jws-secret-volume`  |  `ssl certs`  |  `True` 
+| `${APPLICATION_NAME}-mysql`  |  `${APPLICATION_NAME}-mysql-pvol`  |  `/var/lib/mysql/data`  |  `mysql`  |  `false` 
+|=============
+
+=== External Dependencies
+
+==== Volume Claims
+
+A `PersistentVolume` object is a storage resource in an OpenShift cluster. Storage is provisioned by an administrator
+by creating `PersistentVolume` objects from sources such as GCE Persistent Disks, AWS Elastic Block Stores (EBS), and NFS mounts.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/persistent_volumes.html#overview[Openshift documentation] for
+more information.
+
+|=============
+|Name | Access Mode
+
+| `${APPLICATION_NAME}-mysql-claim`  |  `ReadWriteOnce` 
+|=============
+
+==== Secrets 
+
+This template requires https://github.com/jboss-openshift/application-templates/blob/master/secrets/jws-app-secrets.json[jws-app-secrets.json] to be installed for the application to run.

--- a/docs/templates/webserver/jws-tomcat7-mysql-sti.adoc
+++ b/docs/templates/webserver/jws-tomcat7-mysql-sti.adoc
@@ -1,0 +1,224 @@
+= jws-tomcat7-mysql-sti
+
+Application template for JWS MySQL applications built using STI.
+
+toc::[levels=2]
+
+== Parameters
+
+Templates allow you to define parameters which take on a value. That value is then substituted wherever the parameter is referenced.
+References can be defined in any text field in the objects list field. Refer to the
+https://docs.openshift.org/latest/architecture/core_concepts/templates.html#parameters[Openshift documentation] for more information.
+
+|=======================================================================
+|Variable name |Image Environment Variable |Description |Example value
+
+| `JWS_RELEASE`  |  --  |  `JWS Release version, e.g. 3.0, 2.1, etc.`  |  `3.0` 
+| `APPLICATION_NAME`  |  --  |  `The name for the application.`  |  `jws-app` 
+| `APPLICATION_HOSTNAME`  |  --  |  `Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>`  |  `secure-app.test.router.default.local` 
+| `GIT_URI`  |  --  |  `Git source URI for application`  |  ``https://github.com/jboss-openshift/openshift-examples.git` 
+| `GIT_REF`  |  --  |  `Git branch/tag reference`  |  `master` 
+| `GIT_CONTEXT_DIR`  |  --  |  `Path within Git project to build; empty for root project directory.`  |  `helloworld` 
+| `DB_JNDI`  |  `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb`  |  `${DB_JNDI}` 
+| `DB_DATABASE`  |  `DB_DATABASE`  |  `Database name`  |  `root` 
+| `JWS_HTTPS_SECRET`  |  --  |  `The name of the secret containing the certificate files`  |  `jws-app-secret` 
+| `JWS_HTTPS_CERTIFICATE`  |  `JWS_HTTPS_CERTIFICATE_DIR`  |  `The name of the certificate file within the secret`  |  `server.crt` 
+| `JWS_HTTPS_CERTIFICATE_KEY`  |  `JWS_HTTPS_CERTIFICATE`  |  `The name of the certificate key file within the secret`  |  `server.key` 
+| `JWS_HTTPS_CERTIFICATE_PASSWORD`  |  `JWS_HTTPS_CERTIFICATE`  |  `The certificate password`  |  `${JWS_HTTPS_CERTIFICATE}` 
+| `DB_MIN_POOL_SIZE`  |  `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `MYSQL_LOWER_CASE_TABLE_NAMES`  |  `MYSQL_LOWER_CASE_TABLE_NAMES`  |  `Sets how the table names are stored and compared.`  |  `${MYSQL_LOWER_CASE_TABLE_NAMES}` 
+| `MYSQL_MAX_CONNECTIONS`  |  `MYSQL_MAX_CONNECTIONS`  |  `The maximum permitted number of simultaneous client connections.`  |  `${MYSQL_MAX_CONNECTIONS}` 
+| `MYSQL_FT_MIN_WORD_LEN`  |  `MYSQL_FT_MIN_WORD_LEN`  |  `The minimum length of the word to be included in a FULLTEXT index.`  |  `${MYSQL_FT_MIN_WORD_LEN}` 
+| `MYSQL_FT_MAX_WORD_LEN`  |  `MYSQL_FT_MAX_WORD_LEN`  |  `The maximum length of the word to be included in a FULLTEXT index.`  |  `${MYSQL_FT_MAX_WORD_LEN}` 
+| `MYSQL_AIO`  |  `MYSQL_AIO`  |  `Controls the innodb_use_native_aio setting value if the native AIO is broken.`  |  `${MYSQL_AIO}` 
+| `DB_USERNAME`  |  `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `JWS_ADMIN_USERNAME`  |  `JWS_ADMIN_USERNAME`  |  `JWS Admin User`  |  `${JWS_ADMIN_USERNAME}` 
+| `JWS_ADMIN_PASSWORD`  |  `JWS_ADMIN_PASSWORD`  |  `JWS Admin Password`  |  `${JWS_ADMIN_PASSWORD}` 
+| `GITHUB_TRIGGER_SECRET`  |  --  |  `GitHub trigger secret`  |  `secret101` 
+| `GENERIC_TRIGGER_SECRET`  |  --  |  `Generic build trigger secret`  |  `secret101` 
+| `IMAGE_STREAM_NAMESPACE`  |  --  |  `Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.`  |  `openshift` 
+|=======================================================================
+
+== Objects
+
+The CLI supports various object types. A list of these object types as well as their abbreviations
+can be found in the https://docs.openshift.org/latest/cli_reference/basic_cli_operations.html#object-types[Openshift documentation].
+
+=== Services
+
+A service is an abstraction which defines a logical set of pods and a policy by which to access them. Refer to the
+https://cloud.google.com/container-engine/docs/services/[container-engine documentation] for more information.
+
+|=============
+|Service        |Port  | Description
+
+| `${APPLICATION_NAME}`  |  `8080`  |  `The web server's http port.` 
+| `secure-${APPLICATION_NAME}`  |  `8443`  |  `The web server's https port.` 
+| `${APPLICATION_NAME}-mysql`  |  `3306`  |  `The database server's port.` 
+|=============
+
+=== Routes
+
+A route is a way to expose a service by giving it an externally-reachable hostname such as `www.example.com`. A defined route and the endpoints
+identified by its service can be consumed by a router to provide named connectivity from external clients to your applications. Each route consists
+of a route name, service selector, and (optionally) security configuration. Refer to the
+https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html[Openshift documentation] for more information.
+
+|=============
+| Service    | Security | Hostname
+
+| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+|=============
+
+=== Build Configurations
+
+A `buildConfig` describes a single build definition and a set of triggers for when a new build should be created.
+A `buildConfig` is a REST object, which can be used in a POST to the API server to create a new instance. Refer to
+the https://docs.openshift.com/enterprise/3.0/dev_guide/builds.html#defining-a-buildconfig[Openshift documentation]
+for more information.
+
+|=============
+| STI image  | link | Build output | BuildTriggers and Settings
+
+| `jboss-webserver3-tomcat7-openshift:${JWS_RELEASE}`  |  ` link:../../webserver/tomcat7-openshift{outfilesuffix}[`jboss-webserver/tomcat7-openshift`]`  |  `${APPLICATION_NAME}:latest`  |  `Generic, GitHub, ImageChange` 
+|=============
+
+=== Deployment Configurations
+
+A deployment in OpenShift is a replication controller based on a user defined template called a deployment configuration. Deployments are created manually or in response to triggered events.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/deployments.html#creating-a-deployment-configuration[Openshift documentation] for more information.
+
+==== Triggers
+
+A trigger drives the creation of new deployments in response to events, both inside and outside OpenShift. Refer to the
+https://access.redhat.com/beta/documentation/en/openshift-enterprise-30-developer-guide#triggers[Openshift documentation] for more information.
+
+|============
+|Deployment | Triggers
+
+| `${APPLICATION_NAME}`  |  `ImageChange` 
+| `${APPLICATION_NAME}-mysql`  |  `ImageChange` 
+|============
+
+==== Replicas
+
+A replication controller ensures that a specified number of pod "replicas" are running at any one time.
+If there are too many, the replication controller kills some pods. If there are too few, it starts more.
+Refer to the https://cloud.google.com/container-engine/docs/replicationcontrollers/[container-engine documentation]
+for more information.
+
+|============
+|Deployment | Replicas
+
+| `${APPLICATION_NAME}`  |  `1` 
+| `${APPLICATION_NAME}-mysql`  |  `1` 
+|============
+
+==== Pod Template
+
+===== Service Accounts
+
+Service accounts are API objects that exist within each project. They can be created or deleted like any other API object. Refer to the
+https://docs.openshift.com/enterprise/3.0/dev_guide/service_accounts.html#managing-service-accounts[Openshift documentation] for more
+information.
+
+|============
+|Deployment | Service Account
+
+| `${APPLICATION_NAME}`  |  `jws-service-account` 
+|============
+
+===== Image
+
+|============
+|Deployment | Image
+
+| `${APPLICATION_NAME}`  |  `${APPLICATION_NAME}` 
+| `${APPLICATION_NAME}-mysql`  |  `mysql` 
+|============
+
+===== Readiness Probe
+
+
+====== ${APPLICATION_NAME}
+----
+/bin/bash
+
+-c
+
+curl -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer&att=stateName' |grep -iq 'stateName *= *STARTED'
+----
+
+
+===== Exposed Ports
+
+|=============
+|Deployments | Name  | Port  | Protocol
+
+.2+| `${APPLICATION_NAME}`
+| `http`  |  `8080`  |  `TCP` 
+| `https`  |  `8443`  |  `TCP` 
+.1+| `${APPLICATION_NAME}-mysql`
+| --  |  `3306`  |  `TCP` 
+|=============
+
+===== Image Environment Variables
+
+|=======================================================================
+|Deployment |Variable name |Description |Example value
+
+.14+| `${APPLICATION_NAME}`
+| `DB_SERVICE_PREFIX_MAPPING`  |  --  |  `${APPLICATION_NAME}-mysql=DB` 
+| `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb`  |  `${DB_JNDI}` 
+| `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `DB_DATABASE`  |  `Database name`  |  `${DB_DATABASE}` 
+| `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `JWS_HTTPS_CERTIFICATE_DIR`  |  `The name of the certificate file within the secret`  |  `/etc/jws-secret-volume` 
+| `JWS_HTTPS_CERTIFICATE`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE}` 
+| `JWS_HTTPS_CERTIFICATE_KEY`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE_KEY}` 
+| `JWS_HTTPS_CERTIFICATE_PASSWORD`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE_PASSWORD}` 
+| `JWS_ADMIN_USERNAME`  |  `JWS Admin User`  |  `${JWS_ADMIN_USERNAME}` 
+| `JWS_ADMIN_PASSWORD`  |  `JWS Admin Password`  |  `${JWS_ADMIN_PASSWORD}` 
+.8+| `${APPLICATION_NAME}-mysql`
+| `MYSQL_USER`  |  --  |  `${DB_USERNAME}` 
+| `MYSQL_PASSWORD`  |  --  |  `${DB_PASSWORD}` 
+| `MYSQL_DATABASE`  |  --  |  `${DB_DATABASE}` 
+| `MYSQL_LOWER_CASE_TABLE_NAMES`  |  `Sets how the table names are stored and compared.`  |  `${MYSQL_LOWER_CASE_TABLE_NAMES}` 
+| `MYSQL_MAX_CONNECTIONS`  |  `The maximum permitted number of simultaneous client connections.`  |  `${MYSQL_MAX_CONNECTIONS}` 
+| `MYSQL_FT_MIN_WORD_LEN`  |  `The minimum length of the word to be included in a FULLTEXT index.`  |  `${MYSQL_FT_MIN_WORD_LEN}` 
+| `MYSQL_FT_MAX_WORD_LEN`  |  `The maximum length of the word to be included in a FULLTEXT index.`  |  `${MYSQL_FT_MAX_WORD_LEN}` 
+| `MYSQL_AIO`  |  `Controls the innodb_use_native_aio setting value if the native AIO is broken.`  |  `${MYSQL_AIO}` 
+|=======================================================================
+
+=====  Volumes
+
+|=============
+|Deployment |Name  | mountPath | Purpose | readOnly 
+
+| `${APPLICATION_NAME}`  |  `jws-certificate-volume`  |  `/etc/jws-secret-volume`  |  `ssl certs`  |  `True` 
+|=============
+
+=== External Dependencies
+
+==== Volume Claims
+
+A `PersistentVolume` object is a storage resource in an OpenShift cluster. Storage is provisioned by an administrator
+by creating `PersistentVolume` objects from sources such as GCE Persistent Disks, AWS Elastic Block Stores (EBS), and NFS mounts.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/persistent_volumes.html#overview[Openshift documentation] for
+more information.
+
+|=============
+|Name | Access Mode
+
+|=============
+
+==== Secrets 
+
+This template requires https://github.com/jboss-openshift/application-templates/blob/master/secrets/jws-app-secrets.json[jws-app-secrets.json] to be installed for the application to run.

--- a/docs/templates/webserver/jws-tomcat7-postgresql-persistent-sti.adoc
+++ b/docs/templates/webserver/jws-tomcat7-postgresql-persistent-sti.adoc
@@ -1,0 +1,221 @@
+= jws-tomcat7-postgresql-persistent-sti
+
+Application template for JWS PostgreSQL applications with persistent storage built using STI.
+
+toc::[levels=2]
+
+== Parameters
+
+Templates allow you to define parameters which take on a value. That value is then substituted wherever the parameter is referenced.
+References can be defined in any text field in the objects list field. Refer to the
+https://docs.openshift.org/latest/architecture/core_concepts/templates.html#parameters[Openshift documentation] for more information.
+
+|=======================================================================
+|Variable name |Image Environment Variable |Description |Example value
+
+| `JWS_RELEASE`  |  --  |  `JWS Release version, e.g. 3.0, 2.1, etc.`  |  `3.0` 
+| `APPLICATION_NAME`  |  --  |  `The name for the application.`  |  `jws-app` 
+| `APPLICATION_HOSTNAME`  |  --  |  `Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>`  |  `secure-app.test.router.default.local` 
+| `GIT_URI`  |  --  |  `Git source URI for application`  |  ``https://github.com/jboss-openshift/openshift-examples.git` 
+| `GIT_REF`  |  --  |  `Git branch/tag reference`  |  `master` 
+| `GIT_CONTEXT_DIR`  |  --  |  `Path within Git project to build; empty for root project directory.`  |  `helloworld` 
+| `DB_JNDI`  |  `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb`  |  `${DB_JNDI}` 
+| `DB_DATABASE`  |  `DB_DATABASE`  |  `Database name`  |  `root` 
+| `VOLUME_CAPACITY`  |  --  |  `Size of persistent storage for database volume.`  |  `512Mi` 
+| `JWS_HTTPS_SECRET`  |  --  |  `The name of the secret containing the certificate files`  |  `jws-app-secret` 
+| `JWS_HTTPS_CERTIFICATE`  |  `JWS_HTTPS_CERTIFICATE_DIR`  |  `The name of the certificate file within the secret`  |  `server.crt` 
+| `JWS_HTTPS_CERTIFICATE_KEY`  |  `JWS_HTTPS_CERTIFICATE`  |  `The name of the certificate key file within the secret`  |  `server.key` 
+| `JWS_HTTPS_CERTIFICATE_PASSWORD`  |  `JWS_HTTPS_CERTIFICATE`  |  `The certificate password`  |  `${JWS_HTTPS_CERTIFICATE}` 
+| `DB_MIN_POOL_SIZE`  |  `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `POSTGRESQL_MAX_CONNECTIONS`  |  `POSTGRESQL_MAX_CONNECTIONS`  |  `The maximum number of client connections allowed. This also sets the maximum number of prepared transactions.`  |  `${POSTGRESQL_MAX_CONNECTIONS}` 
+| `POSTGRESQL_SHARED_BUFFERS`  |  `POSTGRESQL_SHARED_BUFFERS`  |  `Configures how much memory is dedicated to PostgreSQL for caching data.`  |  `${POSTGRESQL_SHARED_BUFFERS}` 
+| `DB_USERNAME`  |  `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `JWS_ADMIN_USERNAME`  |  `JWS_ADMIN_USERNAME`  |  `JWS Admin User`  |  `${JWS_ADMIN_USERNAME}` 
+| `JWS_ADMIN_PASSWORD`  |  `JWS_ADMIN_PASSWORD`  |  `JWS Admin Password`  |  `${JWS_ADMIN_PASSWORD}` 
+| `GITHUB_TRIGGER_SECRET`  |  --  |  `GitHub trigger secret`  |  `secret101` 
+| `GENERIC_TRIGGER_SECRET`  |  --  |  `Generic build trigger secret`  |  `secret101` 
+| `IMAGE_STREAM_NAMESPACE`  |  --  |  `Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.`  |  `openshift` 
+|=======================================================================
+
+== Objects
+
+The CLI supports various object types. A list of these object types as well as their abbreviations
+can be found in the https://docs.openshift.org/latest/cli_reference/basic_cli_operations.html#object-types[Openshift documentation].
+
+=== Services
+
+A service is an abstraction which defines a logical set of pods and a policy by which to access them. Refer to the
+https://cloud.google.com/container-engine/docs/services/[container-engine documentation] for more information.
+
+|=============
+|Service        |Port  | Description
+
+| `${APPLICATION_NAME}`  |  `8080`  |  `The web server's http port.` 
+| `secure-${APPLICATION_NAME}`  |  `8443`  |  `The web server's https port.` 
+| `${APPLICATION_NAME}-postgresql`  |  `5432`  |  `The database server's port.` 
+|=============
+
+=== Routes
+
+A route is a way to expose a service by giving it an externally-reachable hostname such as `www.example.com`. A defined route and the endpoints
+identified by its service can be consumed by a router to provide named connectivity from external clients to your applications. Each route consists
+of a route name, service selector, and (optionally) security configuration. Refer to the
+https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html[Openshift documentation] for more information.
+
+|=============
+| Service    | Security | Hostname
+
+| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+|=============
+
+=== Build Configurations
+
+A `buildConfig` describes a single build definition and a set of triggers for when a new build should be created.
+A `buildConfig` is a REST object, which can be used in a POST to the API server to create a new instance. Refer to
+the https://docs.openshift.com/enterprise/3.0/dev_guide/builds.html#defining-a-buildconfig[Openshift documentation]
+for more information.
+
+|=============
+| STI image  | link | Build output | BuildTriggers and Settings
+
+| `jboss-webserver3-tomcat7-openshift:${JWS_RELEASE}`  |  ` link:../../webserver/tomcat7-openshift{outfilesuffix}[`jboss-webserver/tomcat7-openshift`]`  |  `${APPLICATION_NAME}:latest`  |  `Generic, GitHub, ImageChange` 
+|=============
+
+=== Deployment Configurations
+
+A deployment in OpenShift is a replication controller based on a user defined template called a deployment configuration. Deployments are created manually or in response to triggered events.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/deployments.html#creating-a-deployment-configuration[Openshift documentation] for more information.
+
+==== Triggers
+
+A trigger drives the creation of new deployments in response to events, both inside and outside OpenShift. Refer to the
+https://access.redhat.com/beta/documentation/en/openshift-enterprise-30-developer-guide#triggers[Openshift documentation] for more information.
+
+|============
+|Deployment | Triggers
+
+| `${APPLICATION_NAME}`  |  `ImageChange` 
+| `${APPLICATION_NAME}-postgresql`  |  `ImageChange` 
+|============
+
+==== Replicas
+
+A replication controller ensures that a specified number of pod "replicas" are running at any one time.
+If there are too many, the replication controller kills some pods. If there are too few, it starts more.
+Refer to the https://cloud.google.com/container-engine/docs/replicationcontrollers/[container-engine documentation]
+for more information.
+
+|============
+|Deployment | Replicas
+
+| `${APPLICATION_NAME}`  |  `1` 
+| `${APPLICATION_NAME}-postgresql`  |  `1` 
+|============
+
+==== Pod Template
+
+===== Service Accounts
+
+Service accounts are API objects that exist within each project. They can be created or deleted like any other API object. Refer to the
+https://docs.openshift.com/enterprise/3.0/dev_guide/service_accounts.html#managing-service-accounts[Openshift documentation] for more
+information.
+
+|============
+|Deployment | Service Account
+
+| `${APPLICATION_NAME}`  |  `jws-service-account` 
+|============
+
+===== Image
+
+|============
+|Deployment | Image
+
+| `${APPLICATION_NAME}`  |  `${APPLICATION_NAME}` 
+| `${APPLICATION_NAME}-postgresql`  |  `postgresql` 
+|============
+
+===== Readiness Probe
+
+
+====== ${APPLICATION_NAME}
+----
+/bin/bash
+
+-c
+
+curl -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer&att=stateName' |grep -iq 'stateName *= *STARTED'
+----
+
+
+===== Exposed Ports
+
+|=============
+|Deployments | Name  | Port  | Protocol
+
+.2+| `${APPLICATION_NAME}`
+| `http`  |  `8080`  |  `TCP` 
+| `https`  |  `8443`  |  `TCP` 
+.1+| `${APPLICATION_NAME}-postgresql`
+| --  |  `5432`  |  `TCP` 
+|=============
+
+===== Image Environment Variables
+
+|=======================================================================
+|Deployment |Variable name |Description |Example value
+
+.14+| `${APPLICATION_NAME}`
+| `DB_SERVICE_PREFIX_MAPPING`  |  --  |  `${APPLICATION_NAME}-postgresql=DB` 
+| `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb`  |  `${DB_JNDI}` 
+| `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `DB_DATABASE`  |  `Database name`  |  `${DB_DATABASE}` 
+| `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `JWS_HTTPS_CERTIFICATE_DIR`  |  `The name of the certificate file within the secret`  |  `/etc/jws-secret-volume` 
+| `JWS_HTTPS_CERTIFICATE`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE}` 
+| `JWS_HTTPS_CERTIFICATE_KEY`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE_KEY}` 
+| `JWS_HTTPS_CERTIFICATE_PASSWORD`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE_PASSWORD}` 
+| `JWS_ADMIN_USERNAME`  |  `JWS Admin User`  |  `${JWS_ADMIN_USERNAME}` 
+| `JWS_ADMIN_PASSWORD`  |  `JWS Admin Password`  |  `${JWS_ADMIN_PASSWORD}` 
+.5+| `${APPLICATION_NAME}-postgresql`
+| `POSTGRESQL_USER`  |  --  |  `${DB_USERNAME}` 
+| `POSTGRESQL_PASSWORD`  |  --  |  `${DB_PASSWORD}` 
+| `POSTGRESQL_DATABASE`  |  --  |  `${DB_DATABASE}` 
+| `POSTGRESQL_MAX_CONNECTIONS`  |  `The maximum number of client connections allowed. This also sets the maximum number of prepared transactions.`  |  `${POSTGRESQL_MAX_CONNECTIONS}` 
+| `POSTGRESQL_SHARED_BUFFERS`  |  `Configures how much memory is dedicated to PostgreSQL for caching data.`  |  `${POSTGRESQL_SHARED_BUFFERS}` 
+|=======================================================================
+
+=====  Volumes
+
+|=============
+|Deployment |Name  | mountPath | Purpose | readOnly 
+
+| `${APPLICATION_NAME}`  |  `jws-certificate-volume`  |  `/etc/jws-secret-volume`  |  `ssl certs`  |  `True` 
+| `${APPLICATION_NAME}-postgresql`  |  `${APPLICATION_NAME}-postgresql-pvol`  |  `/var/lib/pgsql/data`  |  `postgresql`  |  `false` 
+|=============
+
+=== External Dependencies
+
+==== Volume Claims
+
+A `PersistentVolume` object is a storage resource in an OpenShift cluster. Storage is provisioned by an administrator
+by creating `PersistentVolume` objects from sources such as GCE Persistent Disks, AWS Elastic Block Stores (EBS), and NFS mounts.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/persistent_volumes.html#overview[Openshift documentation] for
+more information.
+
+|=============
+|Name | Access Mode
+
+| `${APPLICATION_NAME}-postgresql-claim`  |  `ReadWriteOnce` 
+|=============
+
+==== Secrets 
+
+This template requires https://github.com/jboss-openshift/application-templates/blob/master/secrets/jws-app-secrets.json[jws-app-secrets.json] to be installed for the application to run.

--- a/docs/templates/webserver/jws-tomcat7-postgresql-sti.adoc
+++ b/docs/templates/webserver/jws-tomcat7-postgresql-sti.adoc
@@ -1,0 +1,218 @@
+= jws-tomcat7-postgresql-sti
+
+Application template for JWS PostgreSQL applications built using STI.
+
+toc::[levels=2]
+
+== Parameters
+
+Templates allow you to define parameters which take on a value. That value is then substituted wherever the parameter is referenced.
+References can be defined in any text field in the objects list field. Refer to the
+https://docs.openshift.org/latest/architecture/core_concepts/templates.html#parameters[Openshift documentation] for more information.
+
+|=======================================================================
+|Variable name |Image Environment Variable |Description |Example value
+
+| `JWS_RELEASE`  |  --  |  `JWS Release version, e.g. 3.0, 2.1, etc.`  |  `3.0` 
+| `APPLICATION_NAME`  |  --  |  `The name for the application.`  |  `jws-app` 
+| `APPLICATION_HOSTNAME`  |  --  |  `Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>`  |  `secure-app.test.router.default.local` 
+| `GIT_URI`  |  --  |  `Git source URI for application`  |  ``https://github.com/jboss-openshift/openshift-examples.git` 
+| `GIT_REF`  |  --  |  `Git branch/tag reference`  |  `master` 
+| `GIT_CONTEXT_DIR`  |  --  |  `Path within Git project to build; empty for root project directory.`  |  `helloworld` 
+| `DB_JNDI`  |  `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb`  |  `${DB_JNDI}` 
+| `DB_DATABASE`  |  `DB_DATABASE`  |  `Database name`  |  `root` 
+| `JWS_HTTPS_SECRET`  |  --  |  `The name of the secret containing the certificate files`  |  `jws-app-secret` 
+| `JWS_HTTPS_CERTIFICATE`  |  `JWS_HTTPS_CERTIFICATE_DIR`  |  `The name of the certificate file within the secret`  |  `server.crt` 
+| `JWS_HTTPS_CERTIFICATE_KEY`  |  `JWS_HTTPS_CERTIFICATE`  |  `The name of the certificate key file within the secret`  |  `server.key` 
+| `JWS_HTTPS_CERTIFICATE_PASSWORD`  |  `JWS_HTTPS_CERTIFICATE`  |  `The certificate password`  |  `${JWS_HTTPS_CERTIFICATE}` 
+| `DB_MIN_POOL_SIZE`  |  `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `POSTGRESQL_MAX_CONNECTIONS`  |  `POSTGRESQL_MAX_CONNECTIONS`  |  `The maximum number of client connections allowed. This also sets the maximum number of prepared transactions.`  |  `${POSTGRESQL_MAX_CONNECTIONS}` 
+| `POSTGRESQL_SHARED_BUFFERS`  |  `POSTGRESQL_SHARED_BUFFERS`  |  `Configures how much memory is dedicated to PostgreSQL for caching data.`  |  `${POSTGRESQL_SHARED_BUFFERS}` 
+| `DB_USERNAME`  |  `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `JWS_ADMIN_USERNAME`  |  `JWS_ADMIN_USERNAME`  |  `JWS Admin User`  |  `${JWS_ADMIN_USERNAME}` 
+| `JWS_ADMIN_PASSWORD`  |  `JWS_ADMIN_PASSWORD`  |  `JWS Admin Password`  |  `${JWS_ADMIN_PASSWORD}` 
+| `GITHUB_TRIGGER_SECRET`  |  --  |  `GitHub trigger secret`  |  `secret101` 
+| `GENERIC_TRIGGER_SECRET`  |  --  |  `Generic build trigger secret`  |  `secret101` 
+| `IMAGE_STREAM_NAMESPACE`  |  --  |  `Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.`  |  `openshift` 
+|=======================================================================
+
+== Objects
+
+The CLI supports various object types. A list of these object types as well as their abbreviations
+can be found in the https://docs.openshift.org/latest/cli_reference/basic_cli_operations.html#object-types[Openshift documentation].
+
+=== Services
+
+A service is an abstraction which defines a logical set of pods and a policy by which to access them. Refer to the
+https://cloud.google.com/container-engine/docs/services/[container-engine documentation] for more information.
+
+|=============
+|Service        |Port  | Description
+
+| `${APPLICATION_NAME}`  |  `8080`  |  `The web server's http port.` 
+| `secure-${APPLICATION_NAME}`  |  `8443`  |  `The web server's https port.` 
+| `${APPLICATION_NAME}-postgresql`  |  `5432`  |  `The database server's port.` 
+|=============
+
+=== Routes
+
+A route is a way to expose a service by giving it an externally-reachable hostname such as `www.example.com`. A defined route and the endpoints
+identified by its service can be consumed by a router to provide named connectivity from external clients to your applications. Each route consists
+of a route name, service selector, and (optionally) security configuration. Refer to the
+https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html[Openshift documentation] for more information.
+
+|=============
+| Service    | Security | Hostname
+
+| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+|=============
+
+=== Build Configurations
+
+A `buildConfig` describes a single build definition and a set of triggers for when a new build should be created.
+A `buildConfig` is a REST object, which can be used in a POST to the API server to create a new instance. Refer to
+the https://docs.openshift.com/enterprise/3.0/dev_guide/builds.html#defining-a-buildconfig[Openshift documentation]
+for more information.
+
+|=============
+| STI image  | link | Build output | BuildTriggers and Settings
+
+| `jboss-webserver3-tomcat7-openshift:${JWS_RELEASE}`  |  ` link:../../webserver/tomcat7-openshift{outfilesuffix}[`jboss-webserver/tomcat7-openshift`]`  |  `${APPLICATION_NAME}:latest`  |  `Generic, GitHub, ImageChange` 
+|=============
+
+=== Deployment Configurations
+
+A deployment in OpenShift is a replication controller based on a user defined template called a deployment configuration. Deployments are created manually or in response to triggered events.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/deployments.html#creating-a-deployment-configuration[Openshift documentation] for more information.
+
+==== Triggers
+
+A trigger drives the creation of new deployments in response to events, both inside and outside OpenShift. Refer to the
+https://access.redhat.com/beta/documentation/en/openshift-enterprise-30-developer-guide#triggers[Openshift documentation] for more information.
+
+|============
+|Deployment | Triggers
+
+| `${APPLICATION_NAME}`  |  `ImageChange` 
+| `${APPLICATION_NAME}-postgresql`  |  `ImageChange` 
+|============
+
+==== Replicas
+
+A replication controller ensures that a specified number of pod "replicas" are running at any one time.
+If there are too many, the replication controller kills some pods. If there are too few, it starts more.
+Refer to the https://cloud.google.com/container-engine/docs/replicationcontrollers/[container-engine documentation]
+for more information.
+
+|============
+|Deployment | Replicas
+
+| `${APPLICATION_NAME}`  |  `1` 
+| `${APPLICATION_NAME}-postgresql`  |  `1` 
+|============
+
+==== Pod Template
+
+===== Service Accounts
+
+Service accounts are API objects that exist within each project. They can be created or deleted like any other API object. Refer to the
+https://docs.openshift.com/enterprise/3.0/dev_guide/service_accounts.html#managing-service-accounts[Openshift documentation] for more
+information.
+
+|============
+|Deployment | Service Account
+
+| `${APPLICATION_NAME}`  |  `jws-service-account` 
+|============
+
+===== Image
+
+|============
+|Deployment | Image
+
+| `${APPLICATION_NAME}`  |  `${APPLICATION_NAME}` 
+| `${APPLICATION_NAME}-postgresql`  |  `postgresql` 
+|============
+
+===== Readiness Probe
+
+
+====== ${APPLICATION_NAME}
+----
+/bin/bash
+
+-c
+
+curl -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer&att=stateName' |grep -iq 'stateName *= *STARTED'
+----
+
+
+===== Exposed Ports
+
+|=============
+|Deployments | Name  | Port  | Protocol
+
+.2+| `${APPLICATION_NAME}`
+| `http`  |  `8080`  |  `TCP` 
+| `https`  |  `8443`  |  `TCP` 
+.1+| `${APPLICATION_NAME}-postgresql`
+| --  |  `5432`  |  `TCP` 
+|=============
+
+===== Image Environment Variables
+
+|=======================================================================
+|Deployment |Variable name |Description |Example value
+
+.14+| `${APPLICATION_NAME}`
+| `DB_SERVICE_PREFIX_MAPPING`  |  --  |  `${APPLICATION_NAME}-postgresql=DB` 
+| `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb`  |  `${DB_JNDI}` 
+| `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `DB_DATABASE`  |  `Database name`  |  `${DB_DATABASE}` 
+| `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `JWS_HTTPS_CERTIFICATE_DIR`  |  `The name of the certificate file within the secret`  |  `/etc/jws-secret-volume` 
+| `JWS_HTTPS_CERTIFICATE`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE}` 
+| `JWS_HTTPS_CERTIFICATE_KEY`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE_KEY}` 
+| `JWS_HTTPS_CERTIFICATE_PASSWORD`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE_PASSWORD}` 
+| `JWS_ADMIN_USERNAME`  |  `JWS Admin User`  |  `${JWS_ADMIN_USERNAME}` 
+| `JWS_ADMIN_PASSWORD`  |  `JWS Admin Password`  |  `${JWS_ADMIN_PASSWORD}` 
+.5+| `${APPLICATION_NAME}-postgresql`
+| `POSTGRESQL_USER`  |  --  |  `${DB_USERNAME}` 
+| `POSTGRESQL_PASSWORD`  |  --  |  `${DB_PASSWORD}` 
+| `POSTGRESQL_DATABASE`  |  --  |  `${DB_DATABASE}` 
+| `POSTGRESQL_MAX_CONNECTIONS`  |  `The maximum number of client connections allowed. This also sets the maximum number of prepared transactions.`  |  `${POSTGRESQL_MAX_CONNECTIONS}` 
+| `POSTGRESQL_SHARED_BUFFERS`  |  `Configures how much memory is dedicated to PostgreSQL for caching data.`  |  `${POSTGRESQL_SHARED_BUFFERS}` 
+|=======================================================================
+
+=====  Volumes
+
+|=============
+|Deployment |Name  | mountPath | Purpose | readOnly 
+
+| `${APPLICATION_NAME}`  |  `jws-certificate-volume`  |  `/etc/jws-secret-volume`  |  `ssl certs`  |  `True` 
+|=============
+
+=== External Dependencies
+
+==== Volume Claims
+
+A `PersistentVolume` object is a storage resource in an OpenShift cluster. Storage is provisioned by an administrator
+by creating `PersistentVolume` objects from sources such as GCE Persistent Disks, AWS Elastic Block Stores (EBS), and NFS mounts.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/persistent_volumes.html#overview[Openshift documentation] for
+more information.
+
+|=============
+|Name | Access Mode
+
+|=============
+
+==== Secrets 
+
+This template requires https://github.com/jboss-openshift/application-templates/blob/master/secrets/jws-app-secrets.json[jws-app-secrets.json] to be installed for the application to run.

--- a/docs/templates/webserver/jws-tomcat8-basic-sti.adoc
+++ b/docs/templates/webserver/jws-tomcat8-basic-sti.adoc
@@ -1,0 +1,176 @@
+= jws-tomcat8-basic-sti
+
+Application template for JWS applications built using STI.
+
+toc::[levels=2]
+
+== Parameters
+
+Templates allow you to define parameters which take on a value. That value is then substituted wherever the parameter is referenced.
+References can be defined in any text field in the objects list field. Refer to the
+https://docs.openshift.org/latest/architecture/core_concepts/templates.html#parameters[Openshift documentation] for more information.
+
+|=======================================================================
+|Variable name |Image Environment Variable |Description |Example value
+
+| `JWS_RELEASE`  |  --  |  `JWS Release version, e.g. 3.0, 2.1, etc.`  |  `3.0` 
+| `APPLICATION_NAME`  |  --  |  `The name for the application.`  |  `jws-app` 
+| `APPLICATION_HOSTNAME`  |  --  |  `Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>`  |  `secure-app.test.router.default.local` 
+| `GIT_URI`  |  --  |  `Git source URI for application`  |  ``https://github.com/jboss-openshift/openshift-examples.git` 
+| `GIT_REF`  |  --  |  `Git branch/tag reference`  |  `master` 
+| `GIT_CONTEXT_DIR`  |  --  |  `Path within Git project to build; empty for root project directory.`  |  `helloworld` 
+| `JWS_ADMIN_USERNAME`  |  `JWS_ADMIN_USERNAME`  |  `JWS Admin User`  |  `${JWS_ADMIN_USERNAME}` 
+| `JWS_ADMIN_PASSWORD`  |  `JWS_ADMIN_PASSWORD`  |  `JWS Admin Password`  |  `${JWS_ADMIN_PASSWORD}` 
+| `GITHUB_TRIGGER_SECRET`  |  --  |  `GitHub trigger secret`  |  `secret101` 
+| `GENERIC_TRIGGER_SECRET`  |  --  |  `Generic build trigger secret`  |  `secret101` 
+| `IMAGE_STREAM_NAMESPACE`  |  --  |  `Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.`  |  `openshift` 
+|=======================================================================
+
+== Objects
+
+The CLI supports various object types. A list of these object types as well as their abbreviations
+can be found in the https://docs.openshift.org/latest/cli_reference/basic_cli_operations.html#object-types[Openshift documentation].
+
+=== Services
+
+A service is an abstraction which defines a logical set of pods and a policy by which to access them. Refer to the
+https://cloud.google.com/container-engine/docs/services/[container-engine documentation] for more information.
+
+|=============
+|Service        |Port  | Description
+
+| `${APPLICATION_NAME}`  |  `8080`  |  `The web server's http port.` 
+|=============
+
+=== Routes
+
+A route is a way to expose a service by giving it an externally-reachable hostname such as `www.example.com`. A defined route and the endpoints
+identified by its service can be consumed by a router to provide named connectivity from external clients to your applications. Each route consists
+of a route name, service selector, and (optionally) security configuration. Refer to the
+https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html[Openshift documentation] for more information.
+
+|=============
+| Service    | Security | Hostname
+
+| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+|=============
+
+=== Build Configurations
+
+A `buildConfig` describes a single build definition and a set of triggers for when a new build should be created.
+A `buildConfig` is a REST object, which can be used in a POST to the API server to create a new instance. Refer to
+the https://docs.openshift.com/enterprise/3.0/dev_guide/builds.html#defining-a-buildconfig[Openshift documentation]
+for more information.
+
+|=============
+| STI image  | link | Build output | BuildTriggers and Settings
+
+| `jboss-webserver3-tomcat8-openshift:${JWS_RELEASE}`  |  ` link:../../webserver/tomcat8-openshift{outfilesuffix}[`jboss-webserver/tomcat8-openshift`]`  |  `${APPLICATION_NAME}:latest`  |  `Generic, GitHub, ImageChange` 
+|=============
+
+=== Deployment Configurations
+
+A deployment in OpenShift is a replication controller based on a user defined template called a deployment configuration. Deployments are created manually or in response to triggered events.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/deployments.html#creating-a-deployment-configuration[Openshift documentation] for more information.
+
+==== Triggers
+
+A trigger drives the creation of new deployments in response to events, both inside and outside OpenShift. Refer to the
+https://access.redhat.com/beta/documentation/en/openshift-enterprise-30-developer-guide#triggers[Openshift documentation] for more information.
+
+|============
+|Deployment | Triggers
+
+| `${APPLICATION_NAME}`  |  `ImageChange` 
+|============
+
+==== Replicas
+
+A replication controller ensures that a specified number of pod "replicas" are running at any one time.
+If there are too many, the replication controller kills some pods. If there are too few, it starts more.
+Refer to the https://cloud.google.com/container-engine/docs/replicationcontrollers/[container-engine documentation]
+for more information.
+
+|============
+|Deployment | Replicas
+
+| `${APPLICATION_NAME}`  |  `1` 
+|============
+
+==== Pod Template
+
+===== Service Accounts
+
+Service accounts are API objects that exist within each project. They can be created or deleted like any other API object. Refer to the
+https://docs.openshift.com/enterprise/3.0/dev_guide/service_accounts.html#managing-service-accounts[Openshift documentation] for more
+information.
+
+|============
+|Deployment | Service Account
+
+|============
+
+===== Image
+
+|============
+|Deployment | Image
+
+| `${APPLICATION_NAME}`  |  `${APPLICATION_NAME}` 
+|============
+
+===== Readiness Probe
+
+
+====== ${APPLICATION_NAME}
+----
+/bin/bash
+
+-c
+
+curl -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer&att=stateName' |grep -iq 'stateName *= *STARTED'
+----
+
+
+===== Exposed Ports
+
+|=============
+|Deployments | Name  | Port  | Protocol
+
+.1+| `${APPLICATION_NAME}`
+| `http`  |  `8080`  |  `TCP` 
+|=============
+
+===== Image Environment Variables
+
+|=======================================================================
+|Deployment |Variable name |Description |Example value
+
+.2+| `${APPLICATION_NAME}`
+| `JWS_ADMIN_USERNAME`  |  `JWS Admin User`  |  `${JWS_ADMIN_USERNAME}` 
+| `JWS_ADMIN_PASSWORD`  |  `JWS Admin Password`  |  `${JWS_ADMIN_PASSWORD}` 
+|=======================================================================
+
+=====  Volumes
+
+|=============
+|Deployment |Name  | mountPath | Purpose | readOnly 
+
+|=============
+
+=== External Dependencies
+
+==== Volume Claims
+
+A `PersistentVolume` object is a storage resource in an OpenShift cluster. Storage is provisioned by an administrator
+by creating `PersistentVolume` objects from sources such as GCE Persistent Disks, AWS Elastic Block Stores (EBS), and NFS mounts.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/persistent_volumes.html#overview[Openshift documentation] for
+more information.
+
+|=============
+|Name | Access Mode
+
+|=============
+
+==== Secrets 
+
+This template requires https://github.com/jboss-openshift/application-templates/blob/master/secrets/jws-app-secrets.json[jws-app-secrets.json] to be installed for the application to run.

--- a/docs/templates/webserver/jws-tomcat8-https-sti.adoc
+++ b/docs/templates/webserver/jws-tomcat8-https-sti.adoc
@@ -1,0 +1,189 @@
+= jws-tomcat8-https-sti
+
+Application template for JWS applications built using STI.
+
+toc::[levels=2]
+
+== Parameters
+
+Templates allow you to define parameters which take on a value. That value is then substituted wherever the parameter is referenced.
+References can be defined in any text field in the objects list field. Refer to the
+https://docs.openshift.org/latest/architecture/core_concepts/templates.html#parameters[Openshift documentation] for more information.
+
+|=======================================================================
+|Variable name |Image Environment Variable |Description |Example value
+
+| `JWS_RELEASE`  |  --  |  `JWS Release version, e.g. 3.0, 2.1, etc.`  |  `3.0` 
+| `APPLICATION_NAME`  |  --  |  `The name for the application.`  |  `jws-app` 
+| `APPLICATION_HOSTNAME`  |  --  |  `Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>`  |  `secure-app.test.router.default.local` 
+| `GIT_URI`  |  --  |  `Git source URI for application`  |  ``https://github.com/jboss-openshift/openshift-examples.git` 
+| `GIT_REF`  |  --  |  `Git branch/tag reference`  |  `master` 
+| `GIT_CONTEXT_DIR`  |  --  |  `Path within Git project to build; empty for root project directory.`  |  `helloworld` 
+| `JWS_HTTPS_SECRET`  |  --  |  `The name of the secret containing the certificate files`  |  `jws-app-secret` 
+| `JWS_HTTPS_CERTIFICATE`  |  `JWS_HTTPS_CERTIFICATE_DIR`  |  `The name of the certificate file within the secret`  |  `server.crt` 
+| `JWS_HTTPS_CERTIFICATE_KEY`  |  `JWS_HTTPS_CERTIFICATE`  |  `The name of the certificate key file within the secret`  |  `server.key` 
+| `JWS_HTTPS_CERTIFICATE_PASSWORD`  |  `JWS_HTTPS_CERTIFICATE`  |  `The certificate password`  |  `${JWS_HTTPS_CERTIFICATE}` 
+| `JWS_ADMIN_USERNAME`  |  `JWS_ADMIN_USERNAME`  |  `JWS Admin User`  |  `${JWS_ADMIN_USERNAME}` 
+| `JWS_ADMIN_PASSWORD`  |  `JWS_ADMIN_PASSWORD`  |  `JWS Admin Password`  |  `${JWS_ADMIN_PASSWORD}` 
+| `GITHUB_TRIGGER_SECRET`  |  --  |  `GitHub trigger secret`  |  `secret101` 
+| `GENERIC_TRIGGER_SECRET`  |  --  |  `Generic build trigger secret`  |  `secret101` 
+| `IMAGE_STREAM_NAMESPACE`  |  --  |  `Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.`  |  `openshift` 
+|=======================================================================
+
+== Objects
+
+The CLI supports various object types. A list of these object types as well as their abbreviations
+can be found in the https://docs.openshift.org/latest/cli_reference/basic_cli_operations.html#object-types[Openshift documentation].
+
+=== Services
+
+A service is an abstraction which defines a logical set of pods and a policy by which to access them. Refer to the
+https://cloud.google.com/container-engine/docs/services/[container-engine documentation] for more information.
+
+|=============
+|Service        |Port  | Description
+
+| `${APPLICATION_NAME}`  |  `8080`  |  `The web server's http port.` 
+| `secure-${APPLICATION_NAME}`  |  `8443`  |  `The web server's https port.` 
+|=============
+
+=== Routes
+
+A route is a way to expose a service by giving it an externally-reachable hostname such as `www.example.com`. A defined route and the endpoints
+identified by its service can be consumed by a router to provide named connectivity from external clients to your applications. Each route consists
+of a route name, service selector, and (optionally) security configuration. Refer to the
+https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html[Openshift documentation] for more information.
+
+|=============
+| Service    | Security | Hostname
+
+| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+|=============
+
+=== Build Configurations
+
+A `buildConfig` describes a single build definition and a set of triggers for when a new build should be created.
+A `buildConfig` is a REST object, which can be used in a POST to the API server to create a new instance. Refer to
+the https://docs.openshift.com/enterprise/3.0/dev_guide/builds.html#defining-a-buildconfig[Openshift documentation]
+for more information.
+
+|=============
+| STI image  | link | Build output | BuildTriggers and Settings
+
+| `jboss-webserver3-tomcat8-openshift:${JWS_RELEASE}`  |  ` link:../../webserver/tomcat8-openshift{outfilesuffix}[`jboss-webserver/tomcat8-openshift`]`  |  `${APPLICATION_NAME}:latest`  |  `Generic, GitHub, ImageChange` 
+|=============
+
+=== Deployment Configurations
+
+A deployment in OpenShift is a replication controller based on a user defined template called a deployment configuration. Deployments are created manually or in response to triggered events.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/deployments.html#creating-a-deployment-configuration[Openshift documentation] for more information.
+
+==== Triggers
+
+A trigger drives the creation of new deployments in response to events, both inside and outside OpenShift. Refer to the
+https://access.redhat.com/beta/documentation/en/openshift-enterprise-30-developer-guide#triggers[Openshift documentation] for more information.
+
+|============
+|Deployment | Triggers
+
+| `${APPLICATION_NAME}`  |  `ImageChange` 
+|============
+
+==== Replicas
+
+A replication controller ensures that a specified number of pod "replicas" are running at any one time.
+If there are too many, the replication controller kills some pods. If there are too few, it starts more.
+Refer to the https://cloud.google.com/container-engine/docs/replicationcontrollers/[container-engine documentation]
+for more information.
+
+|============
+|Deployment | Replicas
+
+| `${APPLICATION_NAME}`  |  `1` 
+|============
+
+==== Pod Template
+
+===== Service Accounts
+
+Service accounts are API objects that exist within each project. They can be created or deleted like any other API object. Refer to the
+https://docs.openshift.com/enterprise/3.0/dev_guide/service_accounts.html#managing-service-accounts[Openshift documentation] for more
+information.
+
+|============
+|Deployment | Service Account
+
+| `${APPLICATION_NAME}`  |  `jws-service-account` 
+|============
+
+===== Image
+
+|============
+|Deployment | Image
+
+| `${APPLICATION_NAME}`  |  `${APPLICATION_NAME}` 
+|============
+
+===== Readiness Probe
+
+
+====== ${APPLICATION_NAME}
+----
+/bin/bash
+
+-c
+
+curl -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer&att=stateName' |grep -iq 'stateName *= *STARTED'
+----
+
+
+===== Exposed Ports
+
+|=============
+|Deployments | Name  | Port  | Protocol
+
+.2+| `${APPLICATION_NAME}`
+| `http`  |  `8080`  |  `TCP` 
+| `https`  |  `8443`  |  `TCP` 
+|=============
+
+===== Image Environment Variables
+
+|=======================================================================
+|Deployment |Variable name |Description |Example value
+
+.6+| `${APPLICATION_NAME}`
+| `JWS_HTTPS_CERTIFICATE_DIR`  |  `The name of the certificate file within the secret`  |  `/etc/jws-secret-volume` 
+| `JWS_HTTPS_CERTIFICATE`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE}` 
+| `JWS_HTTPS_CERTIFICATE_KEY`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE_KEY}` 
+| `JWS_HTTPS_CERTIFICATE_PASSWORD`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE_PASSWORD}` 
+| `JWS_ADMIN_USERNAME`  |  `JWS Admin User`  |  `${JWS_ADMIN_USERNAME}` 
+| `JWS_ADMIN_PASSWORD`  |  `JWS Admin Password`  |  `${JWS_ADMIN_PASSWORD}` 
+|=======================================================================
+
+=====  Volumes
+
+|=============
+|Deployment |Name  | mountPath | Purpose | readOnly 
+
+| `${APPLICATION_NAME}`  |  `jws-certificate-volume`  |  `/etc/jws-secret-volume`  |  `ssl certs`  |  `True` 
+|=============
+
+=== External Dependencies
+
+==== Volume Claims
+
+A `PersistentVolume` object is a storage resource in an OpenShift cluster. Storage is provisioned by an administrator
+by creating `PersistentVolume` objects from sources such as GCE Persistent Disks, AWS Elastic Block Stores (EBS), and NFS mounts.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/persistent_volumes.html#overview[Openshift documentation] for
+more information.
+
+|=============
+|Name | Access Mode
+
+|=============
+
+==== Secrets 
+
+This template requires https://github.com/jboss-openshift/application-templates/blob/master/secrets/jws-app-secrets.json[jws-app-secrets.json] to be installed for the application to run.

--- a/docs/templates/webserver/jws-tomcat8-mongodb-persistent-sti.adoc
+++ b/docs/templates/webserver/jws-tomcat8-mongodb-persistent-sti.adoc
@@ -1,0 +1,226 @@
+= jws-tomcat8-mongodb-persistent-sti
+
+Application template for JWS MongoDB applications with persistent storage built using STI.
+
+toc::[levels=2]
+
+== Parameters
+
+Templates allow you to define parameters which take on a value. That value is then substituted wherever the parameter is referenced.
+References can be defined in any text field in the objects list field. Refer to the
+https://docs.openshift.org/latest/architecture/core_concepts/templates.html#parameters[Openshift documentation] for more information.
+
+|=======================================================================
+|Variable name |Image Environment Variable |Description |Example value
+
+| `JWS_RELEASE`  |  --  |  `JWS Release version, e.g. 3.0, 2.1, etc.`  |  `3.0` 
+| `APPLICATION_NAME`  |  --  |  `The name for the application.`  |  `jws-app` 
+| `APPLICATION_HOSTNAME`  |  --  |  `Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>`  |  `secure-app.test.router.default.local` 
+| `GIT_URI`  |  --  |  `Git source URI for application`  |  ``https://github.com/jboss-openshift/openshift-examples.git` 
+| `GIT_REF`  |  --  |  `Git branch/tag reference`  |  `master` 
+| `GIT_CONTEXT_DIR`  |  --  |  `Path within Git project to build; empty for root project directory.`  |  `helloworld` 
+| `DB_JNDI`  |  `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb`  |  `${DB_JNDI}` 
+| `DB_DATABASE`  |  `DB_DATABASE`  |  `Database name`  |  `root` 
+| `VOLUME_CAPACITY`  |  --  |  `Size of persistent storage for database volume.`  |  `512Mi` 
+| `JWS_HTTPS_SECRET`  |  --  |  `The name of the secret containing the certificate files`  |  `jws-app-secret` 
+| `JWS_HTTPS_CERTIFICATE`  |  `JWS_HTTPS_CERTIFICATE_DIR`  |  `The name of the certificate file within the secret`  |  `server.crt` 
+| `JWS_HTTPS_CERTIFICATE_KEY`  |  `JWS_HTTPS_CERTIFICATE`  |  `The name of the certificate key file within the secret`  |  `server.key` 
+| `JWS_HTTPS_CERTIFICATE_PASSWORD`  |  `JWS_HTTPS_CERTIFICATE`  |  `The certificate password`  |  `${JWS_HTTPS_CERTIFICATE}` 
+| `DB_MIN_POOL_SIZE`  |  `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `MONGODB_NOPREALLOC`  |  `MONGODB_NOPREALLOC`  |  `Disable data file preallocation.`  |  `${MONGODB_NOPREALLOC}` 
+| `MONGODB_SMALLFILES`  |  `MONGODB_SMALLFILES`  |  `Set MongoDB to use a smaller default data file size.`  |  `${MONGODB_SMALLFILES}` 
+| `MONGODB_QUIET`  |  `MONGODB_QUIET`  |  `Runs MongoDB in a quiet mode that attempts to limit the amount of output.`  |  `${MONGODB_QUIET}` 
+| `DB_USERNAME`  |  `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `DB_ADMIN_PASSWORD`  |  `DB_ADMIN_PASSWORD`  |  `Database admin password`  |  `${DB_ADMIN_PASSWORD}` 
+| `JWS_ADMIN_USERNAME`  |  `JWS_ADMIN_USERNAME`  |  `JWS Admin User`  |  `${JWS_ADMIN_USERNAME}` 
+| `JWS_ADMIN_PASSWORD`  |  `JWS_ADMIN_PASSWORD`  |  `JWS Admin Password`  |  `${JWS_ADMIN_PASSWORD}` 
+| `GITHUB_TRIGGER_SECRET`  |  --  |  `GitHub trigger secret`  |  `secret101` 
+| `GENERIC_TRIGGER_SECRET`  |  --  |  `Generic build trigger secret`  |  `secret101` 
+| `IMAGE_STREAM_NAMESPACE`  |  --  |  `Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.`  |  `openshift` 
+|=======================================================================
+
+== Objects
+
+The CLI supports various object types. A list of these object types as well as their abbreviations
+can be found in the https://docs.openshift.org/latest/cli_reference/basic_cli_operations.html#object-types[Openshift documentation].
+
+=== Services
+
+A service is an abstraction which defines a logical set of pods and a policy by which to access them. Refer to the
+https://cloud.google.com/container-engine/docs/services/[container-engine documentation] for more information.
+
+|=============
+|Service        |Port  | Description
+
+| `${APPLICATION_NAME}`  |  `8080`  |  `The web server's http port.` 
+| `secure-${APPLICATION_NAME}`  |  `8443`  |  `The web server's https port.` 
+| `${APPLICATION_NAME}-mongodb`  |  `27017`  |  `The database server's port.` 
+|=============
+
+=== Routes
+
+A route is a way to expose a service by giving it an externally-reachable hostname such as `www.example.com`. A defined route and the endpoints
+identified by its service can be consumed by a router to provide named connectivity from external clients to your applications. Each route consists
+of a route name, service selector, and (optionally) security configuration. Refer to the
+https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html[Openshift documentation] for more information.
+
+|=============
+| Service    | Security | Hostname
+
+| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+|=============
+
+=== Build Configurations
+
+A `buildConfig` describes a single build definition and a set of triggers for when a new build should be created.
+A `buildConfig` is a REST object, which can be used in a POST to the API server to create a new instance. Refer to
+the https://docs.openshift.com/enterprise/3.0/dev_guide/builds.html#defining-a-buildconfig[Openshift documentation]
+for more information.
+
+|=============
+| STI image  | link | Build output | BuildTriggers and Settings
+
+| `jboss-webserver3-tomcat8-openshift:${JWS_RELEASE}`  |  ` link:../../webserver/tomcat8-openshift{outfilesuffix}[`jboss-webserver/tomcat8-openshift`]`  |  `${APPLICATION_NAME}:latest`  |  `Generic, GitHub, ImageChange` 
+|=============
+
+=== Deployment Configurations
+
+A deployment in OpenShift is a replication controller based on a user defined template called a deployment configuration. Deployments are created manually or in response to triggered events.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/deployments.html#creating-a-deployment-configuration[Openshift documentation] for more information.
+
+==== Triggers
+
+A trigger drives the creation of new deployments in response to events, both inside and outside OpenShift. Refer to the
+https://access.redhat.com/beta/documentation/en/openshift-enterprise-30-developer-guide#triggers[Openshift documentation] for more information.
+
+|============
+|Deployment | Triggers
+
+| `${APPLICATION_NAME}`  |  `ImageChange` 
+| `${APPLICATION_NAME}-mongodb`  |  `ImageChange` 
+|============
+
+==== Replicas
+
+A replication controller ensures that a specified number of pod "replicas" are running at any one time.
+If there are too many, the replication controller kills some pods. If there are too few, it starts more.
+Refer to the https://cloud.google.com/container-engine/docs/replicationcontrollers/[container-engine documentation]
+for more information.
+
+|============
+|Deployment | Replicas
+
+| `${APPLICATION_NAME}`  |  `1` 
+| `${APPLICATION_NAME}-mongodb`  |  `1` 
+|============
+
+==== Pod Template
+
+===== Service Accounts
+
+Service accounts are API objects that exist within each project. They can be created or deleted like any other API object. Refer to the
+https://docs.openshift.com/enterprise/3.0/dev_guide/service_accounts.html#managing-service-accounts[Openshift documentation] for more
+information.
+
+|============
+|Deployment | Service Account
+
+| `${APPLICATION_NAME}`  |  `jws-service-account` 
+|============
+
+===== Image
+
+|============
+|Deployment | Image
+
+| `${APPLICATION_NAME}`  |  `${APPLICATION_NAME}` 
+| `${APPLICATION_NAME}-mongodb`  |  `mongodb` 
+|============
+
+===== Readiness Probe
+
+
+====== ${APPLICATION_NAME}
+----
+/bin/bash
+
+-c
+
+curl -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer&att=stateName' |grep -iq 'stateName *= *STARTED'
+----
+
+
+===== Exposed Ports
+
+|=============
+|Deployments | Name  | Port  | Protocol
+
+.2+| `${APPLICATION_NAME}`
+| `http`  |  `8080`  |  `TCP` 
+| `https`  |  `8443`  |  `TCP` 
+.1+| `${APPLICATION_NAME}-mongodb`
+| --  |  `27017`  |  `TCP` 
+|=============
+
+===== Image Environment Variables
+
+|=======================================================================
+|Deployment |Variable name |Description |Example value
+
+.15+| `${APPLICATION_NAME}`
+| `DB_SERVICE_PREFIX_MAPPING`  |  --  |  `${APPLICATION_NAME}-mongodb=DB` 
+| `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb`  |  `${DB_JNDI}` 
+| `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `DB_DATABASE`  |  `Database name`  |  `${DB_DATABASE}` 
+| `DB_ADMIN_PASSWORD`  |  `Database admin password`  |  `${DB_ADMIN_PASSWORD}` 
+| `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `JWS_HTTPS_CERTIFICATE_DIR`  |  `The name of the certificate file within the secret`  |  `/etc/jws-secret-volume` 
+| `JWS_HTTPS_CERTIFICATE`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE}` 
+| `JWS_HTTPS_CERTIFICATE_KEY`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE_KEY}` 
+| `JWS_HTTPS_CERTIFICATE_PASSWORD`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE_PASSWORD}` 
+| `JWS_ADMIN_USERNAME`  |  `JWS Admin User`  |  `${JWS_ADMIN_USERNAME}` 
+| `JWS_ADMIN_PASSWORD`  |  `JWS Admin Password`  |  `${JWS_ADMIN_PASSWORD}` 
+.7+| `${APPLICATION_NAME}-mongodb`
+| `MONGODB_USER`  |  --  |  `${DB_USERNAME}` 
+| `MONGODB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `MONGODB_DATABASE`  |  `Database name`  |  `${DB_DATABASE}` 
+| `MONGODB_ADMIN_PASSWORD`  |  `Database admin password`  |  `${DB_ADMIN_PASSWORD}` 
+| `MONGODB_NOPREALLOC`  |  `Disable data file preallocation.`  |  `${MONGODB_NOPREALLOC}` 
+| `MONGODB_SMALLFILES`  |  `Set MongoDB to use a smaller default data file size.`  |  `${MONGODB_SMALLFILES}` 
+| `MONGODB_QUIET`  |  `Runs MongoDB in a quiet mode that attempts to limit the amount of output.`  |  `${MONGODB_QUIET}` 
+|=======================================================================
+
+=====  Volumes
+
+|=============
+|Deployment |Name  | mountPath | Purpose | readOnly 
+
+| `${APPLICATION_NAME}`  |  `jws-certificate-volume`  |  `/etc/jws-secret-volume`  |  `ssl certs`  |  `True` 
+| `${APPLICATION_NAME}-mongodb`  |  `${APPLICATION_NAME}-mongodb-pvol`  |  `/var/lib/mongodb/data`  |  `mongodb`  |  `false` 
+|=============
+
+=== External Dependencies
+
+==== Volume Claims
+
+A `PersistentVolume` object is a storage resource in an OpenShift cluster. Storage is provisioned by an administrator
+by creating `PersistentVolume` objects from sources such as GCE Persistent Disks, AWS Elastic Block Stores (EBS), and NFS mounts.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/persistent_volumes.html#overview[Openshift documentation] for
+more information.
+
+|=============
+|Name | Access Mode
+
+| `${APPLICATION_NAME}-mongodb-claim`  |  `ReadWriteOnce` 
+|=============
+
+==== Secrets 
+
+This template requires https://github.com/jboss-openshift/application-templates/blob/master/secrets/jws-app-secrets.json[jws-app-secrets.json] to be installed for the application to run.

--- a/docs/templates/webserver/jws-tomcat8-mongodb-sti.adoc
+++ b/docs/templates/webserver/jws-tomcat8-mongodb-sti.adoc
@@ -1,0 +1,223 @@
+= jws-tomcat8-mongodb-sti
+
+Application template for JWS MongoDB applications built using STI.
+
+toc::[levels=2]
+
+== Parameters
+
+Templates allow you to define parameters which take on a value. That value is then substituted wherever the parameter is referenced.
+References can be defined in any text field in the objects list field. Refer to the
+https://docs.openshift.org/latest/architecture/core_concepts/templates.html#parameters[Openshift documentation] for more information.
+
+|=======================================================================
+|Variable name |Image Environment Variable |Description |Example value
+
+| `JWS_RELEASE`  |  --  |  `JWS Release version, e.g. 3.0, 2.1, etc.`  |  `3.0` 
+| `APPLICATION_NAME`  |  --  |  `The name for the application.`  |  `jws-app` 
+| `APPLICATION_HOSTNAME`  |  --  |  `Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>`  |  `secure-app.test.router.default.local` 
+| `GIT_URI`  |  --  |  `Git source URI for application`  |  ``https://github.com/jboss-openshift/openshift-examples.git` 
+| `GIT_REF`  |  --  |  `Git branch/tag reference`  |  `master` 
+| `GIT_CONTEXT_DIR`  |  --  |  `Path within Git project to build; empty for root project directory.`  |  `helloworld` 
+| `DB_JNDI`  |  `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb`  |  `${DB_JNDI}` 
+| `DB_DATABASE`  |  `DB_DATABASE`  |  `Database name`  |  `root` 
+| `JWS_HTTPS_SECRET`  |  --  |  `The name of the secret containing the certificate files`  |  `jws-app-secret` 
+| `JWS_HTTPS_CERTIFICATE`  |  `JWS_HTTPS_CERTIFICATE_DIR`  |  `The name of the certificate file within the secret`  |  `server.crt` 
+| `JWS_HTTPS_CERTIFICATE_KEY`  |  `JWS_HTTPS_CERTIFICATE`  |  `The name of the certificate key file within the secret`  |  `server.key` 
+| `JWS_HTTPS_CERTIFICATE_PASSWORD`  |  `JWS_HTTPS_CERTIFICATE`  |  `The certificate password`  |  `${JWS_HTTPS_CERTIFICATE}` 
+| `DB_MIN_POOL_SIZE`  |  `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `MONGODB_NOPREALLOC`  |  `MONGODB_NOPREALLOC`  |  `Disable data file preallocation.`  |  `${MONGODB_NOPREALLOC}` 
+| `MONGODB_SMALLFILES`  |  `MONGODB_SMALLFILES`  |  `Set MongoDB to use a smaller default data file size.`  |  `${MONGODB_SMALLFILES}` 
+| `MONGODB_QUIET`  |  `MONGODB_QUIET`  |  `Runs MongoDB in a quiet mode that attempts to limit the amount of output.`  |  `${MONGODB_QUIET}` 
+| `DB_USERNAME`  |  `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `DB_ADMIN_PASSWORD`  |  `DB_ADMIN_PASSWORD`  |  `Database admin password`  |  `${DB_ADMIN_PASSWORD}` 
+| `JWS_ADMIN_USERNAME`  |  `JWS_ADMIN_USERNAME`  |  `JWS Admin User`  |  `${JWS_ADMIN_USERNAME}` 
+| `JWS_ADMIN_PASSWORD`  |  `JWS_ADMIN_PASSWORD`  |  `JWS Admin Password`  |  `${JWS_ADMIN_PASSWORD}` 
+| `GITHUB_TRIGGER_SECRET`  |  --  |  `GitHub trigger secret`  |  `secret101` 
+| `GENERIC_TRIGGER_SECRET`  |  --  |  `Generic build trigger secret`  |  `secret101` 
+| `IMAGE_STREAM_NAMESPACE`  |  --  |  `Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.`  |  `openshift` 
+|=======================================================================
+
+== Objects
+
+The CLI supports various object types. A list of these object types as well as their abbreviations
+can be found in the https://docs.openshift.org/latest/cli_reference/basic_cli_operations.html#object-types[Openshift documentation].
+
+=== Services
+
+A service is an abstraction which defines a logical set of pods and a policy by which to access them. Refer to the
+https://cloud.google.com/container-engine/docs/services/[container-engine documentation] for more information.
+
+|=============
+|Service        |Port  | Description
+
+| `${APPLICATION_NAME}`  |  `8080`  |  `The web server's http port.` 
+| `secure-${APPLICATION_NAME}`  |  `8443`  |  `The web server's https port.` 
+| `${APPLICATION_NAME}-mongodb`  |  `27017`  |  `The database server's port.` 
+|=============
+
+=== Routes
+
+A route is a way to expose a service by giving it an externally-reachable hostname such as `www.example.com`. A defined route and the endpoints
+identified by its service can be consumed by a router to provide named connectivity from external clients to your applications. Each route consists
+of a route name, service selector, and (optionally) security configuration. Refer to the
+https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html[Openshift documentation] for more information.
+
+|=============
+| Service    | Security | Hostname
+
+| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+|=============
+
+=== Build Configurations
+
+A `buildConfig` describes a single build definition and a set of triggers for when a new build should be created.
+A `buildConfig` is a REST object, which can be used in a POST to the API server to create a new instance. Refer to
+the https://docs.openshift.com/enterprise/3.0/dev_guide/builds.html#defining-a-buildconfig[Openshift documentation]
+for more information.
+
+|=============
+| STI image  | link | Build output | BuildTriggers and Settings
+
+| `jboss-webserver3-tomcat8-openshift:${JWS_RELEASE}`  |  ` link:../../webserver/tomcat8-openshift{outfilesuffix}[`jboss-webserver/tomcat8-openshift`]`  |  `${APPLICATION_NAME}:latest`  |  `Generic, GitHub, ImageChange` 
+|=============
+
+=== Deployment Configurations
+
+A deployment in OpenShift is a replication controller based on a user defined template called a deployment configuration. Deployments are created manually or in response to triggered events.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/deployments.html#creating-a-deployment-configuration[Openshift documentation] for more information.
+
+==== Triggers
+
+A trigger drives the creation of new deployments in response to events, both inside and outside OpenShift. Refer to the
+https://access.redhat.com/beta/documentation/en/openshift-enterprise-30-developer-guide#triggers[Openshift documentation] for more information.
+
+|============
+|Deployment | Triggers
+
+| `${APPLICATION_NAME}`  |  `ImageChange` 
+| `${APPLICATION_NAME}-mongodb`  |  `ImageChange` 
+|============
+
+==== Replicas
+
+A replication controller ensures that a specified number of pod "replicas" are running at any one time.
+If there are too many, the replication controller kills some pods. If there are too few, it starts more.
+Refer to the https://cloud.google.com/container-engine/docs/replicationcontrollers/[container-engine documentation]
+for more information.
+
+|============
+|Deployment | Replicas
+
+| `${APPLICATION_NAME}`  |  `1` 
+| `${APPLICATION_NAME}-mongodb`  |  `1` 
+|============
+
+==== Pod Template
+
+===== Service Accounts
+
+Service accounts are API objects that exist within each project. They can be created or deleted like any other API object. Refer to the
+https://docs.openshift.com/enterprise/3.0/dev_guide/service_accounts.html#managing-service-accounts[Openshift documentation] for more
+information.
+
+|============
+|Deployment | Service Account
+
+| `${APPLICATION_NAME}`  |  `jws-service-account` 
+|============
+
+===== Image
+
+|============
+|Deployment | Image
+
+| `${APPLICATION_NAME}`  |  `${APPLICATION_NAME}` 
+| `${APPLICATION_NAME}-mongodb`  |  `mongodb` 
+|============
+
+===== Readiness Probe
+
+
+====== ${APPLICATION_NAME}
+----
+/bin/bash
+
+-c
+
+curl -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer&att=stateName' |grep -iq 'stateName *= *STARTED'
+----
+
+
+===== Exposed Ports
+
+|=============
+|Deployments | Name  | Port  | Protocol
+
+.2+| `${APPLICATION_NAME}`
+| `http`  |  `8080`  |  `TCP` 
+| `https`  |  `8443`  |  `TCP` 
+.1+| `${APPLICATION_NAME}-mongodb`
+| --  |  `27017`  |  `TCP` 
+|=============
+
+===== Image Environment Variables
+
+|=======================================================================
+|Deployment |Variable name |Description |Example value
+
+.15+| `${APPLICATION_NAME}`
+| `DB_SERVICE_PREFIX_MAPPING`  |  --  |  `${APPLICATION_NAME}-mongodb=DB` 
+| `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb`  |  `${DB_JNDI}` 
+| `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `DB_DATABASE`  |  `Database name`  |  `${DB_DATABASE}` 
+| `DB_ADMIN_PASSWORD`  |  `Database admin password`  |  `${DB_ADMIN_PASSWORD}` 
+| `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `JWS_HTTPS_CERTIFICATE_DIR`  |  `The name of the certificate file within the secret`  |  `/etc/jws-secret-volume` 
+| `JWS_HTTPS_CERTIFICATE`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE}` 
+| `JWS_HTTPS_CERTIFICATE_KEY`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE_KEY}` 
+| `JWS_HTTPS_CERTIFICATE_PASSWORD`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE_PASSWORD}` 
+| `JWS_ADMIN_USERNAME`  |  `JWS Admin User`  |  `${JWS_ADMIN_USERNAME}` 
+| `JWS_ADMIN_PASSWORD`  |  `JWS Admin Password`  |  `${JWS_ADMIN_PASSWORD}` 
+.7+| `${APPLICATION_NAME}-mongodb`
+| `MONGODB_USER`  |  --  |  `${DB_USERNAME}` 
+| `MONGODB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `MONGODB_DATABASE`  |  `Database name`  |  `${DB_DATABASE}` 
+| `MONGODB_ADMIN_PASSWORD`  |  `Database admin password`  |  `${DB_ADMIN_PASSWORD}` 
+| `MONGODB_NOPREALLOC`  |  `Disable data file preallocation.`  |  `${MONGODB_NOPREALLOC}` 
+| `MONGODB_SMALLFILES`  |  `Set MongoDB to use a smaller default data file size.`  |  `${MONGODB_SMALLFILES}` 
+| `MONGODB_QUIET`  |  `Runs MongoDB in a quiet mode that attempts to limit the amount of output.`  |  `${MONGODB_QUIET}` 
+|=======================================================================
+
+=====  Volumes
+
+|=============
+|Deployment |Name  | mountPath | Purpose | readOnly 
+
+| `${APPLICATION_NAME}`  |  `jws-certificate-volume`  |  `/etc/jws-secret-volume`  |  `ssl certs`  |  `True` 
+|=============
+
+=== External Dependencies
+
+==== Volume Claims
+
+A `PersistentVolume` object is a storage resource in an OpenShift cluster. Storage is provisioned by an administrator
+by creating `PersistentVolume` objects from sources such as GCE Persistent Disks, AWS Elastic Block Stores (EBS), and NFS mounts.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/persistent_volumes.html#overview[Openshift documentation] for
+more information.
+
+|=============
+|Name | Access Mode
+
+|=============
+
+==== Secrets 
+
+This template requires https://github.com/jboss-openshift/application-templates/blob/master/secrets/jws-app-secrets.json[jws-app-secrets.json] to be installed for the application to run.

--- a/docs/templates/webserver/jws-tomcat8-mysql-persistent-sti.adoc
+++ b/docs/templates/webserver/jws-tomcat8-mysql-persistent-sti.adoc
@@ -1,0 +1,227 @@
+= jws-tomcat8-mysql-persistent-sti
+
+Application template for JWS MySQL applications with persistent storage built using STI.
+
+toc::[levels=2]
+
+== Parameters
+
+Templates allow you to define parameters which take on a value. That value is then substituted wherever the parameter is referenced.
+References can be defined in any text field in the objects list field. Refer to the
+https://docs.openshift.org/latest/architecture/core_concepts/templates.html#parameters[Openshift documentation] for more information.
+
+|=======================================================================
+|Variable name |Image Environment Variable |Description |Example value
+
+| `JWS_RELEASE`  |  --  |  `JWS Release version, e.g. 3.0, 2.1, etc.`  |  `3.0` 
+| `APPLICATION_NAME`  |  --  |  `The name for the application.`  |  `jws-app` 
+| `APPLICATION_HOSTNAME`  |  --  |  `Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>`  |  `secure-app.test.router.default.local` 
+| `GIT_URI`  |  --  |  `Git source URI for application`  |  ``https://github.com/jboss-openshift/openshift-examples.git` 
+| `GIT_REF`  |  --  |  `Git branch/tag reference`  |  `master` 
+| `GIT_CONTEXT_DIR`  |  --  |  `Path within Git project to build; empty for root project directory.`  |  `helloworld` 
+| `DB_JNDI`  |  `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb`  |  `${DB_JNDI}` 
+| `DB_DATABASE`  |  `DB_DATABASE`  |  `Database name`  |  `root` 
+| `VOLUME_CAPACITY`  |  --  |  `Size of persistent storage for database volume.`  |  `512Mi` 
+| `JWS_HTTPS_SECRET`  |  --  |  `The name of the secret containing the certificate files`  |  `jws-app-secret` 
+| `JWS_HTTPS_CERTIFICATE`  |  `JWS_HTTPS_CERTIFICATE_DIR`  |  `The name of the certificate file within the secret`  |  `server.crt` 
+| `JWS_HTTPS_CERTIFICATE_KEY`  |  `JWS_HTTPS_CERTIFICATE`  |  `The name of the certificate key file within the secret`  |  `server.key` 
+| `JWS_HTTPS_CERTIFICATE_PASSWORD`  |  `JWS_HTTPS_CERTIFICATE`  |  `The certificate password`  |  `${JWS_HTTPS_CERTIFICATE}` 
+| `DB_MIN_POOL_SIZE`  |  `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `MYSQL_LOWER_CASE_TABLE_NAMES`  |  `MYSQL_LOWER_CASE_TABLE_NAMES`  |  `Sets how the table names are stored and compared.`  |  `${MYSQL_LOWER_CASE_TABLE_NAMES}` 
+| `MYSQL_MAX_CONNECTIONS`  |  `MYSQL_MAX_CONNECTIONS`  |  `The maximum permitted number of simultaneous client connections.`  |  `${MYSQL_MAX_CONNECTIONS}` 
+| `MYSQL_FT_MIN_WORD_LEN`  |  `MYSQL_FT_MIN_WORD_LEN`  |  `The minimum length of the word to be included in a FULLTEXT index.`  |  `${MYSQL_FT_MIN_WORD_LEN}` 
+| `MYSQL_FT_MAX_WORD_LEN`  |  `MYSQL_FT_MAX_WORD_LEN`  |  `The maximum length of the word to be included in a FULLTEXT index.`  |  `${MYSQL_FT_MAX_WORD_LEN}` 
+| `MYSQL_AIO`  |  `MYSQL_AIO`  |  `Controls the innodb_use_native_aio setting value if the native AIO is broken.`  |  `${MYSQL_AIO}` 
+| `DB_USERNAME`  |  `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `JWS_ADMIN_USERNAME`  |  `JWS_ADMIN_USERNAME`  |  `JWS Admin User`  |  `${JWS_ADMIN_USERNAME}` 
+| `JWS_ADMIN_PASSWORD`  |  `JWS_ADMIN_PASSWORD`  |  `JWS Admin Password`  |  `${JWS_ADMIN_PASSWORD}` 
+| `GITHUB_TRIGGER_SECRET`  |  --  |  `GitHub trigger secret`  |  `secret101` 
+| `GENERIC_TRIGGER_SECRET`  |  --  |  `Generic build trigger secret`  |  `secret101` 
+| `IMAGE_STREAM_NAMESPACE`  |  --  |  `Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.`  |  `openshift` 
+|=======================================================================
+
+== Objects
+
+The CLI supports various object types. A list of these object types as well as their abbreviations
+can be found in the https://docs.openshift.org/latest/cli_reference/basic_cli_operations.html#object-types[Openshift documentation].
+
+=== Services
+
+A service is an abstraction which defines a logical set of pods and a policy by which to access them. Refer to the
+https://cloud.google.com/container-engine/docs/services/[container-engine documentation] for more information.
+
+|=============
+|Service        |Port  | Description
+
+| `${APPLICATION_NAME}`  |  `8080`  |  `The web server's http port.` 
+| `secure-${APPLICATION_NAME}`  |  `8443`  |  `The web server's https port.` 
+| `${APPLICATION_NAME}-mysql`  |  `3306`  |  `The database server's port.` 
+|=============
+
+=== Routes
+
+A route is a way to expose a service by giving it an externally-reachable hostname such as `www.example.com`. A defined route and the endpoints
+identified by its service can be consumed by a router to provide named connectivity from external clients to your applications. Each route consists
+of a route name, service selector, and (optionally) security configuration. Refer to the
+https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html[Openshift documentation] for more information.
+
+|=============
+| Service    | Security | Hostname
+
+| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+|=============
+
+=== Build Configurations
+
+A `buildConfig` describes a single build definition and a set of triggers for when a new build should be created.
+A `buildConfig` is a REST object, which can be used in a POST to the API server to create a new instance. Refer to
+the https://docs.openshift.com/enterprise/3.0/dev_guide/builds.html#defining-a-buildconfig[Openshift documentation]
+for more information.
+
+|=============
+| STI image  | link | Build output | BuildTriggers and Settings
+
+| `jboss-webserver3-tomcat8-openshift:${JWS_RELEASE}`  |  ` link:../../webserver/tomcat8-openshift{outfilesuffix}[`jboss-webserver/tomcat8-openshift`]`  |  `${APPLICATION_NAME}:latest`  |  `Generic, GitHub, ImageChange` 
+|=============
+
+=== Deployment Configurations
+
+A deployment in OpenShift is a replication controller based on a user defined template called a deployment configuration. Deployments are created manually or in response to triggered events.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/deployments.html#creating-a-deployment-configuration[Openshift documentation] for more information.
+
+==== Triggers
+
+A trigger drives the creation of new deployments in response to events, both inside and outside OpenShift. Refer to the
+https://access.redhat.com/beta/documentation/en/openshift-enterprise-30-developer-guide#triggers[Openshift documentation] for more information.
+
+|============
+|Deployment | Triggers
+
+| `${APPLICATION_NAME}`  |  `ImageChange` 
+| `${APPLICATION_NAME}-mysql`  |  `ImageChange` 
+|============
+
+==== Replicas
+
+A replication controller ensures that a specified number of pod "replicas" are running at any one time.
+If there are too many, the replication controller kills some pods. If there are too few, it starts more.
+Refer to the https://cloud.google.com/container-engine/docs/replicationcontrollers/[container-engine documentation]
+for more information.
+
+|============
+|Deployment | Replicas
+
+| `${APPLICATION_NAME}`  |  `1` 
+| `${APPLICATION_NAME}-mysql`  |  `1` 
+|============
+
+==== Pod Template
+
+===== Service Accounts
+
+Service accounts are API objects that exist within each project. They can be created or deleted like any other API object. Refer to the
+https://docs.openshift.com/enterprise/3.0/dev_guide/service_accounts.html#managing-service-accounts[Openshift documentation] for more
+information.
+
+|============
+|Deployment | Service Account
+
+| `${APPLICATION_NAME}`  |  `jws-service-account` 
+|============
+
+===== Image
+
+|============
+|Deployment | Image
+
+| `${APPLICATION_NAME}`  |  `${APPLICATION_NAME}` 
+| `${APPLICATION_NAME}-mysql`  |  `mysql` 
+|============
+
+===== Readiness Probe
+
+
+====== ${APPLICATION_NAME}
+----
+/bin/bash
+
+-c
+
+curl -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer&att=stateName' |grep -iq 'stateName *= *STARTED'
+----
+
+
+===== Exposed Ports
+
+|=============
+|Deployments | Name  | Port  | Protocol
+
+.2+| `${APPLICATION_NAME}`
+| `http`  |  `8080`  |  `TCP` 
+| `https`  |  `8443`  |  `TCP` 
+.1+| `${APPLICATION_NAME}-mysql`
+| --  |  `3306`  |  `TCP` 
+|=============
+
+===== Image Environment Variables
+
+|=======================================================================
+|Deployment |Variable name |Description |Example value
+
+.14+| `${APPLICATION_NAME}`
+| `DB_SERVICE_PREFIX_MAPPING`  |  --  |  `${APPLICATION_NAME}-mysql=DB` 
+| `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb`  |  `${DB_JNDI}` 
+| `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `DB_DATABASE`  |  `Database name`  |  `${DB_DATABASE}` 
+| `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `JWS_HTTPS_CERTIFICATE_DIR`  |  `The name of the certificate file within the secret`  |  `/etc/jws-secret-volume` 
+| `JWS_HTTPS_CERTIFICATE`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE}` 
+| `JWS_HTTPS_CERTIFICATE_KEY`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE_KEY}` 
+| `JWS_HTTPS_CERTIFICATE_PASSWORD`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE_PASSWORD}` 
+| `JWS_ADMIN_USERNAME`  |  `JWS Admin User`  |  `${JWS_ADMIN_USERNAME}` 
+| `JWS_ADMIN_PASSWORD`  |  `JWS Admin Password`  |  `${JWS_ADMIN_PASSWORD}` 
+.8+| `${APPLICATION_NAME}-mysql`
+| `MYSQL_USER`  |  --  |  `${DB_USERNAME}` 
+| `MYSQL_PASSWORD`  |  --  |  `${DB_PASSWORD}` 
+| `MYSQL_DATABASE`  |  --  |  `${DB_DATABASE}` 
+| `MYSQL_LOWER_CASE_TABLE_NAMES`  |  `Sets how the table names are stored and compared.`  |  `${MYSQL_LOWER_CASE_TABLE_NAMES}` 
+| `MYSQL_MAX_CONNECTIONS`  |  `The maximum permitted number of simultaneous client connections.`  |  `${MYSQL_MAX_CONNECTIONS}` 
+| `MYSQL_FT_MIN_WORD_LEN`  |  `The minimum length of the word to be included in a FULLTEXT index.`  |  `${MYSQL_FT_MIN_WORD_LEN}` 
+| `MYSQL_FT_MAX_WORD_LEN`  |  `The maximum length of the word to be included in a FULLTEXT index.`  |  `${MYSQL_FT_MAX_WORD_LEN}` 
+| `MYSQL_AIO`  |  `Controls the innodb_use_native_aio setting value if the native AIO is broken.`  |  `${MYSQL_AIO}` 
+|=======================================================================
+
+=====  Volumes
+
+|=============
+|Deployment |Name  | mountPath | Purpose | readOnly 
+
+| `${APPLICATION_NAME}`  |  `jws-certificate-volume`  |  `/etc/jws-secret-volume`  |  `ssl certs`  |  `True` 
+| `${APPLICATION_NAME}-mysql`  |  `${APPLICATION_NAME}-mysql-pvol`  |  `/var/lib/mysql/data`  |  `mysql`  |  `false` 
+|=============
+
+=== External Dependencies
+
+==== Volume Claims
+
+A `PersistentVolume` object is a storage resource in an OpenShift cluster. Storage is provisioned by an administrator
+by creating `PersistentVolume` objects from sources such as GCE Persistent Disks, AWS Elastic Block Stores (EBS), and NFS mounts.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/persistent_volumes.html#overview[Openshift documentation] for
+more information.
+
+|=============
+|Name | Access Mode
+
+| `${APPLICATION_NAME}-mysql-claim`  |  `ReadWriteOnce` 
+|=============
+
+==== Secrets 
+
+This template requires https://github.com/jboss-openshift/application-templates/blob/master/secrets/jws-app-secrets.json[jws-app-secrets.json] to be installed for the application to run.

--- a/docs/templates/webserver/jws-tomcat8-mysql-sti.adoc
+++ b/docs/templates/webserver/jws-tomcat8-mysql-sti.adoc
@@ -1,0 +1,224 @@
+= jws-tomcat8-mysql-sti
+
+Application template for JWS MySQL applications built using STI.
+
+toc::[levels=2]
+
+== Parameters
+
+Templates allow you to define parameters which take on a value. That value is then substituted wherever the parameter is referenced.
+References can be defined in any text field in the objects list field. Refer to the
+https://docs.openshift.org/latest/architecture/core_concepts/templates.html#parameters[Openshift documentation] for more information.
+
+|=======================================================================
+|Variable name |Image Environment Variable |Description |Example value
+
+| `JWS_RELEASE`  |  --  |  `JWS Release version, e.g. 3.0, 2.1, etc.`  |  `3.0` 
+| `APPLICATION_NAME`  |  --  |  `The name for the application.`  |  `jws-app` 
+| `APPLICATION_HOSTNAME`  |  --  |  `Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>`  |  `secure-app.test.router.default.local` 
+| `GIT_URI`  |  --  |  `Git source URI for application`  |  ``https://github.com/jboss-openshift/openshift-examples.git` 
+| `GIT_REF`  |  --  |  `Git branch/tag reference`  |  `master` 
+| `GIT_CONTEXT_DIR`  |  --  |  `Path within Git project to build; empty for root project directory.`  |  `helloworld` 
+| `DB_JNDI`  |  `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb`  |  `${DB_JNDI}` 
+| `DB_DATABASE`  |  `DB_DATABASE`  |  `Database name`  |  `root` 
+| `JWS_HTTPS_SECRET`  |  --  |  `The name of the secret containing the certificate files`  |  `jws-app-secret` 
+| `JWS_HTTPS_CERTIFICATE`  |  `JWS_HTTPS_CERTIFICATE_DIR`  |  `The name of the certificate file within the secret`  |  `server.crt` 
+| `JWS_HTTPS_CERTIFICATE_KEY`  |  `JWS_HTTPS_CERTIFICATE`  |  `The name of the certificate key file within the secret`  |  `server.key` 
+| `JWS_HTTPS_CERTIFICATE_PASSWORD`  |  `JWS_HTTPS_CERTIFICATE`  |  `The certificate password`  |  `${JWS_HTTPS_CERTIFICATE}` 
+| `DB_MIN_POOL_SIZE`  |  `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `MYSQL_LOWER_CASE_TABLE_NAMES`  |  `MYSQL_LOWER_CASE_TABLE_NAMES`  |  `Sets how the table names are stored and compared.`  |  `${MYSQL_LOWER_CASE_TABLE_NAMES}` 
+| `MYSQL_MAX_CONNECTIONS`  |  `MYSQL_MAX_CONNECTIONS`  |  `The maximum permitted number of simultaneous client connections.`  |  `${MYSQL_MAX_CONNECTIONS}` 
+| `MYSQL_FT_MIN_WORD_LEN`  |  `MYSQL_FT_MIN_WORD_LEN`  |  `The minimum length of the word to be included in a FULLTEXT index.`  |  `${MYSQL_FT_MIN_WORD_LEN}` 
+| `MYSQL_FT_MAX_WORD_LEN`  |  `MYSQL_FT_MAX_WORD_LEN`  |  `The maximum length of the word to be included in a FULLTEXT index.`  |  `${MYSQL_FT_MAX_WORD_LEN}` 
+| `MYSQL_AIO`  |  `MYSQL_AIO`  |  `Controls the innodb_use_native_aio setting value if the native AIO is broken.`  |  `${MYSQL_AIO}` 
+| `DB_USERNAME`  |  `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `JWS_ADMIN_USERNAME`  |  `JWS_ADMIN_USERNAME`  |  `JWS Admin User`  |  `${JWS_ADMIN_USERNAME}` 
+| `JWS_ADMIN_PASSWORD`  |  `JWS_ADMIN_PASSWORD`  |  `JWS Admin Password`  |  `${JWS_ADMIN_PASSWORD}` 
+| `GITHUB_TRIGGER_SECRET`  |  --  |  `GitHub trigger secret`  |  `secret101` 
+| `GENERIC_TRIGGER_SECRET`  |  --  |  `Generic build trigger secret`  |  `secret101` 
+| `IMAGE_STREAM_NAMESPACE`  |  --  |  `Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.`  |  `openshift` 
+|=======================================================================
+
+== Objects
+
+The CLI supports various object types. A list of these object types as well as their abbreviations
+can be found in the https://docs.openshift.org/latest/cli_reference/basic_cli_operations.html#object-types[Openshift documentation].
+
+=== Services
+
+A service is an abstraction which defines a logical set of pods and a policy by which to access them. Refer to the
+https://cloud.google.com/container-engine/docs/services/[container-engine documentation] for more information.
+
+|=============
+|Service        |Port  | Description
+
+| `${APPLICATION_NAME}`  |  `8080`  |  `The web server's http port.` 
+| `secure-${APPLICATION_NAME}`  |  `8443`  |  `The web server's https port.` 
+| `${APPLICATION_NAME}-mysql`  |  `3306`  |  `The database server's port.` 
+|=============
+
+=== Routes
+
+A route is a way to expose a service by giving it an externally-reachable hostname such as `www.example.com`. A defined route and the endpoints
+identified by its service can be consumed by a router to provide named connectivity from external clients to your applications. Each route consists
+of a route name, service selector, and (optionally) security configuration. Refer to the
+https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html[Openshift documentation] for more information.
+
+|=============
+| Service    | Security | Hostname
+
+| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+|=============
+
+=== Build Configurations
+
+A `buildConfig` describes a single build definition and a set of triggers for when a new build should be created.
+A `buildConfig` is a REST object, which can be used in a POST to the API server to create a new instance. Refer to
+the https://docs.openshift.com/enterprise/3.0/dev_guide/builds.html#defining-a-buildconfig[Openshift documentation]
+for more information.
+
+|=============
+| STI image  | link | Build output | BuildTriggers and Settings
+
+| `jboss-webserver3-tomcat8-openshift:${JWS_RELEASE}`  |  ` link:../../webserver/tomcat8-openshift{outfilesuffix}[`jboss-webserver/tomcat8-openshift`]`  |  `${APPLICATION_NAME}:latest`  |  `Generic, GitHub, ImageChange` 
+|=============
+
+=== Deployment Configurations
+
+A deployment in OpenShift is a replication controller based on a user defined template called a deployment configuration. Deployments are created manually or in response to triggered events.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/deployments.html#creating-a-deployment-configuration[Openshift documentation] for more information.
+
+==== Triggers
+
+A trigger drives the creation of new deployments in response to events, both inside and outside OpenShift. Refer to the
+https://access.redhat.com/beta/documentation/en/openshift-enterprise-30-developer-guide#triggers[Openshift documentation] for more information.
+
+|============
+|Deployment | Triggers
+
+| `${APPLICATION_NAME}`  |  `ImageChange` 
+| `${APPLICATION_NAME}-mysql`  |  `ImageChange` 
+|============
+
+==== Replicas
+
+A replication controller ensures that a specified number of pod "replicas" are running at any one time.
+If there are too many, the replication controller kills some pods. If there are too few, it starts more.
+Refer to the https://cloud.google.com/container-engine/docs/replicationcontrollers/[container-engine documentation]
+for more information.
+
+|============
+|Deployment | Replicas
+
+| `${APPLICATION_NAME}`  |  `1` 
+| `${APPLICATION_NAME}-mysql`  |  `1` 
+|============
+
+==== Pod Template
+
+===== Service Accounts
+
+Service accounts are API objects that exist within each project. They can be created or deleted like any other API object. Refer to the
+https://docs.openshift.com/enterprise/3.0/dev_guide/service_accounts.html#managing-service-accounts[Openshift documentation] for more
+information.
+
+|============
+|Deployment | Service Account
+
+| `${APPLICATION_NAME}`  |  `jws-service-account` 
+|============
+
+===== Image
+
+|============
+|Deployment | Image
+
+| `${APPLICATION_NAME}`  |  `${APPLICATION_NAME}` 
+| `${APPLICATION_NAME}-mysql`  |  `mysql` 
+|============
+
+===== Readiness Probe
+
+
+====== ${APPLICATION_NAME}
+----
+/bin/bash
+
+-c
+
+curl -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer&att=stateName' |grep -iq 'stateName *= *STARTED'
+----
+
+
+===== Exposed Ports
+
+|=============
+|Deployments | Name  | Port  | Protocol
+
+.2+| `${APPLICATION_NAME}`
+| `http`  |  `8080`  |  `TCP` 
+| `https`  |  `8443`  |  `TCP` 
+.1+| `${APPLICATION_NAME}-mysql`
+| --  |  `3306`  |  `TCP` 
+|=============
+
+===== Image Environment Variables
+
+|=======================================================================
+|Deployment |Variable name |Description |Example value
+
+.14+| `${APPLICATION_NAME}`
+| `DB_SERVICE_PREFIX_MAPPING`  |  --  |  `${APPLICATION_NAME}-mysql=DB` 
+| `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb`  |  `${DB_JNDI}` 
+| `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `DB_DATABASE`  |  `Database name`  |  `${DB_DATABASE}` 
+| `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `JWS_HTTPS_CERTIFICATE_DIR`  |  `The name of the certificate file within the secret`  |  `/etc/jws-secret-volume` 
+| `JWS_HTTPS_CERTIFICATE`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE}` 
+| `JWS_HTTPS_CERTIFICATE_KEY`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE_KEY}` 
+| `JWS_HTTPS_CERTIFICATE_PASSWORD`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE_PASSWORD}` 
+| `JWS_ADMIN_USERNAME`  |  `JWS Admin User`  |  `${JWS_ADMIN_USERNAME}` 
+| `JWS_ADMIN_PASSWORD`  |  `JWS Admin Password`  |  `${JWS_ADMIN_PASSWORD}` 
+.8+| `${APPLICATION_NAME}-mysql`
+| `MYSQL_USER`  |  --  |  `${DB_USERNAME}` 
+| `MYSQL_PASSWORD`  |  --  |  `${DB_PASSWORD}` 
+| `MYSQL_DATABASE`  |  --  |  `${DB_DATABASE}` 
+| `MYSQL_LOWER_CASE_TABLE_NAMES`  |  `Sets how the table names are stored and compared.`  |  `${MYSQL_LOWER_CASE_TABLE_NAMES}` 
+| `MYSQL_MAX_CONNECTIONS`  |  `The maximum permitted number of simultaneous client connections.`  |  `${MYSQL_MAX_CONNECTIONS}` 
+| `MYSQL_FT_MIN_WORD_LEN`  |  `The minimum length of the word to be included in a FULLTEXT index.`  |  `${MYSQL_FT_MIN_WORD_LEN}` 
+| `MYSQL_FT_MAX_WORD_LEN`  |  `The maximum length of the word to be included in a FULLTEXT index.`  |  `${MYSQL_FT_MAX_WORD_LEN}` 
+| `MYSQL_AIO`  |  `Controls the innodb_use_native_aio setting value if the native AIO is broken.`  |  `${MYSQL_AIO}` 
+|=======================================================================
+
+=====  Volumes
+
+|=============
+|Deployment |Name  | mountPath | Purpose | readOnly 
+
+| `${APPLICATION_NAME}`  |  `jws-certificate-volume`  |  `/etc/jws-secret-volume`  |  `ssl certs`  |  `True` 
+|=============
+
+=== External Dependencies
+
+==== Volume Claims
+
+A `PersistentVolume` object is a storage resource in an OpenShift cluster. Storage is provisioned by an administrator
+by creating `PersistentVolume` objects from sources such as GCE Persistent Disks, AWS Elastic Block Stores (EBS), and NFS mounts.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/persistent_volumes.html#overview[Openshift documentation] for
+more information.
+
+|=============
+|Name | Access Mode
+
+|=============
+
+==== Secrets 
+
+This template requires https://github.com/jboss-openshift/application-templates/blob/master/secrets/jws-app-secrets.json[jws-app-secrets.json] to be installed for the application to run.

--- a/docs/templates/webserver/jws-tomcat8-postgresql-persistent-sti.adoc
+++ b/docs/templates/webserver/jws-tomcat8-postgresql-persistent-sti.adoc
@@ -1,0 +1,221 @@
+= jws-tomcat8-postgresql-persistent-sti
+
+Application template for JWS PostgreSQL applications with persistent storage built using STI.
+
+toc::[levels=2]
+
+== Parameters
+
+Templates allow you to define parameters which take on a value. That value is then substituted wherever the parameter is referenced.
+References can be defined in any text field in the objects list field. Refer to the
+https://docs.openshift.org/latest/architecture/core_concepts/templates.html#parameters[Openshift documentation] for more information.
+
+|=======================================================================
+|Variable name |Image Environment Variable |Description |Example value
+
+| `JWS_RELEASE`  |  --  |  `JWS Release version, e.g. 3.0, 2.1, etc.`  |  `3.0` 
+| `APPLICATION_NAME`  |  --  |  `The name for the application.`  |  `jws-app` 
+| `APPLICATION_HOSTNAME`  |  --  |  `Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>`  |  `secure-app.test.router.default.local` 
+| `GIT_URI`  |  --  |  `Git source URI for application`  |  ``https://github.com/jboss-openshift/openshift-examples.git` 
+| `GIT_REF`  |  --  |  `Git branch/tag reference`  |  `master` 
+| `GIT_CONTEXT_DIR`  |  --  |  `Path within Git project to build; empty for root project directory.`  |  `helloworld` 
+| `DB_JNDI`  |  `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb`  |  `${DB_JNDI}` 
+| `DB_DATABASE`  |  `DB_DATABASE`  |  `Database name`  |  `root` 
+| `VOLUME_CAPACITY`  |  --  |  `Size of persistent storage for database volume.`  |  `512Mi` 
+| `JWS_HTTPS_SECRET`  |  --  |  `The name of the secret containing the certificate files`  |  `jws-app-secret` 
+| `JWS_HTTPS_CERTIFICATE`  |  `JWS_HTTPS_CERTIFICATE_DIR`  |  `The name of the certificate file within the secret`  |  `server.crt` 
+| `JWS_HTTPS_CERTIFICATE_KEY`  |  `JWS_HTTPS_CERTIFICATE`  |  `The name of the certificate key file within the secret`  |  `server.key` 
+| `JWS_HTTPS_CERTIFICATE_PASSWORD`  |  `JWS_HTTPS_CERTIFICATE`  |  `The certificate password`  |  `${JWS_HTTPS_CERTIFICATE}` 
+| `DB_MIN_POOL_SIZE`  |  `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `POSTGRESQL_MAX_CONNECTIONS`  |  `POSTGRESQL_MAX_CONNECTIONS`  |  `The maximum number of client connections allowed. This also sets the maximum number of prepared transactions.`  |  `${POSTGRESQL_MAX_CONNECTIONS}` 
+| `POSTGRESQL_SHARED_BUFFERS`  |  `POSTGRESQL_SHARED_BUFFERS`  |  `Configures how much memory is dedicated to PostgreSQL for caching data.`  |  `${POSTGRESQL_SHARED_BUFFERS}` 
+| `DB_USERNAME`  |  `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `JWS_ADMIN_USERNAME`  |  `JWS_ADMIN_USERNAME`  |  `JWS Admin User`  |  `${JWS_ADMIN_USERNAME}` 
+| `JWS_ADMIN_PASSWORD`  |  `JWS_ADMIN_PASSWORD`  |  `JWS Admin Password`  |  `${JWS_ADMIN_PASSWORD}` 
+| `GITHUB_TRIGGER_SECRET`  |  --  |  `GitHub trigger secret`  |  `secret101` 
+| `GENERIC_TRIGGER_SECRET`  |  --  |  `Generic build trigger secret`  |  `secret101` 
+| `IMAGE_STREAM_NAMESPACE`  |  --  |  `Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.`  |  `openshift` 
+|=======================================================================
+
+== Objects
+
+The CLI supports various object types. A list of these object types as well as their abbreviations
+can be found in the https://docs.openshift.org/latest/cli_reference/basic_cli_operations.html#object-types[Openshift documentation].
+
+=== Services
+
+A service is an abstraction which defines a logical set of pods and a policy by which to access them. Refer to the
+https://cloud.google.com/container-engine/docs/services/[container-engine documentation] for more information.
+
+|=============
+|Service        |Port  | Description
+
+| `${APPLICATION_NAME}`  |  `8080`  |  `The web server's http port.` 
+| `secure-${APPLICATION_NAME}`  |  `8443`  |  `The web server's https port.` 
+| `${APPLICATION_NAME}-postgresql`  |  `5432`  |  `The database server's port.` 
+|=============
+
+=== Routes
+
+A route is a way to expose a service by giving it an externally-reachable hostname such as `www.example.com`. A defined route and the endpoints
+identified by its service can be consumed by a router to provide named connectivity from external clients to your applications. Each route consists
+of a route name, service selector, and (optionally) security configuration. Refer to the
+https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html[Openshift documentation] for more information.
+
+|=============
+| Service    | Security | Hostname
+
+| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+|=============
+
+=== Build Configurations
+
+A `buildConfig` describes a single build definition and a set of triggers for when a new build should be created.
+A `buildConfig` is a REST object, which can be used in a POST to the API server to create a new instance. Refer to
+the https://docs.openshift.com/enterprise/3.0/dev_guide/builds.html#defining-a-buildconfig[Openshift documentation]
+for more information.
+
+|=============
+| STI image  | link | Build output | BuildTriggers and Settings
+
+| `jboss-webserver3-tomcat8-openshift:${JWS_RELEASE}`  |  ` link:../../webserver/tomcat8-openshift{outfilesuffix}[`jboss-webserver/tomcat8-openshift`]`  |  `${APPLICATION_NAME}:latest`  |  `Generic, GitHub, ImageChange` 
+|=============
+
+=== Deployment Configurations
+
+A deployment in OpenShift is a replication controller based on a user defined template called a deployment configuration. Deployments are created manually or in response to triggered events.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/deployments.html#creating-a-deployment-configuration[Openshift documentation] for more information.
+
+==== Triggers
+
+A trigger drives the creation of new deployments in response to events, both inside and outside OpenShift. Refer to the
+https://access.redhat.com/beta/documentation/en/openshift-enterprise-30-developer-guide#triggers[Openshift documentation] for more information.
+
+|============
+|Deployment | Triggers
+
+| `${APPLICATION_NAME}`  |  `ImageChange` 
+| `${APPLICATION_NAME}-postgresql`  |  `ImageChange` 
+|============
+
+==== Replicas
+
+A replication controller ensures that a specified number of pod "replicas" are running at any one time.
+If there are too many, the replication controller kills some pods. If there are too few, it starts more.
+Refer to the https://cloud.google.com/container-engine/docs/replicationcontrollers/[container-engine documentation]
+for more information.
+
+|============
+|Deployment | Replicas
+
+| `${APPLICATION_NAME}`  |  `1` 
+| `${APPLICATION_NAME}-postgresql`  |  `1` 
+|============
+
+==== Pod Template
+
+===== Service Accounts
+
+Service accounts are API objects that exist within each project. They can be created or deleted like any other API object. Refer to the
+https://docs.openshift.com/enterprise/3.0/dev_guide/service_accounts.html#managing-service-accounts[Openshift documentation] for more
+information.
+
+|============
+|Deployment | Service Account
+
+| `${APPLICATION_NAME}`  |  `jws-service-account` 
+|============
+
+===== Image
+
+|============
+|Deployment | Image
+
+| `${APPLICATION_NAME}`  |  `${APPLICATION_NAME}` 
+| `${APPLICATION_NAME}-postgresql`  |  `postgresql` 
+|============
+
+===== Readiness Probe
+
+
+====== ${APPLICATION_NAME}
+----
+/bin/bash
+
+-c
+
+curl -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer&att=stateName' |grep -iq 'stateName *= *STARTED'
+----
+
+
+===== Exposed Ports
+
+|=============
+|Deployments | Name  | Port  | Protocol
+
+.2+| `${APPLICATION_NAME}`
+| `http`  |  `8080`  |  `TCP` 
+| `https`  |  `8443`  |  `TCP` 
+.1+| `${APPLICATION_NAME}-postgresql`
+| --  |  `5432`  |  `TCP` 
+|=============
+
+===== Image Environment Variables
+
+|=======================================================================
+|Deployment |Variable name |Description |Example value
+
+.14+| `${APPLICATION_NAME}`
+| `DB_SERVICE_PREFIX_MAPPING`  |  --  |  `${APPLICATION_NAME}-postgresql=DB` 
+| `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb`  |  `${DB_JNDI}` 
+| `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `DB_DATABASE`  |  `Database name`  |  `${DB_DATABASE}` 
+| `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `JWS_HTTPS_CERTIFICATE_DIR`  |  `The name of the certificate file within the secret`  |  `/etc/jws-secret-volume` 
+| `JWS_HTTPS_CERTIFICATE`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE}` 
+| `JWS_HTTPS_CERTIFICATE_KEY`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE_KEY}` 
+| `JWS_HTTPS_CERTIFICATE_PASSWORD`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE_PASSWORD}` 
+| `JWS_ADMIN_USERNAME`  |  `JWS Admin User`  |  `${JWS_ADMIN_USERNAME}` 
+| `JWS_ADMIN_PASSWORD`  |  `JWS Admin Password`  |  `${JWS_ADMIN_PASSWORD}` 
+.5+| `${APPLICATION_NAME}-postgresql`
+| `POSTGRESQL_USER`  |  --  |  `${DB_USERNAME}` 
+| `POSTGRESQL_PASSWORD`  |  --  |  `${DB_PASSWORD}` 
+| `POSTGRESQL_DATABASE`  |  --  |  `${DB_DATABASE}` 
+| `POSTGRESQL_MAX_CONNECTIONS`  |  `The maximum number of client connections allowed. This also sets the maximum number of prepared transactions.`  |  `${POSTGRESQL_MAX_CONNECTIONS}` 
+| `POSTGRESQL_SHARED_BUFFERS`  |  `Configures how much memory is dedicated to PostgreSQL for caching data.`  |  `${POSTGRESQL_SHARED_BUFFERS}` 
+|=======================================================================
+
+=====  Volumes
+
+|=============
+|Deployment |Name  | mountPath | Purpose | readOnly 
+
+| `${APPLICATION_NAME}`  |  `jws-certificate-volume`  |  `/etc/jws-secret-volume`  |  `ssl certs`  |  `True` 
+| `${APPLICATION_NAME}-postgresql`  |  `${APPLICATION_NAME}-postgresql-pvol`  |  `/var/lib/pgsql/data`  |  `postgresql`  |  `false` 
+|=============
+
+=== External Dependencies
+
+==== Volume Claims
+
+A `PersistentVolume` object is a storage resource in an OpenShift cluster. Storage is provisioned by an administrator
+by creating `PersistentVolume` objects from sources such as GCE Persistent Disks, AWS Elastic Block Stores (EBS), and NFS mounts.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/persistent_volumes.html#overview[Openshift documentation] for
+more information.
+
+|=============
+|Name | Access Mode
+
+| `${APPLICATION_NAME}-postgresql-claim`  |  `ReadWriteOnce` 
+|=============
+
+==== Secrets 
+
+This template requires https://github.com/jboss-openshift/application-templates/blob/master/secrets/jws-app-secrets.json[jws-app-secrets.json] to be installed for the application to run.

--- a/docs/templates/webserver/jws-tomcat8-postgresql-sti.adoc
+++ b/docs/templates/webserver/jws-tomcat8-postgresql-sti.adoc
@@ -1,0 +1,218 @@
+= jws-tomcat8-postgresql-sti
+
+Application template for JWS PostgreSQL applications built using STI.
+
+toc::[levels=2]
+
+== Parameters
+
+Templates allow you to define parameters which take on a value. That value is then substituted wherever the parameter is referenced.
+References can be defined in any text field in the objects list field. Refer to the
+https://docs.openshift.org/latest/architecture/core_concepts/templates.html#parameters[Openshift documentation] for more information.
+
+|=======================================================================
+|Variable name |Image Environment Variable |Description |Example value
+
+| `JWS_RELEASE`  |  --  |  `JWS Release version, e.g. 3.0, 2.1, etc.`  |  `3.0` 
+| `APPLICATION_NAME`  |  --  |  `The name for the application.`  |  `jws-app` 
+| `APPLICATION_HOSTNAME`  |  --  |  `Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>`  |  `secure-app.test.router.default.local` 
+| `GIT_URI`  |  --  |  `Git source URI for application`  |  ``https://github.com/jboss-openshift/openshift-examples.git` 
+| `GIT_REF`  |  --  |  `Git branch/tag reference`  |  `master` 
+| `GIT_CONTEXT_DIR`  |  --  |  `Path within Git project to build; empty for root project directory.`  |  `helloworld` 
+| `DB_JNDI`  |  `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb`  |  `${DB_JNDI}` 
+| `DB_DATABASE`  |  `DB_DATABASE`  |  `Database name`  |  `root` 
+| `JWS_HTTPS_SECRET`  |  --  |  `The name of the secret containing the certificate files`  |  `jws-app-secret` 
+| `JWS_HTTPS_CERTIFICATE`  |  `JWS_HTTPS_CERTIFICATE_DIR`  |  `The name of the certificate file within the secret`  |  `server.crt` 
+| `JWS_HTTPS_CERTIFICATE_KEY`  |  `JWS_HTTPS_CERTIFICATE`  |  `The name of the certificate key file within the secret`  |  `server.key` 
+| `JWS_HTTPS_CERTIFICATE_PASSWORD`  |  `JWS_HTTPS_CERTIFICATE`  |  `The certificate password`  |  `${JWS_HTTPS_CERTIFICATE}` 
+| `DB_MIN_POOL_SIZE`  |  `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `POSTGRESQL_MAX_CONNECTIONS`  |  `POSTGRESQL_MAX_CONNECTIONS`  |  `The maximum number of client connections allowed. This also sets the maximum number of prepared transactions.`  |  `${POSTGRESQL_MAX_CONNECTIONS}` 
+| `POSTGRESQL_SHARED_BUFFERS`  |  `POSTGRESQL_SHARED_BUFFERS`  |  `Configures how much memory is dedicated to PostgreSQL for caching data.`  |  `${POSTGRESQL_SHARED_BUFFERS}` 
+| `DB_USERNAME`  |  `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `JWS_ADMIN_USERNAME`  |  `JWS_ADMIN_USERNAME`  |  `JWS Admin User`  |  `${JWS_ADMIN_USERNAME}` 
+| `JWS_ADMIN_PASSWORD`  |  `JWS_ADMIN_PASSWORD`  |  `JWS Admin Password`  |  `${JWS_ADMIN_PASSWORD}` 
+| `GITHUB_TRIGGER_SECRET`  |  --  |  `GitHub trigger secret`  |  `secret101` 
+| `GENERIC_TRIGGER_SECRET`  |  --  |  `Generic build trigger secret`  |  `secret101` 
+| `IMAGE_STREAM_NAMESPACE`  |  --  |  `Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.`  |  `openshift` 
+|=======================================================================
+
+== Objects
+
+The CLI supports various object types. A list of these object types as well as their abbreviations
+can be found in the https://docs.openshift.org/latest/cli_reference/basic_cli_operations.html#object-types[Openshift documentation].
+
+=== Services
+
+A service is an abstraction which defines a logical set of pods and a policy by which to access them. Refer to the
+https://cloud.google.com/container-engine/docs/services/[container-engine documentation] for more information.
+
+|=============
+|Service        |Port  | Description
+
+| `${APPLICATION_NAME}`  |  `8080`  |  `The web server's http port.` 
+| `secure-${APPLICATION_NAME}`  |  `8443`  |  `The web server's https port.` 
+| `${APPLICATION_NAME}-postgresql`  |  `5432`  |  `The database server's port.` 
+|=============
+
+=== Routes
+
+A route is a way to expose a service by giving it an externally-reachable hostname such as `www.example.com`. A defined route and the endpoints
+identified by its service can be consumed by a router to provide named connectivity from external clients to your applications. Each route consists
+of a route name, service selector, and (optionally) security configuration. Refer to the
+https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html[Openshift documentation] for more information.
+
+|=============
+| Service    | Security | Hostname
+
+| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+|=============
+
+=== Build Configurations
+
+A `buildConfig` describes a single build definition and a set of triggers for when a new build should be created.
+A `buildConfig` is a REST object, which can be used in a POST to the API server to create a new instance. Refer to
+the https://docs.openshift.com/enterprise/3.0/dev_guide/builds.html#defining-a-buildconfig[Openshift documentation]
+for more information.
+
+|=============
+| STI image  | link | Build output | BuildTriggers and Settings
+
+| `jboss-webserver3-tomcat8-openshift:${JWS_RELEASE}`  |  ` link:../../webserver/tomcat8-openshift{outfilesuffix}[`jboss-webserver/tomcat8-openshift`]`  |  `${APPLICATION_NAME}:latest`  |  `Generic, GitHub, ImageChange` 
+|=============
+
+=== Deployment Configurations
+
+A deployment in OpenShift is a replication controller based on a user defined template called a deployment configuration. Deployments are created manually or in response to triggered events.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/deployments.html#creating-a-deployment-configuration[Openshift documentation] for more information.
+
+==== Triggers
+
+A trigger drives the creation of new deployments in response to events, both inside and outside OpenShift. Refer to the
+https://access.redhat.com/beta/documentation/en/openshift-enterprise-30-developer-guide#triggers[Openshift documentation] for more information.
+
+|============
+|Deployment | Triggers
+
+| `${APPLICATION_NAME}`  |  `ImageChange` 
+| `${APPLICATION_NAME}-postgresql`  |  `ImageChange` 
+|============
+
+==== Replicas
+
+A replication controller ensures that a specified number of pod "replicas" are running at any one time.
+If there are too many, the replication controller kills some pods. If there are too few, it starts more.
+Refer to the https://cloud.google.com/container-engine/docs/replicationcontrollers/[container-engine documentation]
+for more information.
+
+|============
+|Deployment | Replicas
+
+| `${APPLICATION_NAME}`  |  `1` 
+| `${APPLICATION_NAME}-postgresql`  |  `1` 
+|============
+
+==== Pod Template
+
+===== Service Accounts
+
+Service accounts are API objects that exist within each project. They can be created or deleted like any other API object. Refer to the
+https://docs.openshift.com/enterprise/3.0/dev_guide/service_accounts.html#managing-service-accounts[Openshift documentation] for more
+information.
+
+|============
+|Deployment | Service Account
+
+| `${APPLICATION_NAME}`  |  `jws-service-account` 
+|============
+
+===== Image
+
+|============
+|Deployment | Image
+
+| `${APPLICATION_NAME}`  |  `${APPLICATION_NAME}` 
+| `${APPLICATION_NAME}-postgresql`  |  `postgresql` 
+|============
+
+===== Readiness Probe
+
+
+====== ${APPLICATION_NAME}
+----
+/bin/bash
+
+-c
+
+curl -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer&att=stateName' |grep -iq 'stateName *= *STARTED'
+----
+
+
+===== Exposed Ports
+
+|=============
+|Deployments | Name  | Port  | Protocol
+
+.2+| `${APPLICATION_NAME}`
+| `http`  |  `8080`  |  `TCP` 
+| `https`  |  `8443`  |  `TCP` 
+.1+| `${APPLICATION_NAME}-postgresql`
+| --  |  `5432`  |  `TCP` 
+|=============
+
+===== Image Environment Variables
+
+|=======================================================================
+|Deployment |Variable name |Description |Example value
+
+.14+| `${APPLICATION_NAME}`
+| `DB_SERVICE_PREFIX_MAPPING`  |  --  |  `${APPLICATION_NAME}-postgresql=DB` 
+| `DB_JNDI`  |  `Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb`  |  `${DB_JNDI}` 
+| `DB_USERNAME`  |  `Database user name`  |  `${DB_USERNAME}` 
+| `DB_PASSWORD`  |  `Database user password`  |  `${DB_PASSWORD}` 
+| `DB_DATABASE`  |  `Database name`  |  `${DB_DATABASE}` 
+| `DB_MIN_POOL_SIZE`  |  `Sets xa-pool/min-pool-size for the configured datasource.`  |  `${DB_MIN_POOL_SIZE}` 
+| `DB_MAX_POOL_SIZE`  |  `Sets xa-pool/max-pool-size for the configured datasource.`  |  `${DB_MAX_POOL_SIZE}` 
+| `DB_TX_ISOLATION`  |  `Sets transaction-isolation for the configured datasource.`  |  `${DB_TX_ISOLATION}` 
+| `JWS_HTTPS_CERTIFICATE_DIR`  |  `The name of the certificate file within the secret`  |  `/etc/jws-secret-volume` 
+| `JWS_HTTPS_CERTIFICATE`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE}` 
+| `JWS_HTTPS_CERTIFICATE_KEY`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE_KEY}` 
+| `JWS_HTTPS_CERTIFICATE_PASSWORD`  |  `The name of the certificate file within the secret`  |  `${JWS_HTTPS_CERTIFICATE_PASSWORD}` 
+| `JWS_ADMIN_USERNAME`  |  `JWS Admin User`  |  `${JWS_ADMIN_USERNAME}` 
+| `JWS_ADMIN_PASSWORD`  |  `JWS Admin Password`  |  `${JWS_ADMIN_PASSWORD}` 
+.5+| `${APPLICATION_NAME}-postgresql`
+| `POSTGRESQL_USER`  |  --  |  `${DB_USERNAME}` 
+| `POSTGRESQL_PASSWORD`  |  --  |  `${DB_PASSWORD}` 
+| `POSTGRESQL_DATABASE`  |  --  |  `${DB_DATABASE}` 
+| `POSTGRESQL_MAX_CONNECTIONS`  |  `The maximum number of client connections allowed. This also sets the maximum number of prepared transactions.`  |  `${POSTGRESQL_MAX_CONNECTIONS}` 
+| `POSTGRESQL_SHARED_BUFFERS`  |  `Configures how much memory is dedicated to PostgreSQL for caching data.`  |  `${POSTGRESQL_SHARED_BUFFERS}` 
+|=======================================================================
+
+=====  Volumes
+
+|=============
+|Deployment |Name  | mountPath | Purpose | readOnly 
+
+| `${APPLICATION_NAME}`  |  `jws-certificate-volume`  |  `/etc/jws-secret-volume`  |  `ssl certs`  |  `True` 
+|=============
+
+=== External Dependencies
+
+==== Volume Claims
+
+A `PersistentVolume` object is a storage resource in an OpenShift cluster. Storage is provisioned by an administrator
+by creating `PersistentVolume` objects from sources such as GCE Persistent Disks, AWS Elastic Block Stores (EBS), and NFS mounts.
+Refer to the https://docs.openshift.com/enterprise/3.0/dev_guide/persistent_volumes.html#overview[Openshift documentation] for
+more information.
+
+|=============
+|Name | Access Mode
+
+|=============
+
+==== Secrets 
+
+This template requires https://github.com/jboss-openshift/application-templates/blob/master/secrets/jws-app-secrets.json[jws-app-secrets.json] to be installed for the application to run.


### PR DESCRIPTION
This imports Kyle's docs-generation script and adjusts it to work straight out of a clone of this repository (and a few other minor things).

The last commit imports a generated copy of template documentation for the current state of the templates in the repository. You can therefore browse the generate documentation straight from github ([example from my fork](https://github.com/jmtd/application-templates/blob/docs/docs/templates/index.adoc)).

The 'secrets' templates are not documented yet. I have some further commits that add the necessary changes to generate documentation for these (and other minor improvements), for a later Pull Request.