### PR TITLE
[CLOUD-335] jolokia port missing from decisionserver62-amq-s2i.json template

### DIFF
--- a/decisionserver/decisionserver62-amq-s2i.json
+++ b/decisionserver/decisionserver62-amq-s2i.json
@@ -431,6 +431,11 @@
                                 },
                                 "ports": [
                                     {
+                                        "name": "jolokia",
+                                        "containerPort": 8778,
+                                        "protocol": "TCP"
+                                    },
+                                    {
                                         "name": "http",
                                         "containerPort": 8080,
                                         "protocol": "TCP"


### PR DESCRIPTION
[CLOUD-335] jolokia port missing from decisionserver62-amq-s2i.json template
https://issues.jboss.org/browse/CLOUD-335