### PR TITLE
docs: add additional description for AMQ SSL images

### DIFF
--- a/amq-ssl.adoc.in
+++ b/amq-ssl.adoc.in
@@ -1,0 +1,56 @@
+For SSL to work, you have to have keystore and truststore files. If you don't have them already, you can generate them using _keytool_ application which is part of Java distribution. Assuming that JAVA_HOME points to your Java distribution, open a working directory and run the commands from the command line.
+
+1. Prepare variables
+
+  BROKER_KEYSTORE_PASSWORD=<password for broker keystore>
+  BROKER_TRUSTSTORE_PASSWORD=<password for broker truststore>
+  CLIENT_KEYSTORE_PASSWORD=<password for client keystore>
+
+
+2. Create client keystore (optional - if you alredy have certificate for the client, proceed to step 4)
+
+  $JAVA_HOME/bin/keytool \
+	-genkey \
+	-keyalg RSA \
+	-alias amq-client \
+	-keystore amq-client.ks \
+	-storepass $CLIENT_KEYSTORE_PASSWORD \
+    -keypass $CLIENT_KEYSTORE_PASSWORD
+
+3. Create client certificate (optional - if you alredy have certificate for the client, proceed to step 4)
+
+  $JAVA_HOME/bin/keytool \
+	-export \
+	-alias amq-client \
+	-keystore amq-client.ks \
+    -storepass $CLIENT_KEYSTORE_PASSWORD \
+	-file amq-client.cert
+
+4. Create broker keystore
+
+  $JAVA_HOME/bin/keytool \
+	-genkey \
+	-keyalg RSA \
+	-alias amq-broker \
+	-keystore amq-broker.ks \
+	-storepass $BROKER_KEYSTORE_PASSWORD \
+    -keypass $BROKER_KEYSTORE_PASSWORD
+
+5. Create broker truststore from client certificate
+
+  $JAVA_HOME/bin/keytool \
+	-import \
+	-alias amq-broker \
+	-keystore amq-broker.ts \
+	-file amq-client.cert \
+	-storepass $BROKER_TRUSTSTORE_PASSWORD \
+    -trustcacerts \
+    -noprompt
+
+Now, you can use files `amq-broker.ks` and `amq-broker.ts` in OpenShift secret definition. Leave the files `amq-client.ks` and `amq-client.cert` be as they are not needed by the broker. Also, when creating A-MQ application, set the template parameters as: +
+
+AMQ_KEYSTORE=amq-broker.ks +
+AMQ_KEYSTORE_PASSWORD=<password for broker keystore> +
+AMQ_TRUSTSTORE=amq-broker.ts +
+AMQ_TRUSTSTORE_PASSWORD=<password for broker truststore> +
+

--- a/docs/amq/amq6-persistent-ssl.adoc
+++ b/docs/amq/amq6-persistent-ssl.adoc
@@ -9,6 +9,64 @@
 
 Application template for A-MQ brokers using persistent storage.
 
+For SSL to work, you have to have keystore and truststore files. If you don't have them already, you can generate them using _keytool_ application which is part of Java distribution. Assuming that JAVA_HOME points to your Java distribution, open a working directory and run the commands from the command line.
+
+1. Prepare variables
+
+  BROKER_KEYSTORE_PASSWORD=<password for broker keystore>
+  BROKER_TRUSTSTORE_PASSWORD=<password for broker truststore>
+  CLIENT_KEYSTORE_PASSWORD=<password for client keystore>
+
+
+2. Create client keystore (optional - if you alredy have certificate for the client, proceed to step 4)
+
+  $JAVA_HOME/bin/keytool \
+	-genkey \
+	-keyalg RSA \
+	-alias amq-client \
+	-keystore amq-client.ks \
+	-storepass $CLIENT_KEYSTORE_PASSWORD \
+    -keypass $CLIENT_KEYSTORE_PASSWORD
+
+3. Create client certificate (optional - if you alredy have certificate for the client, proceed to step 4)
+
+  $JAVA_HOME/bin/keytool \
+	-export \
+	-alias amq-client \
+	-keystore amq-client.ks \
+    -storepass $CLIENT_KEYSTORE_PASSWORD \
+	-file amq-client.cert
+
+4. Create broker keystore
+
+  $JAVA_HOME/bin/keytool \
+	-genkey \
+	-keyalg RSA \
+	-alias amq-broker \
+	-keystore amq-broker.ks \
+	-storepass $BROKER_KEYSTORE_PASSWORD \
+    -keypass $BROKER_KEYSTORE_PASSWORD
+
+5. Create broker truststore from client certificate
+
+  $JAVA_HOME/bin/keytool \
+	-import \
+	-alias amq-broker \
+	-keystore amq-broker.ts \
+	-file amq-client.cert \
+	-storepass $BROKER_TRUSTSTORE_PASSWORD \
+    -trustcacerts \
+    -noprompt
+
+Now, you can use files `amq-broker.ks` and `amq-broker.ts` in OpenShift secret definition. Leave the files `amq-client.ks` and `amq-client.cert` be as they are not needed by the broker. Also, when creating A-MQ application, set the template parameters as: +
+
+AMQ_KEYSTORE=amq-broker.ks +
+AMQ_KEYSTORE_PASSWORD=<password for broker keystore> +
+AMQ_TRUSTSTORE=amq-broker.ts +
+AMQ_TRUSTSTORE_PASSWORD=<password for broker truststore> +
+
+
+
 
 == Parameters
 

