### PR TITLE
Docs: handle missing required field

### DIFF
--- a/docs/amq/amq6-persistent.adoc
+++ b/docs/amq/amq6-persistent.adoc
@@ -31,7 +31,10 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 | `AMQ_ADMIN_PASSWORD`  |  `AMQ_ADMIN_PASSWORD`  |  `ActiveMQ Admin Password`  |  `${AMQ_ADMIN_PASSWORD}`  |  `Yes` 
 | `AMQ_SECRET`  |  --  |  `Name of a secret containing SSL related files`  |  `amq-app-secret`  |  `Yes` 
 | `AMQ_TRUSTSTORE`  |  `AMQ_TRUSTSTORE`  |  `SSL trust store filename`  |  `broker.ts`  |  `Yes` 
+| `AMQ_TRUSTSTORE_PASSWORD`  |  `AMQ_TRUSTSTORE`  |  `SSL trust store password`  |  `${AMQ_TRUSTSTORE}`  |  `?` 
 | `AMQ_KEYSTORE`  |  `AMQ_KEYSTORE_TRUSTSTORE_DIR`  |  `SSL key store filename`  |  `broker.ks`  |  `Yes` 
+| `AMQ_KEYSTORE_PASSWORD`  |  `AMQ_KEYSTORE`  |  `SSL key store password`  |  `${AMQ_KEYSTORE}`  |  `?` 
+| `AMQ_STORAGE_USAGE_LIMIT`  |  `AMQ_STORAGE_USAGE_LIMIT`  |  `The A-MQ storage usage limit`  |  `100 gb`  |  `?` 
 | `IMAGE_STREAM_NAMESPACE`  |  --  |  `Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.`  |  `openshift`  |  `Yes` 
 |=======================================================================
 
@@ -54,6 +57,7 @@ https://cloud.google.com/container-engine/docs/services/[container-engine docume
 | `${APPLICATION_NAME}-amq-amqp`  |  `5672`  |  `The broker's amqp port.` 
 | `${APPLICATION_NAME}-amq-amqp-ssl`  |  `5671`  |  `The broker's amqp ssl port.` 
 | `${APPLICATION_NAME}-amq-mqtt`  |  `1883`  |  `The broker's mqtt port.` 
+| `${APPLICATION_NAME}-amq-mqtt-ssl`  |  `8883`  |  `The broker's mqtt ssl port.` 
 | `${APPLICATION_NAME}-amq-stomp`  |  `61613`  |  `The broker's stomp port.` 
 | `${APPLICATION_NAME}-amq-stomp-ssl`  |  `61612`  |  `The broker's stomp ssl port.` 
 | `${APPLICATION_NAME}-amq-tcp`  |  `61616`  |  `The broker's tcp (openwire) port.` 
@@ -158,17 +162,20 @@ information.
 |=======================================================================
 |Deployment |Variable name |Description |Example value
 
-.10+| `${APPLICATION_NAME}-amq`
+.13+| `${APPLICATION_NAME}-amq`
 | `AMQ_USER`  |  `Broker user name`  |  `${MQ_USERNAME}` 
 | `AMQ_PASSWORD`  |  `Broker user password`  |  `${MQ_PASSWORD}` 
-| `AMQ_TRANSPORTS`  |  --  |  `${MQ_TRANSPORTS}` 
+| `AMQ_TRANSPORTS`  |  --  |  `${MQ_PROTOCOL}` 
 | `AMQ_QUEUES`  |  `Queue names`  |  `${MQ_QUEUES}` 
 | `AMQ_TOPICS`  |  `Topic names`  |  `${MQ_TOPICS}` 
 | `AMQ_ADMIN_USERNAME`  |  `ActiveMQ Admin User`  |  `${AMQ_ADMIN_USERNAME}` 
 | `AMQ_ADMIN_PASSWORD`  |  `ActiveMQ Admin Password`  |  `${AMQ_ADMIN_PASSWORD}` 
 | `AMQ_KEYSTORE_TRUSTSTORE_DIR`  |  `SSL key store filename`  |  `/etc/amq-secret-volume` 
 | `AMQ_TRUSTSTORE`  |  `SSL trust store filename`  |  `${AMQ_TRUSTSTORE}` 
+| `AMQ_TRUSTSTORE_PASSWORD`  |  `SSL trust store filename`  |  `${AMQ_TRUSTSTORE_PASSWORD}` 
 | `AMQ_KEYSTORE`  |  `SSL key store filename`  |  `${AMQ_KEYSTORE}` 
