### PR TITLE
[CLOUD-203] A-MQ templates with and without SSL

### DIFF
--- a/amq/amq6-basic.json
+++ b/amq/amq6-basic.json
@@ -3,12 +3,12 @@
     "apiVersion": "v1",
     "metadata": {
         "annotations": {
-            "description": "Application template for A-MQ broker(s) using persistent storage."
+            "description": "Application template for A-MQ broker(s).  This template is without SSL support."
         },
-        "name": "amq6-persistent"
+        "name": "amq6-basic"
     },
     "labels": {
-        "template": "amq6-persistent"
+        "template": "amq6-basic"
     },
     "parameters": [
         {
@@ -40,12 +40,6 @@
             "name": "MQ_TOPICS",
             "value": "",
             "required": "No"
-        },
-        {
-            "description": "Size of persistent storage for database volume.",
-            "name": "VOLUME_CAPACITY",
-            "value": "512Mi",
-            "required": "Yes"
         },
         {
             "description": "Broker user name",
@@ -232,12 +226,6 @@
                                 "name": "${APPLICATION_NAME}-amq",
                                 "image": "jboss-amq-6",
                                 "imagePullPolicy": "Always",
-                                "volumeMounts": [
-                                    {
-                                        "mountPath": "/opt/amq/data/kahadb",
-                                        "name": "${APPLICATION_NAME}-amq-pvol"
-                                    }
-                                ],
                                 "readinessProbe": {
                                     "exec": {
                                         "command": [
@@ -301,38 +289,14 @@
                                     {
                                         "name": "AMQ_ADMIN_PASSWORD",
                                         "value": "${AMQ_ADMIN_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "AMQ_MESH_SERVICE_NAME",
+                                        "value": "${APPLICATION_NAME}-amq-tcp"
                                     }
                                 ]
                             }
-                        ],
-                        "volumes": [
-                            {
-                                "name": "${APPLICATION_NAME}-amq-pvol",
-                                "persistentVolumeClaim": {
-                                    "claimName": "${APPLICATION_NAME}-amq-claim"
-                                }
-                            }
                         ]
-                    }
-                }
-            }
-        },
-        {
-            "apiVersion": "v1",
-            "kind": "PersistentVolumeClaim",
-            "metadata": {
-                "name": "${APPLICATION_NAME}-amq-claim",
-                "labels": {
-                    "application": "${APPLICATION_NAME}"
-                }
-            },
-            "spec": {
-                "accessModes": [
-                    "ReadWriteOnce"
-                ],
-                "resources": {
-                    "requests": {
-                        "storage": "${VOLUME_CAPACITY}"
                     }
                 }
             }

--- a/amq/amq6-persistent-ssl.json
+++ b/amq/amq6-persistent-ssl.json
@@ -5,10 +5,10 @@
         "annotations": {
             "description": "Application template for A-MQ broker(s) using persistent storage."
         },
-        "name": "amq6-persistent"
+        "name": "amq6-persistent-ssl"
     },
     "labels": {
-        "template": "amq6-persistent"
+        "template": "amq6-persistent-ssl"
     },
     "parameters": [
         {
@@ -76,6 +76,36 @@
             "required": "Yes"
         },
         {
+            "description": "Name of a secret containing SSL related files",
+            "name": "AMQ_SECRET",
+            "value": "amq-app-secret",
+            "required": "Yes"
+        },
+        {
+            "description": "SSL trust store filename",
+            "name": "AMQ_TRUSTSTORE",
+            "value": "broker.ts",
+            "required": "Yes"
+        },
+        {
+            "description": "Password for accessing trust store",
+            "name": "AMQ_TRUSTSTORE_PASSWORD",
+            "value": "",
+            "required": "Yes"
+        },
+        {
+            "description": "SSL key store filename",
+            "name": "AMQ_KEYSTORE",
+            "value": "broker.ks",
+            "required": "Yes"
+        },
+        {
+            "description": "Password for accessing key store",
+            "name": "AMQ_KEYSTORE_PASSWORD",
+            "value": "",
+            "required": "Yes"
+        },
+        {
             "description": "A-MQ storage limit",
             "name": "AMQ_STORAGE_USAGE_LIMIT",
             "value": "100 gb",
@@ -119,6 +149,30 @@
             "spec": {
                 "ports": [
                     {
+                        "port": 5671,
+                        "targetPort": 5671
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}-amq"
+                }
+            },
+            "metadata": {
+                "name": "${APPLICATION_NAME}-amq-amqp-ssl",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "annotations": {
+                    "description": "The broker's AMQP SSL port."
+                }
+            }
+        },
+        {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "spec": {
+                "ports": [
+                    {
                         "port": 1883,
                         "targetPort": 1883
                     }
@@ -134,6 +188,30 @@
                 },
                 "annotations": {
                     "description": "The broker's MQTT port."
+                }
+            }
+        },
+        {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "spec": {
+                "ports": [
+                    {
+                        "port": 8883,
+                        "targetPort": 8883
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}-amq"
+                }
+            },
+            "metadata": {
+                "name": "${APPLICATION_NAME}-amq-mqtt-ssl",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "annotations": {
+                    "description": "The broker's MQTT SSL port."
                 }
             }
         },
@@ -167,6 +245,30 @@
             "spec": {
                 "ports": [
                     {
+                        "port": 61612,
+                        "targetPort": 61612
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}-amq"
+                }
+            },
+            "metadata": {
+                "name": "${APPLICATION_NAME}-amq-stomp-ssl",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "annotations": {
+                    "description": "The broker's STOMP SSL port."
+                }
+            }
+        },
+        {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "spec": {
+                "ports": [
+                    {
                         "port": 61616,
                         "targetPort": 61616
                     }
@@ -182,6 +284,30 @@
                 },
                 "annotations": {
                     "description": "The broker's OpenWire port."
+                }
+            }
+        },
+        {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "spec": {
+                "ports": [
+                    {
+                        "port": 61617,
+                        "targetPort": 61617
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}-amq"
+                }
+            },
+            "metadata": {
+                "name": "${APPLICATION_NAME}-amq-tcp-ssl",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "annotations": {
+                    "description": "The broker's OpenWire SSL port."
                 }
             }
         },
