### PR TITLE
[CLOUD-299] kie-server doesn't start when JMS is configured

### DIFF
--- a/decisionserver/decisionserver62-amq-s2i.json
+++ b/decisionserver/decisionserver62-amq-s2i.json
@@ -3,15 +3,15 @@
     "apiVersion": "v1",
     "metadata": {
         "annotations": {
-            "description": "Application template for BRMS Realtime Decision Server 6 HTTPS applications built using S2I.",
+            "description": "Application template for BRMS Realtime Decision Server 6 A-MQ applications built using S2I.",
             "iconClass": "icon-jboss",
-            "tags": "decisionserver,java,jboss,xpaas",
+            "tags": "decisionserver,amq,java,messaging,jboss,xpaas",
             "version": "1.2.0"
         },
-        "name": "decisionserver62-https-s2i"
+        "name": "decisionserver62-amq-s2i"
     },
     "labels": {
-        "template": "decisionserver62-https-s2i",
+        "template": "decisionserver62-amq-s2i",
         "xpaas": "1.2.0"
     },
     "parameters": [
@@ -21,28 +21,28 @@
             "required": true
         },
         {
-            "description": "The protocol to access the KIE Server REST interface.",
-            "name": "KIE_SERVER_PROTOCOL",
-            "value": "https",
-            "required": false
-        },
-        {
-            "description": "The port to access the KIE Server REST interface.",
-            "name": "KIE_SERVER_PORT",
-            "value": "8443",
-            "required": false
-        },
-        {
-            "description": "The user name to access the KIE Server REST interface.",
+            "description": "The user name to access the KIE Server JMS interface.",
             "name": "KIE_SERVER_USER",
             "value": "kieserver",
             "required": false
         },
         {
-            "description": "The password to access the KIE Server REST interface.",
+            "description": "The password to access the KIE Server JMS interface.",
             "name": "KIE_SERVER_PASSWORD",
             "from": "[a-zA-Z]{6}[0-9]{1}!",
             "generate": "expression",
+            "required": false
+        },
+        {
+            "description": "JAAS LoginContext domain that shall be used to authenticate users when using JMS.",
+            "name": "KIE_SERVER_DOMAIN",
+            "value": "other",
+            "required": false
+        },
+        {
+            "description": "JNDI name of response queue for JMS.",
+            "name": "KIE_SERVER_JMS_QUEUES_RESPONSE",
+            "value": "queue/KIE.SERVER.RESPONSE",
             "required": false
         },
         {
@@ -76,14 +76,26 @@
             "required": false
         },
         {
-            "description": "Queue names",
-            "name": "HORNETQ_QUEUES",
-            "value": "",
+            "description": "JNDI name for connection factory used by applications to connect to the broker, e.g. java:/JmsXA",
+            "name": "MQ_JNDI",
+            "value": "java:/JmsXA",
             "required": false
         },
         {
-            "description": "Topic names",
-            "name": "HORNETQ_TOPICS",
+            "description": "Broker protocols to configure, separated by commas. Allowed values are: `openwire`, `amqp`, `stomp` and `mqtt`. Only `openwire` is supported by EAP.",
+            "name": "MQ_PROTOCOL",
+            "value": "openwire",
+            "required": false
+        },
+        {
+            "description": "Queue names, separated by commas. These queues will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP.",
+            "name": "MQ_QUEUES",
+            "value": "KIE.SERVER.REQUEST,KIE.SERVER.RESPONSE",
+            "required": false
+        },
+        {
+            "description": "Topic names, separated by commas. These topics will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP.",
+            "name": "MQ_TOPICS",
             "value": "",
             "required": false
         },
@@ -91,7 +103,7 @@
             "description": "The name of the secret containing the keystore file",
             "name": "EAP_HTTPS_SECRET",
             "value": "eap-app-secret",
-            "required": true
+            "required": false
         },
         {
             "description": "The name of the keystore file within the secret",
@@ -112,8 +124,29 @@
             "required": false
         },
         {
-            "description": "HornetQ cluster admin password",
-            "name": "HORNETQ_CLUSTER_PASSWORD",
+            "description": "User name for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.",
+            "name": "MQ_USERNAME",
+            "from": "user[a-zA-Z0-9]{3}",
+            "generate": "expression",
+            "required": false
+        },
+        {
+            "description": "Password for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.",
+            "name": "MQ_PASSWORD",
+            "from": "[a-zA-Z0-9]{8}",
+            "generate": "expression",
+            "required": false
+        },
+        {
+            "description": "User name for broker admin. If left empty, it will be generated.",
+            "name": "AMQ_ADMIN_USERNAME",
+            "from": "user[a-zA-Z0-9]{3}",
+            "generate": "expression",
+            "required": true
+        },
+        {
+            "description": "Password for broker admin. If left empty, it will be generated.",
+            "name": "AMQ_ADMIN_PASSWORD",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
             "required": true
@@ -160,7 +193,7 @@
                     "application": "${APPLICATION_NAME}"
                 },
                 "annotations": {
-                    "description": "The web server's http port."
+                    "description": "The web server's HTTP port."
                 }
             }
         },