+| `AMQ_KEYSTORE_PASSWORD`  |  `SSL key store filename`  |  `${AMQ_KEYSTORE_PASSWORD}` 
+| `AMQ_STORAGE_USAGE_LIMIT`  |  `The A-MQ storage usage limit`  |  `${AMQ_STORAGE_USAGE_LIMIT}` 
 |=======================================================================
 
 

--- a/docs/amq/amq6.adoc
+++ b/docs/amq/amq6.adoc
@@ -30,7 +30,10 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 | `AMQ_ADMIN_PASSWORD`  |  `AMQ_ADMIN_PASSWORD`  |  `ActiveMQ Admin Password`  |  `${AMQ_ADMIN_PASSWORD}`  |  `Yes` 
 | `AMQ_SECRET`  |  --  |  `Name of a secret containing SSL related files`  |  `amq-app-secret`  |  `Yes` 
 | `AMQ_TRUSTSTORE`  |  `AMQ_TRUSTSTORE`  |  `SSL trust store filename`  |  `broker.ts`  |  `Yes` 
+| `AMQ_TRUSTSTORE_PASSWORD`  |  `AMQ_TRUSTSTORE`  |  `SSL trust store password`  |  `${AMQ_TRUSTSTORE}`  |  `?` 
 | `AMQ_KEYSTORE`  |  `AMQ_KEYSTORE_TRUSTSTORE_DIR`  |  `SSL key store filename`  |  `broker.ks`  |  `Yes` 
+| `AMQ_KEYSTORE_PASSWORD`  |  `AMQ_KEYSTORE`  |  `SSL key store password`  |  `${AMQ_KEYSTORE}`  |  `?` 
+| `AMQ_STORAGE_USAGE_LIMIT`  |  `AMQ_STORAGE_USAGE_LIMIT`  |  `The A-MQ storage usage limit`  |  `100 gb`  |  `?` 
 | `IMAGE_STREAM_NAMESPACE`  |  --  |  `Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.`  |  `openshift`  |  `Yes` 
 |=======================================================================
 
@@ -53,6 +56,7 @@ https://cloud.google.com/container-engine/docs/services/[container-engine docume
 | `${APPLICATION_NAME}-amq-amqp`  |  `5672`  |  `The broker's amqp port.` 
 | `${APPLICATION_NAME}-amq-amqp-ssl`  |  `5671`  |  `The broker's amqp ssl port.` 
 | `${APPLICATION_NAME}-amq-mqtt`  |  `1883`  |  `The broker's mqtt port.` 
+| `${APPLICATION_NAME}-amq-mqtt-ssl`  |  `8883`  |  `The broker's mqtt ssl port.` 
 | `${APPLICATION_NAME}-amq-stomp`  |  `61613`  |  `The broker's stomp port.` 
 | `${APPLICATION_NAME}-amq-stomp-ssl`  |  `61612`  |  `The broker's stomp ssl port.` 
 | `${APPLICATION_NAME}-amq-tcp`  |  `61616`  |  `The broker's tcp (openwire) port.` 
@@ -157,10 +161,10 @@ information.
 |=======================================================================
 |Deployment |Variable name |Description |Example value
 
-.11+| `${APPLICATION_NAME}-amq`
+.14+| `${APPLICATION_NAME}-amq`
 | `AMQ_USER`  |  `Broker user name`  |  `${MQ_USERNAME}` 
 | `AMQ_PASSWORD`  |  `Broker user password`  |  `${MQ_PASSWORD}` 
-| `AMQ_TRANSPORTS`  |  --  |  `${MQ_TRANSPORTS}` 
+| `AMQ_TRANSPORTS`  |  --  |  `${MQ_PROTOCOL}` 
 | `AMQ_QUEUES`  |  `Queue names`  |  `${MQ_QUEUES}` 
 | `AMQ_TOPICS`  |  `Topic names`  |  `${MQ_TOPICS}` 
 | `AMQ_ADMIN_USERNAME`  |  `ActiveMQ Admin User`  |  `${AMQ_ADMIN_USERNAME}` 
@@ -168,7 +172,10 @@ information.
 | `AMQ_MESH_SERVICE_NAME`  |  --  |  `${APPLICATION_NAME}-amq-tcp` 
 | `AMQ_KEYSTORE_TRUSTSTORE_DIR`  |  `SSL key store filename`  |  `/etc/amq-secret-volume` 
 | `AMQ_TRUSTSTORE`  |  `SSL trust store filename`  |  `${AMQ_TRUSTSTORE}` 
+| `AMQ_TRUSTSTORE_PASSWORD`  |  `SSL trust store filename`  |  `${AMQ_TRUSTSTORE_PASSWORD}` 
 | `AMQ_KEYSTORE`  |  `SSL key store filename`  |  `${AMQ_KEYSTORE}` 