@@ -227,12 +353,18 @@
                         }
                     },
                     "spec": {
+                        "serviceAccount": "amq-service-account",
                         "containers": [
                             {
                                 "name": "${APPLICATION_NAME}-amq",
                                 "image": "jboss-amq-6",
                                 "imagePullPolicy": "Always",
                                 "volumeMounts": [
+                                    {
+                                        "name": "broker-secret-volume",
+                                        "mountPath": "/etc/amq-secret-volume",
+                                        "readOnly": true
+                                    },
                                     {
                                         "mountPath": "/opt/amq/data/kahadb",
                                         "name": "${APPLICATION_NAME}-amq-pvol"
@@ -254,8 +386,18 @@
                                         "protocol": "TCP"
                                     },
                                     {
+                                        "name": "amqp-ssl",
+                                        "containerPort": 5671,
+                                        "protocol": "TCP"
+                                    },
+                                    {
                                         "name": "mqtt",
                                         "containerPort": 1883,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "mqtt-ssl",
+                                        "containerPort": 8883,
                                         "protocol": "TCP"
                                     },
                                     {
@@ -264,8 +406,18 @@
                                         "protocol": "TCP"
                                     },
                                     {
+                                        "name": "stomp-ssl",
+                                        "containerPort": 61612,
+                                        "protocol": "TCP"
+                                    },
+                                    {
                                         "name": "tcp",
                                         "containerPort": 61616,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "tcp-ssl",
+                                        "containerPort": 61617,
                                         "protocol": "TCP"
                                     }
                                 ],
@@ -291,21 +443,47 @@
                                         "value": "${MQ_TOPICS}"
                                     },
                                     {
-                                        "name": "AMQ_STORAGE_USAGE_LIMIT",
-                                        "value": "${AMQ_STORAGE_USAGE_LIMIT}"
-                                    },
-                                    {
                                         "name": "AMQ_ADMIN_USERNAME",
                                         "value": "${AMQ_ADMIN_USERNAME}"
                                     },
                                     {
                                         "name": "AMQ_ADMIN_PASSWORD",
                                         "value": "${AMQ_ADMIN_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "AMQ_KEYSTORE_TRUSTSTORE_DIR",
+                                        "value": "/etc/amq-secret-volume"
+                                    },
+                                    {
+                                        "name": "AMQ_TRUSTSTORE",
+                                        "value": "${AMQ_TRUSTSTORE}"
+                                    },
+                                    {
+                                        "name": "AMQ_TRUSTSTORE_PASSWORD",
+                                        "value": "${AMQ_TRUSTSTORE_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "AMQ_KEYSTORE",
+                                        "value": "${AMQ_KEYSTORE}"
+                                    },
+                                    {
+                                        "name": "AMQ_KEYSTORE_PASSWORD",
+                                        "value": "${AMQ_KEYSTORE_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "AMQ_STORAGE_USAGE_LIMIT",
+                                        "value": "${AMQ_STORAGE_USAGE_LIMIT}"
                                     }
                                 ]
                             }
                         ],
                         "volumes": [
+                            {
+                                "name": "broker-secret-volume",
+                                "secret": {
+                                    "secretName": "${AMQ_SECRET}"
+                                }
+                            },
                             {
                                 "name": "${APPLICATION_NAME}-amq-pvol",
                                 "persistentVolumeClaim": {

--- a/amq/amq6-ssl.json
+++ b/amq/amq6-ssl.json
@@ -3,16 +3,16 @@
     "apiVersion": "v1",
     "metadata": {
         "annotations": {
-            "description": "Application template for ActiveMQ brokers."
+            "description": "Application template for A-MQ broker(s) with SSL support."
         },
-        "name": "amq6"
+        "name": "amq6-ssl"
     },
     "labels": {
-        "template": "amq6"
+        "template": "amq6-ssl"
     },
     "parameters": [
         {
-            "description": "ActiveMQ Release version, e.g. 6.2, etc.",
+            "description": "A-MQ Release version, e.g. 6.2, etc.",
             "name": "AMQ_RELEASE",
             "value": "6.2",
             "required": "Yes"
@@ -24,7 +24,7 @@
             "required": "Yes"
         },
         {
-            "description": "Protocol to configure.  Only openwire is supported by EAP.  amqp, amqp+ssl, mqtt, stomp, stomp+ssl, and ssl are not supported by EAP",
+            "description": "Protocol to configure.  Only openwire is supported by EAP.  Protocols amqp, mqtt and stomp are not supported by EAP.",
             "name": "MQ_PROTOCOL",
             "value": "openwire",
             "required": "No"
@@ -56,14 +56,14 @@
             "required": "No"
         },
         {
-            "description": "ActiveMQ Admin User",
+            "description": "A-MQ admin user",
             "name": "AMQ_ADMIN_USERNAME",
             "from": "user[a-zA-Z0-9]{3}",
             "generate": "expression",
             "required": "Yes"
         },
         {
-            "description": "ActiveMQ Admin Password",
+            "description": "A-MQ admin password",
             "name": "AMQ_ADMIN_PASSWORD",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -82,10 +82,28 @@
             "required": "Yes"
         },
         {
+            "description": "Password for accessing trust store",
+            "name": "AMQ_TRUSTSTORE_PASSWORD",
+            "value": "",
+            "required": "Yes"
+        },
+        {
             "description": "SSL key store filename",
             "name": "AMQ_KEYSTORE",
             "value": "broker.ks",
             "required": "Yes"
+        },
+        {
+            "description": "Password for accessing key store",
+            "name": "AMQ_KEYSTORE_PASSWORD",
+            "value": "",
+            "required": "Yes"
+        },
+        {
+            "description": "A-MQ storage limit",
+            "name": "AMQ_STORAGE_USAGE_LIMIT",
+            "value": "100 gb",
+            "required": "No"
         },
         {
             "description": "Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.",
@@ -115,7 +133,7 @@
                     "application": "${APPLICATION_NAME}"
                 },
                 "annotations": {
-                    "description": "The broker's amqp port."
+                    "description": "The broker's AMQP port."
                 }
             }
         },
@@ -139,7 +157,7 @@
                     "application": "${APPLICATION_NAME}"
                 },
                 "annotations": {
-                    "description": "The broker's amqp ssl port."
+                    "description": "The broker's AMQP SSL port."
                 }
             }
         },