@@ -184,7 +217,31 @@
                     "application": "${APPLICATION_NAME}"
                 },
                 "annotations": {
-                    "description": "The web server's https port."
+                    "description": "The web server's HTTPS port."
+                }
+            }
+        },
+        {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "spec": {
+                "ports": [
+                    {
+                        "port": 61616,
+                        "targetPort": 61616
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}-amq"
+                }
+            },
+            "metadata": {
+                "name": "${APPLICATION_NAME}-amq-tcp",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "annotations": {
+                    "description": "The broker's OpenWire port."
                 }
             }
         },
@@ -198,7 +255,7 @@
                     "application": "${APPLICATION_NAME}"
                 },
                 "annotations": {
-                    "description": "Route for application's http service."
+                    "description": "Route for application's HTTP service."
                 }
             },
             "spec": {
@@ -218,7 +275,7 @@
                     "application": "${APPLICATION_NAME}"
                 },
                 "annotations": {
-                    "description": "Route for application's https service."
+                    "description": "Route for application's HTTPS service."
                 }
             },
             "spec": {
@@ -395,20 +452,48 @@
                                         "value": "${KIE_CONTAINER_DEPLOYMENT}"
                                     },
                                     {
-                                        "name": "KIE_SERVER_PROTOCOL",
-                                        "value": "${KIE_SERVER_PROTOCOL}"
-                                    },
-                                    {
-                                        "name": "KIE_SERVER_PORT",
-                                        "value": "${KIE_SERVER_PORT}"
-                                    },
-                                    {
                                         "name": "KIE_SERVER_USER",
                                         "value": "${KIE_SERVER_USER}"
                                     },
                                     {
                                         "name": "KIE_SERVER_PASSWORD",
                                         "value": "${KIE_SERVER_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_DOMAIN",
+                                        "value": "${KIE_SERVER_DOMAIN}"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_JMS_QUEUES_RESPONSE",
+                                        "value": "${KIE_SERVER_JMS_QUEUES_RESPONSE}"
+                                    },
+                                    {
+                                        "name": "MQ_SERVICE_PREFIX_MAPPING",
+                                        "value": "${APPLICATION_NAME}-amq=MQ"
+                                    },
+                                    {
+                                        "name": "MQ_JNDI",
+                                        "value": "${MQ_JNDI}"
+                                    },
+                                    {
+                                        "name": "MQ_USERNAME",
+                                        "value": "${MQ_USERNAME}"
+                                    },
+                                    {
+                                        "name": "MQ_PASSWORD",
+                                        "value": "${MQ_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "MQ_PROTOCOL",
+                                        "value": "tcp"
+                                    },
+                                    {
+                                        "name": "MQ_QUEUES",
+                                        "value": "${MQ_QUEUES}"
+                                    },
+                                    {
+                                        "name": "MQ_TOPICS",
+                                        "value": "${MQ_TOPICS}"
                                     },
                                     {
                                         "name": "EAP_HTTPS_KEYSTORE_DIR",
@@ -425,18 +510,6 @@
                                     {
                                         "name": "EAP_HTTPS_PASSWORD",
                                         "value": "${EAP_HTTPS_PASSWORD}"
-                                    },
-                                    {
-                                        "name": "HORNETQ_CLUSTER_PASSWORD",
-                                        "value": "${HORNETQ_CLUSTER_PASSWORD}"
-                                    },
-                                    {
-                                        "name": "HORNETQ_QUEUES",
-                                        "value": "${HORNETQ_QUEUES}"
-                                    },
-                                    {
-                                        "name": "HORNETQ_TOPICS",
-                                        "value": "${HORNETQ_TOPICS}"
                                     }
                                 ]
                             }
