### PR TITLE
[CLOUD-357] Ensure decisionserver templates work with no parameters being specified

### DIFF
--- a/decisionserver/decisionserver62-amq-s2i.json
+++ b/decisionserver/decisionserver62-amq-s2i.json
@@ -18,7 +18,8 @@
         {
             "description": "The KIE Container deployment configuration in format: containerId=groupId:artifactId:version|c2=g2:a2:v2",
             "name": "KIE_CONTAINER_DEPLOYMENT",
-            "required": true
+            "value": "HelloRulesContainer=org.openshift.quickstarts:decisionserver-hellorules:1.0.0-SNAPSHOT",
+            "required": false
         },
         {
             "description": "The user name to access the KIE Server REST or JMS interface.",
@@ -114,13 +115,13 @@
         {
             "description": "The name associated with the server certificate",
             "name": "EAP_HTTPS_NAME",
-            "value": "",
+            "value": "jboss",
             "required": false
         },
         {
             "description": "The password for the keystore and certificate",
             "name": "EAP_HTTPS_PASSWORD",
-            "value": "",
+            "value": "mykeystorepass",
             "required": false
         },
         {

--- a/decisionserver/decisionserver62-basic-s2i.json
+++ b/decisionserver/decisionserver62-basic-s2i.json
@@ -18,7 +18,8 @@
         {
             "description": "The KIE Container deployment configuration in format: containerId=groupId:artifactId:version|c2=g2:a2:v2",
             "name": "KIE_CONTAINER_DEPLOYMENT",
-            "required": true
+            "value": "HelloRulesContainer=org.openshift.quickstarts:decisionserver-hellorules:1.0.0-SNAPSHOT",
+            "required": false
         },
         {
             "description": "The user name to access the KIE Server REST or JMS interface.",

--- a/decisionserver/decisionserver62-https-s2i.json
+++ b/decisionserver/decisionserver62-https-s2i.json
@@ -18,7 +18,8 @@
         {
             "description": "The KIE Container deployment configuration in format: containerId=groupId:artifactId:version|c2=g2:a2:v2",
             "name": "KIE_CONTAINER_DEPLOYMENT",
-            "required": true
+            "value": "HelloRulesContainer=org.openshift.quickstarts:decisionserver-hellorules:1.0.0-SNAPSHOT",
+            "required": false
         },
         {
             "description": "The protocol to access the KIE Server REST interface.",
@@ -102,13 +103,13 @@
         {
             "description": "The name associated with the server certificate",
             "name": "EAP_HTTPS_NAME",
-            "value": "",
+            "value": "jboss",
             "required": false
         },
         {
             "description": "The password for the keystore and certificate",
             "name": "EAP_HTTPS_PASSWORD",
-            "value": "",
+            "value": "mykeystorepass",
             "required": false
         },
         {


### PR DESCRIPTION
[CLOUD-357] Ensure decisionserver templates work with no parameters being specified
https://issues.jboss.org/browse/CLOUD-357