@@ -163,7 +181,31 @@
                     "application": "${APPLICATION_NAME}"
                 },
                 "annotations": {
-                    "description": "The broker's mqtt port."
+                    "description": "The broker's MQTT port."
+                }
+            }
+        },
+        {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "spec": {
+                "ports": [
+                    {
+                        "port": 8883,
+                        "targetPort": 8883
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}-amq"
+                }
+            },
+            "metadata": {
+                "name": "${APPLICATION_NAME}-amq-mqtt-ssl",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "annotations": {
+                    "description": "The broker's MQTT SSL port."
                 }
             }
         },
@@ -187,7 +229,7 @@
                     "application": "${APPLICATION_NAME}"
                 },
                 "annotations": {
-                    "description": "The broker's stomp port."
+                    "description": "The broker's STOMP port."
                 }
             }
         },
@@ -211,7 +253,7 @@
                     "application": "${APPLICATION_NAME}"
                 },
                 "annotations": {
-                    "description": "The broker's stomp ssl port."
+                    "description": "The broker's STOMP SSL port."
                 }
             }
         },
@@ -235,7 +277,7 @@
                     "application": "${APPLICATION_NAME}"
                 },
                 "annotations": {
-                    "description": "The broker's tcp (openwire) port."
+                    "description": "The broker's OpenWire port."
                 }
             }
         },