+| `AMQ_KEYSTORE_PASSWORD`  |  `SSL key store filename`  |  `${AMQ_KEYSTORE_PASSWORD}` 
+| `AMQ_STORAGE_USAGE_LIMIT`  |  `The A-MQ storage usage limit`  |  `${AMQ_STORAGE_USAGE_LIMIT}` 
 |=======================================================================
 
 

--- a/docs/eap/eap6-amq-persistent-sti.adoc
+++ b/docs/eap/eap6-amq-persistent-sti.adoc
@@ -77,8 +77,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
-| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-http`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
 |=============
 
 
@@ -219,7 +219,7 @@ information.
 .7+| `${APPLICATION_NAME}-amq`
 | `AMQ_USER`  |  `Broker user name`  |  `${MQ_USERNAME}` 
 | `AMQ_PASSWORD`  |  `Broker user password`  |  `${MQ_PASSWORD}` 
-| `AMQ_TRANSPORTS`  |  --  |  `${MQ_TRANSPORTS}` 
+| `AMQ_TRANSPORTS`  |  --  |  `${MQ_PROTOCOL}` 
 | `AMQ_QUEUES`  |  `Queue names`  |  `${MQ_QUEUES}` 
 | `AMQ_TOPICS`  |  `Topic names`  |  `${MQ_TOPICS}` 
 | `AMQ_ADMIN_USERNAME`  |  `ActiveMQ Admin User`  |  `${AMQ_ADMIN_USERNAME}` 

--- a/docs/eap/eap6-amq-sti.adoc
+++ b/docs/eap/eap6-amq-sti.adoc
@@ -76,8 +76,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
-| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-http`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
 |=============
 
 
@@ -218,7 +218,7 @@ information.
 .7+| `${APPLICATION_NAME}-amq`
 | `AMQ_USER`  |  `Broker user name`  |  `${MQ_USERNAME}` 
 | `AMQ_PASSWORD`  |  `Broker user password`  |  `${MQ_PASSWORD}` 
-| `AMQ_TRANSPORTS`  |  --  |  `${MQ_TRANSPORTS}` 
+| `AMQ_TRANSPORTS`  |  --  |  `${MQ_PROTOCOL}` 
 | `AMQ_QUEUES`  |  `Queue names`  |  `${MQ_QUEUES}` 
 | `AMQ_TOPICS`  |  `Topic names`  |  `${MQ_TOPICS}` 
 | `AMQ_ADMIN_USERNAME`  |  `ActiveMQ Admin User`  |  `${AMQ_ADMIN_USERNAME}` 

--- a/docs/eap/eap6-basic-sti.adoc
+++ b/docs/eap/eap6-basic-sti.adoc
@@ -64,7 +64,7 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-http`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
 |=============
 
 

--- a/docs/eap/eap6-https-sti.adoc
+++ b/docs/eap/eap6-https-sti.adoc
@@ -69,8 +69,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
-| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-http`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
 |=============
 
 

--- a/docs/eap/eap6-mongodb-persistent-sti.adoc
+++ b/docs/eap/eap6-mongodb-persistent-sti.adoc
@@ -82,8 +82,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
-| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-http`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
 |=============
 
 

--- a/docs/eap/eap6-mongodb-sti.adoc
+++ b/docs/eap/eap6-mongodb-sti.adoc
@@ -81,8 +81,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
-| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-http`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
 |=============
 
 

--- a/docs/eap/eap6-mysql-persistent-sti.adoc
+++ b/docs/eap/eap6-mysql-persistent-sti.adoc
@@ -83,8 +83,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
-| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-http`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
 |=============
 
 

--- a/docs/eap/eap6-mysql-sti.adoc
+++ b/docs/eap/eap6-mysql-sti.adoc
@@ -82,8 +82,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
-| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-http`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
 |=============
 
 

--- a/docs/eap/eap6-postgresql-persistent-sti.adoc
+++ b/docs/eap/eap6-postgresql-persistent-sti.adoc
@@ -80,8 +80,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
-| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-http`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
 |=============
 
 

--- a/docs/eap/eap6-postgresql-sti.adoc
+++ b/docs/eap/eap6-postgresql-sti.adoc
@@ -79,8 +79,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
-| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-http`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
 |=============
 
 

--- a/docs/webserver/jws-tomcat7-basic-sti.adoc
+++ b/docs/webserver/jws-tomcat7-basic-sti.adoc
@@ -63,7 +63,7 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-http`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
 |=============
 
 

--- a/docs/webserver/jws-tomcat7-https-sti.adoc
+++ b/docs/webserver/jws-tomcat7-https-sti.adoc
@@ -68,8 +68,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
-| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-http`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
 |=============
 
 