@@ -447,6 +520,139 @@
                                 "secret": {
                                     "secretName": "${EAP_HTTPS_SECRET}"
                                 }
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "kind": "DeploymentConfig",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "${APPLICATION_NAME}-amq",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                }
+            },
+            "spec": {
+                "strategy": {
+                    "type": "Recreate"
+                },
+                "triggers": [
+                    {
+                        "type": "ImageChange",
+                        "imageChangeParams": {
+                            "automatic": true,
+                            "containerNames": [
+                                "${APPLICATION_NAME}-amq"
+                            ],
+                            "from": {
+                                "kind": "ImageStreamTag",
+                                "namespace": "${IMAGE_STREAM_NAMESPACE}",
+                                "name": "jboss-amq-62:1.2"
+                            }
+                        }
+                    },
+                    {
+                        "type": "ConfigChange"
+                    }
+                ],
+                "replicas": 1,
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}-amq"
+                },
+                "template": {
+                    "metadata": {
+                        "name": "${APPLICATION_NAME}-amq",
+                        "labels": {
+                            "deploymentConfig": "${APPLICATION_NAME}-amq",
+                            "application": "${APPLICATION_NAME}"
+                        }
+                    },
+                    "spec": {
+                        "terminationGracePeriodSeconds": 60,
+                        "containers": [
+                            {
+                                "name": "${APPLICATION_NAME}-amq",
+                                "image": "jboss-amq-62",
+                                "imagePullPolicy": "Always",
+                                "readinessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "/bin/bash",
+                                            "-c",
+                                            "curl -s -L -u ${AMQ_ADMIN_USERNAME}:${AMQ_ADMIN_PASSWORD} 'http://localhost:8161/hawtio/jolokia/read/org.apache.activemq:type=Broker,brokerName=*,service=Health/CurrentStatus' | grep -q '\"CurrentStatus\" *: *\"Good\"'"
+                                        ]
+                                    }
+                                },
+                                "ports": [
+                                    {
+                                        "name": "amqp",
+                                        "containerPort": 5672,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "amqp-ssl",
+                                        "containerPort": 5671,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "mqtt",
+                                        "containerPort": 1883,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "stomp",
+                                        "containerPort": 61613,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "stomp-ssl",
+                                        "containerPort": 61612,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "tcp",
+                                        "containerPort": 61616,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "tcp-ssl",
+                                        "containerPort": 61617,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "env": [
+                                    {
+                                        "name": "AMQ_USER",
+                                        "value": "${MQ_USERNAME}"
+                                    },
+                                    {
+                                        "name": "AMQ_PASSWORD",
+                                        "value": "${MQ_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "AMQ_TRANSPORTS",
+                                        "value": "${MQ_PROTOCOL}"
+                                    },
+                                    {
+                                        "name": "AMQ_QUEUES",
+                                        "value": "${MQ_QUEUES}"
+                                    },
+                                    {
+                                        "name": "AMQ_TOPICS",
+                                        "value": "${MQ_TOPICS}"
+                                    },
+                                    {
+                                        "name": "AMQ_ADMIN_USERNAME",
+                                        "value": "${AMQ_ADMIN_USERNAME}"
+                                    },
+                                    {
+                                        "name": "AMQ_ADMIN_PASSWORD",
+                                        "value": "${AMQ_ADMIN_PASSWORD}"
+                                    }
+                                ]
                             }
                         ]
                     }

--- a/decisionserver/decisionserver62-basic-s2i.json
+++ b/decisionserver/decisionserver62-basic-s2i.json
@@ -3,8 +3,8 @@
     "apiVersion": "v1",
     "metadata": {
         "annotations": {
-            "iconClass": "icon-jboss",
             "description": "Application template for BRMS Realtime Decision Server 6 applications built using S2I.",
+            "iconClass": "icon-jboss",
             "tags": "decisionserver,java,jboss,xpaas",
             "version": "1.2.0"
         },
@@ -266,6 +266,7 @@
                         }
                     },
                     "spec": {
+                        "terminationGracePeriodSeconds": 60,
                         "containers": [
                             {
                                 "name": "${APPLICATION_NAME}",

--- a/eap/eap64-amq-persistent-s2i.json
+++ b/eap/eap64-amq-persistent-s2i.json
@@ -30,13 +30,13 @@
         {
             "description": "Git source URI for application",
             "name": "SOURCE_REPOSITORY_URL",
-            "value": "https://github.com/jboss-openshift/openshift-quickstarts.git",
+            "value": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
             "required": true
         },
         {
             "description": "Git branch/tag reference",
             "name": "SOURCE_REPOSITORY_REF",
-            "value": "1.1",
+            "value": "6.4.x",
             "required": false
         },
         {

--- a/eap/eap64-amq-s2i.json
+++ b/eap/eap64-amq-s2i.json
@@ -30,13 +30,13 @@
         {
             "description": "Git source URI for application",
             "name": "SOURCE_REPOSITORY_URL",
-            "value": "https://github.com/jboss-openshift/openshift-quickstarts.git",
+            "value": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
             "required": true
         },
         {
             "description": "Git branch/tag reference",
             "name": "SOURCE_REPOSITORY_REF",
-            "value": "1.1",
+            "value": "6.4.x",
             "required": false
         },
         {


### PR DESCRIPTION
[CLOUD-299] kie-server doesn't start when JMS is configured
https://issues.jboss.org/browse/CLOUD-299

IMPORTANT: CLOUD-299 is rebased on top of CLOUD-329, so CLOUD-329 should be processed first!