@@ -259,7 +301,7 @@
                     "application": "${APPLICATION_NAME}"
                 },
                 "annotations": {
-                    "description": "The broker's tcp ssl (openwire) port."
+                    "description": "The broker's OpenWire SSL port."
                 }
             }
         },
@@ -344,6 +386,11 @@
                                         "protocol": "TCP"
                                     },
                                     {
+                                        "name": "mqtt-ssl",
+                                        "containerPort": 8883,
+                                        "protocol": "TCP"
+                                    },
+                                    {
                                         "name": "stomp",
                                         "containerPort": 61613,
                                         "protocol": "TCP"
@@ -375,7 +422,7 @@
                                     },
                                     {
                                         "name": "AMQ_TRANSPORTS",
-                                        "value": "${MQ_TRANSPORTS}"
+                                        "value": "${MQ_PROTOCOL}"
                                     },
                                     {
                                         "name": "AMQ_QUEUES",
@@ -406,8 +453,20 @@
                                         "value": "${AMQ_TRUSTSTORE}"
                                     },
                                     {
+                                        "name": "AMQ_TRUSTSTORE_PASSWORD",
+                                        "value": "${AMQ_TRUSTSTORE_PASSWORD}"
+                                    },
+                                    {
                                         "name": "AMQ_KEYSTORE",
                                         "value": "${AMQ_KEYSTORE}"
+                                    },
+                                    {
+                                        "name": "AMQ_KEYSTORE_PASSWORD",
+                                        "value": "${AMQ_KEYSTORE_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "AMQ_STORAGE_USAGE_LIMIT",
+                                        "value": "${AMQ_STORAGE_USAGE_LIMIT}"
                                     }
                                 ]
                             }


### PR DESCRIPTION
The former templates with SSL support were renamed:
amq6.json -> amq6-ssl.json
amq6-persistent.json -> amq6-persistent-ssl.json

There are two brand new templates for A-MQ without SSL support:
amq6-basic.json
amq6-persistent.json

(due to file name collision, GitHub displays the amq6-persistent.json file as modified)