--- a/docs/webserver/jws-tomcat7-mongodb-persistent-sti.adoc
+++ b/docs/webserver/jws-tomcat7-mongodb-persistent-sti.adoc
@@ -81,8 +81,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
-| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-http`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
 |=============
 
 

--- a/docs/webserver/jws-tomcat7-mongodb-sti.adoc
+++ b/docs/webserver/jws-tomcat7-mongodb-sti.adoc
@@ -80,8 +80,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
-| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-http`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
 |=============
 
 

--- a/docs/webserver/jws-tomcat7-mysql-persistent-sti.adoc
+++ b/docs/webserver/jws-tomcat7-mysql-persistent-sti.adoc
@@ -82,8 +82,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
-| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-http`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
 |=============
 
 

--- a/docs/webserver/jws-tomcat7-mysql-sti.adoc
+++ b/docs/webserver/jws-tomcat7-mysql-sti.adoc
@@ -81,8 +81,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
-| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-http`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
 |=============
 
 

--- a/docs/webserver/jws-tomcat7-postgresql-persistent-sti.adoc
+++ b/docs/webserver/jws-tomcat7-postgresql-persistent-sti.adoc
@@ -79,8 +79,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
-| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-http`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
 |=============
 
 

--- a/docs/webserver/jws-tomcat7-postgresql-sti.adoc
+++ b/docs/webserver/jws-tomcat7-postgresql-sti.adoc
@@ -78,8 +78,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
-| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-http`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
 |=============
 
 

--- a/docs/webserver/jws-tomcat8-basic-sti.adoc
+++ b/docs/webserver/jws-tomcat8-basic-sti.adoc
@@ -63,7 +63,7 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-http`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
 |=============
 
 

--- a/docs/webserver/jws-tomcat8-https-sti.adoc
+++ b/docs/webserver/jws-tomcat8-https-sti.adoc
@@ -68,8 +68,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
-| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-http`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
 |=============
 
 

--- a/docs/webserver/jws-tomcat8-mongodb-persistent-sti.adoc
+++ b/docs/webserver/jws-tomcat8-mongodb-persistent-sti.adoc
@@ -81,8 +81,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
-| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-http`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
 |=============
 
 

--- a/docs/webserver/jws-tomcat8-mongodb-sti.adoc
+++ b/docs/webserver/jws-tomcat8-mongodb-sti.adoc
@@ -80,8 +80,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
-| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-http`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
 |=============
 
 

--- a/docs/webserver/jws-tomcat8-mysql-persistent-sti.adoc
+++ b/docs/webserver/jws-tomcat8-mysql-persistent-sti.adoc
@@ -82,8 +82,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
-| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-http`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
 |=============
 
 

--- a/docs/webserver/jws-tomcat8-mysql-sti.adoc
+++ b/docs/webserver/jws-tomcat8-mysql-sti.adoc
@@ -81,8 +81,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
-| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-http`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
 |=============
 
 

--- a/docs/webserver/jws-tomcat8-postgresql-persistent-sti.adoc
+++ b/docs/webserver/jws-tomcat8-postgresql-persistent-sti.adoc
@@ -79,8 +79,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
-| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-http`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
 |=============
 
 

--- a/docs/webserver/jws-tomcat8-postgresql-sti.adoc
+++ b/docs/webserver/jws-tomcat8-postgresql-sti.adoc
@@ -78,8 +78,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-| `${APPLICATION_NAME}-http-route`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
-| `${APPLICATION_NAME}-https-route`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-http`  |  `none`  |  `${APPLICATION_HOSTNAME}` 
+| `${APPLICATION_NAME}-https`  |  `TLS passthrough`  |  `${APPLICATION_HOSTNAME}` 
 |=============
 
 

--- a/gen_template_docs.py
+++ b/gen_template_docs.py
@@ -142,7 +142,8 @@ def createParameterTable(data):
       environment = [item for sublist in deploy for item in sublist]
       envVar = getVariableInfo(environment, param["name"], "name")
       value = param["value"] if param.get("value") else getVariableInfo(environment, param["name"], "value")
-      columns = [param["name"], envVar, param["description"], value, param["required"]]
+      req = param["required"] if "required" in param else "?"
+      columns = [param["name"], envVar, param["description"], value, req]
       text += buildRow(columns)
    return text
 


### PR DESCRIPTION
Use "?" for the "Required" field in the environment varabiles tables, if it is not supplied in the JSON.

We should fill in those fields for recently added env vars in commit `c7e833ff`, but I'm not sure what they should be at this point in time.

Refresh the auto-generated docs.