--- a/docs/amq/amq6-ssl.adoc
+++ b/docs/amq/amq6-ssl.adoc
@@ -9,6 +9,64 @@
 
 Application template for A-MQ brokers.
 
+For SSL to work, you have to have keystore and truststore files. If you don't have them already, you can generate them using _keytool_ application which is part of Java distribution. Assuming that JAVA_HOME points to your Java distribution, open a working directory and run the commands from the command line.
+
+1. Prepare variables
+
+  BROKER_KEYSTORE_PASSWORD=<password for broker keystore>
+  BROKER_TRUSTSTORE_PASSWORD=<password for broker truststore>
+  CLIENT_KEYSTORE_PASSWORD=<password for client keystore>
+
+
+2. Create client keystore (optional - if you alredy have certificate for the client, proceed to step 4)
+
+  $JAVA_HOME/bin/keytool \
+	-genkey \
+	-keyalg RSA \
+	-alias amq-client \
+	-keystore amq-client.ks \
+	-storepass $CLIENT_KEYSTORE_PASSWORD \
+    -keypass $CLIENT_KEYSTORE_PASSWORD
+
+3. Create client certificate (optional - if you alredy have certificate for the client, proceed to step 4)
+
+  $JAVA_HOME/bin/keytool \
+	-export \
+	-alias amq-client \
+	-keystore amq-client.ks \
+    -storepass $CLIENT_KEYSTORE_PASSWORD \
+	-file amq-client.cert
+
+4. Create broker keystore
+
+  $JAVA_HOME/bin/keytool \
+	-genkey \
+	-keyalg RSA \
+	-alias amq-broker \
+	-keystore amq-broker.ks \
+	-storepass $BROKER_KEYSTORE_PASSWORD \
+    -keypass $BROKER_KEYSTORE_PASSWORD
+
+5. Create broker truststore from client certificate
+
+  $JAVA_HOME/bin/keytool \
+	-import \
+	-alias amq-broker \
+	-keystore amq-broker.ts \
+	-file amq-client.cert \
+	-storepass $BROKER_TRUSTSTORE_PASSWORD \
+    -trustcacerts \
+    -noprompt
+
+Now, you can use files `amq-broker.ks` and `amq-broker.ts` in OpenShift secret definition. Leave the files `amq-client.ks` and `amq-client.cert` be as they are not needed by the broker. Also, when creating A-MQ application, set the template parameters as: +
+
+AMQ_KEYSTORE=amq-broker.ks +
+AMQ_KEYSTORE_PASSWORD=<password for broker keystore> +
+AMQ_TRUSTSTORE=amq-broker.ts +
+AMQ_TRUSTSTORE_PASSWORD=<password for broker truststore> +
+
+
+
 
 == Parameters
 

--- a/gen_template_docs.py
+++ b/gen_template_docs.py
@@ -20,6 +20,7 @@ REPO_NAME = "application-templates/"
 TEMPLATE_DOCS = "docs/"
 APPLICATION_DIRECTORIES = ("amq","eap","webserver")
 ignore_dirs = ['docs', '.git']
+amq_ssl_desc = None
 
 LINKS =  {"jboss-eap64-openshift:1.1":               "../../eap/eap-openshift{outfilesuffix}[`jboss-eap-6/eap-openshift`]", \
           "jboss-webserver30-tomcat7-openshift:1.1": "../../webserver/tomcat7-openshift{outfilesuffix}[`jboss-webserver/tomcat7-openshift`]", \
@@ -76,6 +77,14 @@ def createTemplate(data, directory, template_file):
     # Fill in the template description, if supplied
     if 'annotations' in data['metadata'] and 'description' in data['metadata']['annotations']:
         tdata['description'] = data['metadata']['annotations']['description']
+
+    # special case: AMQ SSL templates have additional description
+    global amq_ssl_desc
+    if re.match('amq',template_file) and re.match('.*ssl\.json$', template_file):
+        if not amq_ssl_desc:
+            with open('amq-ssl.adoc.in','r') as tmp:
+                amq_ssl_desc = tmp.read()
+        tdata['description'] += "\n\n" + amq_ssl_desc
 
     # Fill in template parameters table, if there are any
     if ("parameters" in data and "objects" in data) and len(data["parameters"]) > 0:


### PR DESCRIPTION
Add an additional doc file describing specifics for AMQ SSL templates and conditionally append it to generated pages if they correspond to an AMQ SSL template. Initial text courtesy of @rnetuka.