### PR TITLE
Release notes tweaks

### DIFF
--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -16,65 +16,108 @@ toc::[levels=1]
 
 == JBoss A-MQ
 
+* link:./amq/amq62-basic.adoc[amq62-basic]
 * link:./amq/amq62-persistent-ssl.adoc[amq62-persistent-ssl]
 * link:./amq/amq62-persistent.adoc[amq62-persistent]
 * link:./amq/amq62-ssl.adoc[amq62-ssl]
-* link:./amq/amq62-basic.adoc[amq62-basic]
 
 == JBoss EAP
 
-* link:./eap/eap64-mongodb-persistent-s2i.adoc[eap64-mongodb-persistent-s2i]
-* link:./eap/eap64-https-s2i.adoc[eap64-https-s2i]
-* link:./eap/eap64-mysql-persistent-s2i.adoc[eap64-mysql-persistent-s2i]
-* link:./eap/eap64-postgresql-s2i.adoc[eap64-postgresql-s2i]
-* link:./eap/eap64-basic-s2i.adoc[eap64-basic-s2i]
-* link:./eap/eap64-mysql-s2i.adoc[eap64-mysql-s2i]
-* link:./eap/eap64-mongodb-s2i.adoc[eap64-mongodb-s2i]
-* link:./eap/eap64-amq-s2i.adoc[eap64-amq-s2i]
-* link:./eap/eap64-postgresql-persistent-s2i.adoc[eap64-postgresql-persistent-s2i]
 * link:./eap/eap64-amq-persistent-s2i.adoc[eap64-amq-persistent-s2i]
+* link:./eap/eap64-amq-s2i.adoc[eap64-amq-s2i]
+* link:./eap/eap64-basic-s2i.adoc[eap64-basic-s2i]
+* link:./eap/eap64-https-s2i.adoc[eap64-https-s2i]
+* link:./eap/eap64-mongodb-persistent-s2i.adoc[eap64-mongodb-persistent-s2i]
+* link:./eap/eap64-mongodb-s2i.adoc[eap64-mongodb-s2i]
+* link:./eap/eap64-mysql-persistent-s2i.adoc[eap64-mysql-persistent-s2i]
+* link:./eap/eap64-mysql-s2i.adoc[eap64-mysql-s2i]
+* link:./eap/eap64-postgresql-persistent-s2i.adoc[eap64-postgresql-persistent-s2i]
+* link:./eap/eap64-postgresql-s2i.adoc[eap64-postgresql-s2i]
 
 == secrets
 
-* link:./secrets/jws-app-secret.adoc[jws-app-secret]
-* link:./secrets/eap-app-secret.adoc[eap-app-secret]
 * link:./secrets/amq-app-secret.adoc[amq-app-secret]
 * link:./secrets/datagrid-app-secret.adoc[datagrid-app-secret]
+* link:./secrets/eap-app-secret.adoc[eap-app-secret]
+* link:./secrets/jws-app-secret.adoc[jws-app-secret]
 
 == JBoss Web Server
 
-* link:./webserver/jws30-tomcat8-mysql-persistent-s2i.adoc[jws30-tomcat8-mysql-persistent-s2i]
-* link:./webserver/jws30-tomcat8-mongodb-persistent-s2i.adoc[jws30-tomcat8-mongodb-persistent-s2i]
-* link:./webserver/jws30-tomcat8-https-s2i.adoc[jws30-tomcat8-https-s2i]
+* link:./webserver/jws30-tomcat7-basic-s2i.adoc[jws30-tomcat7-basic-s2i]
+* link:./webserver/jws30-tomcat7-https-s2i.adoc[jws30-tomcat7-https-s2i]
+* link:./webserver/jws30-tomcat7-mongodb-persistent-s2i.adoc[jws30-tomcat7-mongodb-persistent-s2i]
+* link:./webserver/jws30-tomcat7-mongodb-s2i.adoc[jws30-tomcat7-mongodb-s2i]
 * link:./webserver/jws30-tomcat7-mysql-persistent-s2i.adoc[jws30-tomcat7-mysql-persistent-s2i]
+* link:./webserver/jws30-tomcat7-mysql-s2i.adoc[jws30-tomcat7-mysql-s2i]
+* link:./webserver/jws30-tomcat7-postgresql-persistent-s2i.adoc[jws30-tomcat7-postgresql-persistent-s2i]
+* link:./webserver/jws30-tomcat7-postgresql-s2i.adoc[jws30-tomcat7-postgresql-s2i]
+* link:./webserver/jws30-tomcat8-basic-s2i.adoc[jws30-tomcat8-basic-s2i]
+* link:./webserver/jws30-tomcat8-https-s2i.adoc[jws30-tomcat8-https-s2i]
+* link:./webserver/jws30-tomcat8-mongodb-persistent-s2i.adoc[jws30-tomcat8-mongodb-persistent-s2i]
+* link:./webserver/jws30-tomcat8-mongodb-s2i.adoc[jws30-tomcat8-mongodb-s2i]
+* link:./webserver/jws30-tomcat8-mysql-persistent-s2i.adoc[jws30-tomcat8-mysql-persistent-s2i]
+* link:./webserver/jws30-tomcat8-mysql-s2i.adoc[jws30-tomcat8-mysql-s2i]
 * link:./webserver/jws30-tomcat8-postgresql-persistent-s2i.adoc[jws30-tomcat8-postgresql-persistent-s2i]
 * link:./webserver/jws30-tomcat8-postgresql-s2i.adoc[jws30-tomcat8-postgresql-s2i]
-* link:./webserver/jws30-tomcat7-mongodb-persistent-s2i.adoc[jws30-tomcat7-mongodb-persistent-s2i]
-* link:./webserver/jws30-tomcat7-postgresql-s2i.adoc[jws30-tomcat7-postgresql-s2i]
-* link:./webserver/jws30-tomcat7-mysql-s2i.adoc[jws30-tomcat7-mysql-s2i]
-* link:./webserver/jws30-tomcat7-basic-s2i.adoc[jws30-tomcat7-basic-s2i]
-* link:./webserver/jws30-tomcat8-basic-s2i.adoc[jws30-tomcat8-basic-s2i]
-* link:./webserver/jws30-tomcat7-postgresql-persistent-s2i.adoc[jws30-tomcat7-postgresql-persistent-s2i]
-* link:./webserver/jws30-tomcat7-https-s2i.adoc[jws30-tomcat7-https-s2i]
-* link:./webserver/jws30-tomcat8-mongodb-s2i.adoc[jws30-tomcat8-mongodb-s2i]
-* link:./webserver/jws30-tomcat7-mongodb-s2i.adoc[jws30-tomcat7-mongodb-s2i]
-* link:./webserver/jws30-tomcat8-mysql-s2i.adoc[jws30-tomcat8-mysql-s2i]
 
 == JBoss BRMS Realtime Decision Server
 
-* link:./decisionserver/decisionserver62-https-s2i.adoc[decisionserver62-https-s2i]
+* link:./decisionserver/decisionserver62-amq-s2i.adoc[decisionserver62-amq-s2i]
 * link:./decisionserver/decisionserver62-basic-s2i.adoc[decisionserver62-basic-s2i]
+* link:./decisionserver/decisionserver62-https-s2i.adoc[decisionserver62-https-s2i]
 
 == JBoss Data Grid
 
-* link:./datagrid/datagrid65-postgresql.adoc[datagrid65-postgresql]
-* link:./datagrid/datagrid65-remote-cache.adoc[datagrid65-remote-cache]
 * link:./datagrid/datagrid65-basic.adoc[datagrid65-basic]
 * link:./datagrid/datagrid65-https.adoc[datagrid65-https]
 * link:./datagrid/datagrid65-mysql-persistent.adoc[datagrid65-mysql-persistent]
-* link:./datagrid/datagrid65-postgresql-persistent.adoc[datagrid65-postgresql-persistent]
 * link:./datagrid/datagrid65-mysql.adoc[datagrid65-mysql]
+* link:./datagrid/datagrid65-postgresql-persistent.adoc[datagrid65-postgresql-persistent]
+* link:./datagrid/datagrid65-postgresql.adoc[datagrid65-postgresql]
+* link:./datagrid/datagrid65-remote-cache.adoc[datagrid65-remote-cache]
 
-= Release Notes
+////
+  the source for the release notes part of this page is in the file
+  ./release-notes.adoc.in
+////
 
-include::./release-notes.adoc[]
+== Release Notes
+
+=== Release 1.2.0
+ * Added support for JBoss Data Grid
+ * Added support for JBoss Decision Server
+ * Added liveness probe to EAP templates
+ * Encrypt JGroups communication (EAP based templates)
+ * JMS physical names
+ * Add Jolokia port to templates
+ * Renamed APPLICATION_DOMAIN to HOSTNAME_HTTP and HOSTNAME_HTTPS to correspond to http and https routes
+
+=== Release 1.1.0
+ * Added terminationGracePeriodSeconds to pod templates
+ * Renamed templates:
+ ** Include product minor version in names (e.g. eap6-basic-s2i => eap64-basic-s2i)
+ ** Replaced sti with s2i
+ * Add ConfigChange trigger to DeploymentConfig in all templates
+ * Set appropriate defaults so all templates can be instantiated as-is
+ * Image names and tags have changed from product release to xPaaS release (e.g. jboss-eap-6/eap6-openshift:6.4 => jboss-eap-6/eap64-openshift:1.1)
+ * ImageStream names have changed to include minor version in names (e.g. jboss-eap6-openshift => jboss-eap64-openshift) 
+ * Use Kubernetes to locate cluster nodes instead of DNS (e.g. KUBE_PING vs DNS_PING in JGroups configuration)
+ * Add ConfigChange trigger to BuildConfig in all templates
+ * Add forcePull=true to BuildConfig in all templates
+ * Add required=true to all required parameters
+ * Fix inconsistency in A-MQ templates, MQ_PROTOCOL and AMQ_TRANSPORTS
+ * Modified route names to produce better default hostnames
+ * Updated source parameter names to be consistent with other OpenShift templates (e.g. GIT_URI => SOURCE_REPOSITORY_URL)
+ * Add missing mqtt+ssl port to A-MQ templates
+ * Add parameter to select ImageStream namespace, defaulting to "openshift"
+
+=== Release 1.0.2
+ * Fix capitalization of GitHub trigger type
+
+=== Release 1.0.1
+ * Shorten port names
+ * update deprecated items in BuildConfig
+
+=== Release 1.0.0
+ * Initial release with support for JBoss EAP, JBoss Web Server, and JBoss A-MQ
+

--- a/docs/datagrid/datagrid65-basic.adoc
+++ b/docs/datagrid/datagrid65-basic.adoc
@@ -11,6 +11,21 @@
 
 Application template for JDG 6.5 applications.
 
+For simple authentication, set
+
+  JDG_SIMPLE_AUTHENTICATION=true
+  JDG_USERNAME=<username>
+  JDG_PASSWORD=<password>
+
+This will enable user authentication with the datagrid. Provided username and password will be used to access the cache over both HTTPS and HotRod. With this case, the user will have all permissions configured.
+
+Restrictions for password:
+
+  at least 8 characters
+  at least 1 digit
+  at least 1 non-alphanumeric symbol
+
+
 toc::[]
 
 
@@ -24,12 +39,64 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |Variable name |Image Environment Variable |Description |Example value |Required
 
 |`APPLICATION_NAME` | -- | The name for the application. | datagrid-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
+|`JDG_SIMPLE_AUTHENTICATION` | `JDG_SIMPLE_AUTHENTICATION` | Flag to enable/disable simple user authentication | false | False
+|`JDG_SECDOMAIN_NAME` | `JDG_SECDOMAIN_NAME` | Security domain name for user authentication | jdg-openshift | False
+|`JDG_USERNAME` | `JDG_USERNAME` | User name for JDG user. If left empty, it will be generated. | `${JDG_USERNAME}` | False
+|`JDG_PASSWORD` | `JDG_PASSWORD` | Password for JDG user. If left empty, it will be generated. | `${JDG_PASSWORD}` | False
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
-|`JDG_JGROUPS_ENCRYPT_SECRET` | -- | The name of the secret containing the keystore file. | jdg-jgroups-encrypt-secret | False
-|`JDG_JGROUPS_ENCRYPT_KEYSTORE` | -- | "The name of the keystore file within the secret. | keystore.jks | False
-|`JDG_JGROUPS_ENCRYPT_NAME` | -- | The name associated with the server certificate. | jboss | False
-|`JDG_JGROUPS_ENCRYPT_PASSWORD` | -- | The password for the keystore and certificate. | mykeystorepass | False
+|`INFINISPAN_CONNECTORS` | `INFINISPAN_CONNECTORS` | Comma-separated list of connector types that should be configured (defaults to 'memcached,hotrod,rest') | hotrod,memcached,rest | False
+|`HOTROD_CACHE_CONTAINER` | `HOTROD_CACHE_CONTAINER` | The cache container used by the Hot Rod connector (defaults to 'clustered') | clustered | True
+|`HOTROD_SOCKET_BINDING` | `HOTROD_SOCKET_BINDING` | The socket binding port used by the Hot Rod connector (defaults to 'hotrod') | hotrod | True
+|`HOTROD_NAME` | `HOTROD_NAME` |  | `${HOTROD_NAME}` | False
+|`HOTROD_WORKER_THREADS` | `HOTROD_WORKER_THREADS` | The number of worker threads available for the Hot Rod connector (defaults to 160) | `${HOTROD_WORKER_THREADS}` | False
+|`HOTROD_IDLE_TIMEOUT` | `HOTROD_IDLE_TIMEOUT` | The time (in milliseconds) the connector can remain idle before the connection times out (defaults to -1 - no timeout) | `${HOTROD_IDLE_TIMEOUT}` | False
+|`HOTROD_TCP_NODELAY` | `HOTROD_TCP_NODELAY` | Whether TCP packets will be delayed and sent out in batches (defaults to true) | `${HOTROD_TCP_NODELAY}` | False
+|`HOTROD_SEND_BUFFER_SIZE` | `HOTROD_SEND_BUFFER_SIZE` | The size of the send buffer for the Hot Rod connector (defaults to size of the TCP stack buffer) | `${HOTROD_SEND_BUFFER_SIZE}` | False
+|`HOTROD_RECEIVE_BUFFER_SIZE` | `HOTROD_RECEIVE_BUFFER_SIZE` | The size of the receive buffer for the Hot Rod connector (defaults to size of the TCP stack buffer) | `${HOTROD_RECEIVE_BUFFER_SIZE}` | False
+|`TOPOLOGY_CACHE_SUFFIX` | `TOPOLOGY_CACHE_SUFFIX` |  | `${TOPOLOGY_CACHE_SUFFIX}` | False
+|`TOPOLOGY_LOCK_TIMEOUT` | `TOPOLOGY_LOCK_TIMEOUT` | The time (in milliseconds) after which the operation attempting to obtain a lock times out (defaults to 10 seconds) | `${TOPOLOGY_LOCK_TIMEOUT}` | False
+|`TOPOLOGY_REPLICATION_TIMEOUT` | `TOPOLOGY_REPLICATION_TIMEOUT` | The time (in milliseconds) after which the replication operation times out (defaults to 10 seconds) | `${TOPOLOGY_REPLICATION_TIMEOUT}` | False
+|`TOPOLOGY_EXTERNAL_HOST` | `TOPOLOGY_EXTERNAL_HOST` | The hostname sent by the Hot Rod server to clients listed in the topology information (defaults to the host address) | `${TOPOLOGY_EXTERNAL_HOST}` | False
+|`TOPOLOGY_EXTERNAL_PORT` | `TOPOLOGY_EXTERNAL_PORT` | The port sent by the Hot Rod server to clients listed in the topology information (defaults to the configured port) | `${TOPOLOGY_EXTERNAL_PORT}` | False
+|`TOPOLOGY_LAZY_RETRIEVAL` | `TOPOLOGY_LAZY_RETRIEVAL` | Whether the Hot Rod connector will carry out retrieval operations lazily (defaults to true) | `${TOPOLOGY_LAZY_RETRIEVAL}` | False
+|`TOPOLOGY_AWAIT_INITIAL_TRANSFER` | `TOPOLOGY_AWAIT_INITIAL_TRANSFER` | Whether the initial state retrieval happens immediately at startup; applies only when TOPOLOGY_LAZY_RETRIEVAL is set to false (defaults to true) | `${TOPOLOGY_AWAIT_INITIAL_TRANSFER}` | False
+|`AUTHENTICATION_SECURITY_REALM` | `AUTHENTICATION_SECURITY_REALM` |  | `${AUTHENTICATION_SECURITY_REALM}` | False
+|`SASL_SERVER_NAME` | `SASL_SERVER_NAME` |  | `${SASL_SERVER_NAME}` | False
+|`SASL_SECURITY_CONTEXT_NAME` | `SASL_SECURITY_CONTEXT_NAME` |  | `${SASL_SECURITY_CONTEXT_NAME}` | False
+|`SASL_MECHANISMS` | `SASL_MECHANISMS` |  | `${SASL_MECHANISMS}` | False
+|`SASL_QOP` | `SASL_QOP` |  | `${SASL_QOP}` | False
+|`SASL_STRENGTH` | `SASL_STRENGTH` |  | `${SASL_STRENGTH}` | False
+|`SASL_POLICY_FORWARD_SECRECY` | `SASL_POLICY_FORWARD_SECRECY` |  | `${SASL_POLICY_FORWARD_SECRECY}` | False
+|`SASL_POLICY_NO_ACTIVE` | `SASL_POLICY_NO_ACTIVE` |  | `${SASL_POLICY_NO_ACTIVE}` | False
+|`SASL_POLICY_NO_ANONYMOUS` | `SASL_POLICY_NO_ANONYMOUS` |  | `${SASL_POLICY_NO_ANONYMOUS}` | False
+|`SASL_POLICY_NO_DICTIONARY` | `SASL_POLICY_NO_DICTIONARY` |  | `${SASL_POLICY_NO_DICTIONARY}` | False
+|`SASL_POLICY_NO_PLAIN_TEXT` | `SASL_POLICY_NO_PLAIN_TEXT` |  | `${SASL_POLICY_NO_PLAIN_TEXT}` | False
+|`SASL_POLICY_PASS_CREDENTIALS` | `SASL_POLICY_PASS_CREDENTIALS` |  | `${SASL_POLICY_PASS_CREDENTIALS}` | False
+|`SASL_PROPERTIES` | `SASL_PROPERTIES` |  | `${SASL_PROPERTIES}` | False
+|`ENCRYPTION_SECURITY_REALM` | `ENCRYPTION_SECURITY_REALM` |  | `${ENCRYPTION_SECURITY_REALM}` | False
+|`ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH` | `ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH` |  | `${ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH}` | False
+|`MEMCACHED_CACHE_CONTAINER` | `MEMCACHED_CACHE_CONTAINER` | The cache container used by the memcached connector (defaults to 'clustered') | clustered | True
+|`MEMCACHED_CACHE` | `MEMCACHED_CACHE_CONTAINER` | The name of the cache to expose through this memcached connector (defaults to 'default') | default | False
+|`MEMCACHED_SOCKET_BINDING` | `MEMCACHED_SOCKET_BINDING` | The socked binding port used by the memcached connector (defaults to 'memcached') | memcached | True
+|`MEMCACHED_NAME` | `MEMCACHED_NAME` | The name of this memcached connector (defaults to 'memcached') | memcached | False
+|`MEMCACHED_WORKER_THREADS` | `MEMCACHED_WORKER_THREADS` | The number of worker threads available for the memcached connector (defaults to 160) | `${MEMCACHED_WORKER_THREADS}` | False
+|`MEMCACHED_IDLE_TIMEOUT` | `MEMCACHED_IDLE_TIMEOUT` | The time (in milliseconds) the connector can remain idle before the connection times out (defaults to -1 - no timeout) | `${MEMCACHED_IDLE_TIMEOUT}` | False
+|`MEMCACHED_TCP_NODELAY` | `MEMCACHED_TCP_NODELAY` | Whether TCP packets will be delayed and sent out in batches (defaults to true) | `${MEMCACHED_TCP_NODELAY}` | False
+|`MEMCACHED_SEND_BUFFER_SIZE` | `MEMCACHED_SEND_BUFFER_SIZE` | The size of the send buffer for the memcached connector (defaults to the size of the TCP stack buffer) | `${MEMCACHED_SEND_BUFFER_SIZE}` | False
+|`MEMCACHED_RECEIVE_BUFFER_SIZE` | `MEMCACHED_RECEIVE_BUFFER_SIZE` | The size of the receive buffer for the memcached connector (defaults to the size of the TCP stack buffer) | `${MEMCACHED_RECEIVE_BUFFER_SIZE}` | False
+|`REST_VIRTUAL_SERVER` | `REST_VIRTUAL_SERVER` | The virtual server used by the REST connector (defaults to 'default-host') | `${REST_VIRTUAL_SERVER}` | False
+|`REST_CACHE_CONTAINER` | `REST_CACHE_CONTAINER` | The cache container used by the REST connector (defaults to 'clustered') | clustered | True
+|`REST_CONTEXT_PATH` | `REST_CONTEXT_PATH` | The context path for the REST connector (defaults to '') | `${REST_CONTEXT_PATH}` | False
+|`REST_SECURITY_DOMAIN` | `REST_SECURITY_DOMAIN` | The domain, declared in the security subsystem, that should be used to authenticate access to the REST endpoint | `${REST_SECURITY_DOMAIN}` | False
+|`REST_AUTH_METHOD` | `REST_AUTH_METHOD` | The method used to retrieve credentials for the REST endpoint (defaults to 'BASIC') | `${REST_AUTH_METHOD}` | False
+|`REST_SECURITY_MODE` | `REST_SECURITY_MODE` | Whether authentication is required only for WRITE operations or for READ operations as well (defaults to 'READ_WRITE') | `${REST_SECURITY_MODE}` | False
+|`REST_EXTENDED_HEADERS` | `REST_EXTENDED_HEADERS` |  | `${REST_EXTENDED_HEADERS}` | False
+|`JDG_JGROUPS_ENCRYPT_SECRET` | `JDG_JGROUPS_ENCRYPT_SECRET` | The name of the secret containing the keystore file | `${JDG_JGROUPS_ENCRYPT_SECRET}` | False
+|`JDG_JGROUPS_ENCRYPT_KEYSTORE` | `JDG_JGROUPS_ENCRYPT_KEYSTORE` | The name of the keystore file within the secret | `${JDG_JGROUPS_ENCRYPT_KEYSTORE}` | False
+|`JDG_JGROUPS_ENCRYPT_NAME` | `JDG_JGROUPS_ENCRYPT_NAME` | The name associated with the server certificate | `${JDG_JGROUPS_ENCRYPT_NAME}` | False
+|`JDG_JGROUPS_ENCRYPT_PASSWORD` | `JDG_JGROUPS_ENCRYPT_PASSWORD` | The password for the keystore and certificate | `${JDG_JGROUPS_ENCRYPT_PASSWORD}` | False
+|`JGROUPS_CLUSTER_PASSWORD` | `JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}` | True
 |=======================================================================
 
 
@@ -65,9 +132,7 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-memcached` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-hotrod` | none | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
 |=============
 
 
@@ -148,7 +213,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.4+| `${APPLICATION_NAME}`
+.5+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |ping | 8888 | `TCP`
 |memcached | 11211 | `TCP`
@@ -162,9 +228,65 @@ information.
 |=======================================================================
 |Deployment |Variable name |Description |Example value
 
-.2+| `${APPLICATION_NAME}`
+.58+| `${APPLICATION_NAME}`
+|`JDG_SIMPLE_AUTHENTICATION` | Flag to enable/disable simple user authentication | `${JDG_SIMPLE_AUTHENTICATION}`
+|`JDG_USERNAME` | User name for JDG user. If left empty, it will be generated. | `${JDG_USERNAME}`
+|`JDG_PASSWORD` | Password for JDG user. If left empty, it will be generated. | `${JDG_PASSWORD}`
+|`JDG_SECDOMAIN_NAME` | Security domain name for user authentication | `${JDG_SECDOMAIN_NAME}`
 |`OPENSHIFT_KUBE_PING_LABELS` | -- | `application=${APPLICATION_NAME}`
 |`OPENSHIFT_KUBE_PING_NAMESPACE` | -- | --
+|`INFINISPAN_CONNECTORS` | Comma-separated list of connector types that should be configured (defaults to 'memcached,hotrod,rest') | `${INFINISPAN_CONNECTORS}`
+|`HOTROD_CACHE_CONTAINER` | The cache container used by the Hot Rod connector (defaults to 'clustered') | `${HOTROD_CACHE_CONTAINER}`
+|`HOTROD_SOCKET_BINDING` | The socket binding port used by the Hot Rod connector (defaults to 'hotrod') | `${HOTROD_SOCKET_BINDING}`
+|`HOTROD_NAME` |  | `${HOTROD_NAME}`
+|`HOTROD_WORKER_THREADS` | The number of worker threads available for the Hot Rod connector (defaults to 160) | `${HOTROD_WORKER_THREADS}`
+|`HOTROD_IDLE_TIMEOUT` | The time (in milliseconds) the connector can remain idle before the connection times out (defaults to -1 - no timeout) | `${HOTROD_IDLE_TIMEOUT}`
+|`HOTROD_TCP_NODELAY` | Whether TCP packets will be delayed and sent out in batches (defaults to true) | `${HOTROD_TCP_NODELAY}`
+|`HOTROD_SEND_BUFFER_SIZE` | The size of the send buffer for the Hot Rod connector (defaults to size of the TCP stack buffer) | `${HOTROD_SEND_BUFFER_SIZE}`
+|`HOTROD_RECEIVE_BUFFER_SIZE` | The size of the receive buffer for the Hot Rod connector (defaults to size of the TCP stack buffer) | `${HOTROD_RECEIVE_BUFFER_SIZE}`
+|`TOPOLOGY_CACHE_SUFFIX` |  | `${TOPOLOGY_CACHE_SUFFIX}`
+|`TOPOLOGY_LOCK_TIMEOUT` | The time (in milliseconds) after which the operation attempting to obtain a lock times out (defaults to 10 seconds) | `${TOPOLOGY_LOCK_TIMEOUT}`
+|`TOPOLOGY_REPLICATION_TIMEOUT` | The time (in milliseconds) after which the replication operation times out (defaults to 10 seconds) | `${TOPOLOGY_REPLICATION_TIMEOUT}`
+|`TOPOLOGY_EXTERNAL_HOST` | The hostname sent by the Hot Rod server to clients listed in the topology information (defaults to the host address) | `${TOPOLOGY_EXTERNAL_HOST}`
+|`TOPOLOGY_EXTERNAL_PORT` | The port sent by the Hot Rod server to clients listed in the topology information (defaults to the configured port) | `${TOPOLOGY_EXTERNAL_PORT}`
+|`TOPOLOGY_LAZY_RETRIEVAL` | Whether the Hot Rod connector will carry out retrieval operations lazily (defaults to true) | `${TOPOLOGY_LAZY_RETRIEVAL}`
+|`TOPOLOGY_AWAIT_INITIAL_TRANSFER` | Whether the initial state retrieval happens immediately at startup; applies only when TOPOLOGY_LAZY_RETRIEVAL is set to false (defaults to true) | `${TOPOLOGY_AWAIT_INITIAL_TRANSFER}`
+|`AUTHENTICATION_SECURITY_REALM` |  | `${AUTHENTICATION_SECURITY_REALM}`
+|`SASL_SERVER_NAME` |  | `${SASL_SERVER_NAME}`
+|`SASL_SECURITY_CONTEXT_NAME` |  | `${SASL_SECURITY_CONTEXT_NAME}`
+|`SASL_MECHANISMS` |  | `${SASL_MECHANISMS}`
+|`SASL_QOP` |  | `${SASL_QOP}`
+|`SASL_STRENGTH` |  | `${SASL_STRENGTH}`
+|`SASL_POLICY_FORWARD_SECRECY` |  | `${SASL_POLICY_FORWARD_SECRECY}`
+|`SASL_POLICY_NO_ACTIVE` |  | `${SASL_POLICY_NO_ACTIVE}`
+|`SASL_POLICY_NO_ANONYMOUS` |  | `${SASL_POLICY_NO_ANONYMOUS}`
+|`SASL_POLICY_NO_DICTIONARY` |  | `${SASL_POLICY_NO_DICTIONARY}`
+|`SASL_POLICY_NO_PLAIN_TEXT` |  | `${SASL_POLICY_NO_PLAIN_TEXT}`
+|`SASL_POLICY_PASS_CREDENTIALS` |  | `${SASL_POLICY_PASS_CREDENTIALS}`
+|`SASL_PROPERTIES` |  | `${SASL_PROPERTIES}`
+|`ENCRYPTION_SECURITY_REALM` |  | `${ENCRYPTION_SECURITY_REALM}`
+|`ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH` |  | `${ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH}`
+|`MEMCACHED_CACHE_CONTAINER` | The cache container used by the memcached connector (defaults to 'clustered') | `${MEMCACHED_CACHE_CONTAINER}`
+|`MEMCACHED_CACHE` | The cache container used by the memcached connector (defaults to 'clustered') | `${MEMCACHED_CACHE}`
+|`MEMCACHED_SOCKET_BINDING` | The socked binding port used by the memcached connector (defaults to 'memcached') | `${MEMCACHED_SOCKET_BINDING}`
+|`MEMCACHED_NAME` | The name of this memcached connector (defaults to 'memcached') | `${MEMCACHED_NAME}`
+|`MEMCACHED_WORKER_THREADS` | The number of worker threads available for the memcached connector (defaults to 160) | `${MEMCACHED_WORKER_THREADS}`
+|`MEMCACHED_IDLE_TIMEOUT` | The time (in milliseconds) the connector can remain idle before the connection times out (defaults to -1 - no timeout) | `${MEMCACHED_IDLE_TIMEOUT}`
+|`MEMCACHED_TCP_NODELAY` | Whether TCP packets will be delayed and sent out in batches (defaults to true) | `${MEMCACHED_TCP_NODELAY}`
+|`MEMCACHED_SEND_BUFFER_SIZE` | The size of the send buffer for the memcached connector (defaults to the size of the TCP stack buffer) | `${MEMCACHED_SEND_BUFFER_SIZE}`
+|`MEMCACHED_RECEIVE_BUFFER_SIZE` | The size of the receive buffer for the memcached connector (defaults to the size of the TCP stack buffer) | `${MEMCACHED_RECEIVE_BUFFER_SIZE}`
+|`REST_VIRTUAL_SERVER` | The virtual server used by the REST connector (defaults to 'default-host') | `${REST_VIRTUAL_SERVER}`
+|`REST_CACHE_CONTAINER` | The cache container used by the REST connector (defaults to 'clustered') | `${REST_CACHE_CONTAINER}`
+|`REST_CONTEXT_PATH` | The context path for the REST connector (defaults to '') | `${REST_CONTEXT_PATH}`
+|`REST_SECURITY_DOMAIN` | The domain, declared in the security subsystem, that should be used to authenticate access to the REST endpoint | `${REST_SECURITY_DOMAIN}`
+|`REST_AUTH_METHOD` | The method used to retrieve credentials for the REST endpoint (defaults to 'BASIC') | `${REST_AUTH_METHOD}`
+|`REST_SECURITY_MODE` | Whether authentication is required only for WRITE operations or for READ operations as well (defaults to 'READ_WRITE') | `${REST_SECURITY_MODE}`
+|`REST_EXTENDED_HEADERS` |  | `${REST_EXTENDED_HEADERS}`
+|`JDG_JGROUPS_ENCRYPT_SECRET` | The name of the secret containing the keystore file | `${JDG_JGROUPS_ENCRYPT_SECRET}`
+|`JDG_JGROUPS_ENCRYPT_KEYSTORE` | The name of the keystore file within the secret | `${JDG_JGROUPS_ENCRYPT_KEYSTORE}`
+|`JDG_JGROUPS_ENCRYPT_NAME` | The name associated with the server certificate | `${JDG_JGROUPS_ENCRYPT_NAME}`
+|`JDG_JGROUPS_ENCRYPT_PASSWORD` | The password for the keystore and certificate | `${JDG_JGROUPS_ENCRYPT_PASSWORD}`
+|`JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}`
 |=======================================================================
 
 

--- a/docs/datagrid/datagrid65-https.adoc
+++ b/docs/datagrid/datagrid65-https.adoc
@@ -11,6 +11,21 @@
 
 Application template for JDG 6.5 applications.
 
+For simple authentication, set
+
+  JDG_SIMPLE_AUTHENTICATION=true
+  JDG_USERNAME=<username>
+  JDG_PASSWORD=<password>
+
+This will enable user authentication with the datagrid. Provided username and password will be used to access the cache over both HTTPS and HotRod. With this case, the user will have all permissions configured.
+
+Restrictions for password:
+
+  at least 8 characters
+  at least 1 digit
+  at least 1 non-alphanumeric symbol
+
+
 toc::[]
 
 
@@ -24,12 +39,69 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |Variable name |Image Environment Variable |Description |Example value |Required
 
 |`APPLICATION_NAME` | -- | The name for the application. | datagrid-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
+|`HOSTNAME_HTTPS` | -- | Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-<project>.<default-domain-suffix> | -- | False
+|`JDG_SIMPLE_AUTHENTICATION` | `JDG_SIMPLE_AUTHENTICATION` | Flag to enable/disable user authentication | false | False
+|`JDG_SECDOMAIN_NAME` | `JDG_SECDOMAIN_NAME` | Security domain name for user authentication | jdg-openshift | False
+|`JDG_USERNAME` | `JDG_USERNAME` | User name for JDG user. If left empty, it will be generated. | `${JDG_USERNAME}` | False
+|`JDG_PASSWORD` | `JDG_PASSWORD` | Password for JDG user. If left empty, it will be generated. | `${JDG_PASSWORD}` | False
 |`JDG_HTTPS_SECRET` | -- | The name of the secret containing the keystore file | datagrid-app-secret | True
 |`JDG_HTTPS_KEYSTORE` | `JDG_HTTPS_KEYSTORE_DIR` | The name of the keystore file within the secret | keystore.jks | False
 |`JDG_HTTPS_NAME` | `JDG_HTTPS_NAME` | The name associated with the server certificate | `${JDG_HTTPS_NAME}` | False
 |`JDG_HTTPS_PASSWORD` | `JDG_HTTPS_PASSWORD` | The password for the keystore and certificate | `${JDG_HTTPS_PASSWORD}` | False
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
+|`INFINISPAN_CONNECTORS` | `INFINISPAN_CONNECTORS` | Comma-separated list of connector types that should be configured (defaults to 'memcached,hotrod,rest') | hotrod,memcached,rest | False
+|`HOTROD_CACHE_CONTAINER` | `HOTROD_CACHE_CONTAINER` | The cache container used by the Hot Rod connector (defaults to 'clustered') | clustered | True
+|`HOTROD_SOCKET_BINDING` | `HOTROD_SOCKET_BINDING` | The socket binding port used by the Hot Rod connector (defaults to 'hotrod') | hotrod | True
+|`HOTROD_NAME` | `HOTROD_NAME` |  | `${HOTROD_NAME}` | False
+|`HOTROD_WORKER_THREADS` | `HOTROD_WORKER_THREADS` | The number of worker threads available for the Hot Rod connector (defaults to 160) | `${HOTROD_WORKER_THREADS}` | False
+|`HOTROD_IDLE_TIMEOUT` | `HOTROD_IDLE_TIMEOUT` | The time (in milliseconds) the connector can remain idle before the connection times out (defaults to -1 - no timeout) | `${HOTROD_IDLE_TIMEOUT}` | False
+|`HOTROD_TCP_NODELAY` | `HOTROD_TCP_NODELAY` | Whether TCP packets will be delayed and sent out in batches (defaults to true) | `${HOTROD_TCP_NODELAY}` | False
+|`HOTROD_SEND_BUFFER_SIZE` | `HOTROD_SEND_BUFFER_SIZE` | The size of the send buffer for the Hot Rod connector (defaults to size of the TCP stack buffer) | `${HOTROD_SEND_BUFFER_SIZE}` | False
+|`HOTROD_RECEIVE_BUFFER_SIZE` | `HOTROD_RECEIVE_BUFFER_SIZE` | The size of the receive buffer for the Hot Rod connector (defaults to size of the TCP stack buffer) | `${HOTROD_RECEIVE_BUFFER_SIZE}` | False
+|`TOPOLOGY_CACHE_SUFFIX` | `TOPOLOGY_CACHE_SUFFIX` |  | `${TOPOLOGY_CACHE_SUFFIX}` | False
+|`TOPOLOGY_LOCK_TIMEOUT` | `TOPOLOGY_LOCK_TIMEOUT` | The time (in milliseconds) after which the operation attempting to obtain a lock times out (defaults to 10 seconds) | `${TOPOLOGY_LOCK_TIMEOUT}` | False
+|`TOPOLOGY_REPLICATION_TIMEOUT` | `TOPOLOGY_REPLICATION_TIMEOUT` | The time (in milliseconds) after which the replication operation times out (defaults to 10 seconds) | `${TOPOLOGY_REPLICATION_TIMEOUT}` | False
+|`TOPOLOGY_EXTERNAL_HOST` | `TOPOLOGY_EXTERNAL_HOST` | The hostname sent by the Hot Rod server to clients listed in the topology information (defaults to the host address) | `${TOPOLOGY_EXTERNAL_HOST}` | False
+|`TOPOLOGY_EXTERNAL_PORT` | `TOPOLOGY_EXTERNAL_PORT` | The port sent by the Hot Rod server to clients listed in the topology information (defaults to the configured port) | `${TOPOLOGY_EXTERNAL_PORT}` | False
+|`TOPOLOGY_LAZY_RETRIEVAL` | `TOPOLOGY_LAZY_RETRIEVAL` | Whether the Hot Rod connector will carry out retrieval operations lazily (defaults to true) | `${TOPOLOGY_LAZY_RETRIEVAL}` | False
+|`TOPOLOGY_AWAIT_INITIAL_TRANSFER` | `TOPOLOGY_AWAIT_INITIAL_TRANSFER` | Whether the initial state retrieval happens immediately at startup; applies only when TOPOLOGY_LAZY_RETRIEVAL is set to false (defaults to true) | `${TOPOLOGY_AWAIT_INITIAL_TRANSFER}` | False
+|`AUTHENTICATION_SECURITY_REALM` | `AUTHENTICATION_SECURITY_REALM` |  | `${AUTHENTICATION_SECURITY_REALM}` | False
+|`SASL_SERVER_NAME` | `SASL_SERVER_NAME` |  | `${SASL_SERVER_NAME}` | False
+|`SASL_SECURITY_CONTEXT_NAME` | `SASL_SECURITY_CONTEXT_NAME` |  | `${SASL_SECURITY_CONTEXT_NAME}` | False
+|`SASL_MECHANISMS` | `SASL_MECHANISMS` |  | `${SASL_MECHANISMS}` | False
+|`SASL_QOP` | `SASL_QOP` |  | `${SASL_QOP}` | False
+|`SASL_STRENGTH` | `SASL_STRENGTH` |  | `${SASL_STRENGTH}` | False
+|`SASL_POLICY_FORWARD_SECRECY` | `SASL_POLICY_FORWARD_SECRECY` |  | `${SASL_POLICY_FORWARD_SECRECY}` | False
+|`SASL_POLICY_NO_ACTIVE` | `SASL_POLICY_NO_ACTIVE` |  | `${SASL_POLICY_NO_ACTIVE}` | False
+|`SASL_POLICY_NO_ANONYMOUS` | `SASL_POLICY_NO_ANONYMOUS` |  | `${SASL_POLICY_NO_ANONYMOUS}` | False
+|`SASL_POLICY_NO_DICTIONARY` | `SASL_POLICY_NO_DICTIONARY` |  | `${SASL_POLICY_NO_DICTIONARY}` | False
+|`SASL_POLICY_NO_PLAIN_TEXT` | `SASL_POLICY_NO_PLAIN_TEXT` |  | `${SASL_POLICY_NO_PLAIN_TEXT}` | False
+|`SASL_POLICY_PASS_CREDENTIALS` | `SASL_POLICY_PASS_CREDENTIALS` |  | `${SASL_POLICY_PASS_CREDENTIALS}` | False
+|`SASL_PROPERTIES` | `SASL_PROPERTIES` |  | `${SASL_PROPERTIES}` | False
+|`ENCRYPTION_SECURITY_REALM` | `ENCRYPTION_SECURITY_REALM` |  | `${ENCRYPTION_SECURITY_REALM}` | False
+|`ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH` | `ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH` |  | `${ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH}` | False
+|`MEMCACHED_CACHE_CONTAINER` | `MEMCACHED_CACHE_CONTAINER` | The cache container used by the memcached connector (defaults to 'clustered') | clustered | True
+|`MEMCACHED_CACHE` | `MEMCACHED_CACHE_CONTAINER` | The name of the cache to expose through this memcached connector (defaults to 'default') | default | False
+|`MEMCACHED_SOCKET_BINDING` | `MEMCACHED_SOCKET_BINDING` | The socked binding port used by the memcached connector (defaults to 'memcached') | memcached | True
+|`MEMCACHED_NAME` | `MEMCACHED_NAME` | The name of this memcached connector (defaults to 'memcached') | memcached | False
+|`MEMCACHED_WORKER_THREADS` | `MEMCACHED_WORKER_THREADS` | The number of worker threads available for the memcached connector (defaults to 160) | `${MEMCACHED_WORKER_THREADS}` | False
+|`MEMCACHED_IDLE_TIMEOUT` | `MEMCACHED_IDLE_TIMEOUT` | The time (in milliseconds) the connector can remain idle before the connection times out (defaults to -1 - no timeout) | `${MEMCACHED_IDLE_TIMEOUT}` | False
+|`MEMCACHED_TCP_NODELAY` | `MEMCACHED_TCP_NODELAY` | Whether TCP packets will be delayed and sent out in batches (defaults to true) | `${MEMCACHED_TCP_NODELAY}` | False
+|`MEMCACHED_SEND_BUFFER_SIZE` | `MEMCACHED_SEND_BUFFER_SIZE` | The size of the send buffer for the memcached connector (defaults to the size of the TCP stack buffer) | `${MEMCACHED_SEND_BUFFER_SIZE}` | False
+|`MEMCACHED_RECEIVE_BUFFER_SIZE` | `MEMCACHED_RECEIVE_BUFFER_SIZE` | The size of the receive buffer for the memcached connector (defaults to the size of the TCP stack buffer) | `${MEMCACHED_RECEIVE_BUFFER_SIZE}` | False
+|`REST_VIRTUAL_SERVER` | `REST_VIRTUAL_SERVER` | The virtual server used by the REST connector (defaults to 'default-host') | `${REST_VIRTUAL_SERVER}` | False
+|`REST_CACHE_CONTAINER` | `REST_CACHE_CONTAINER` | The cache container used by the REST connector (defaults to 'clustered') | clustered | True
+|`REST_CONTEXT_PATH` | `REST_CONTEXT_PATH` | The context path for the REST connector (defaults to '') | `${REST_CONTEXT_PATH}` | False
+|`REST_SECURITY_DOMAIN` | `REST_SECURITY_DOMAIN` | The domain, declared in the security subsystem, that should be used to authenticate access to the REST endpoint | `${REST_SECURITY_DOMAIN}` | False
+|`REST_AUTH_METHOD` | `REST_AUTH_METHOD` | The method used to retrieve credentials for the REST endpoint (defaults to 'BASIC') | `${REST_AUTH_METHOD}` | False
+|`REST_SECURITY_MODE` | `REST_SECURITY_MODE` | Whether authentication is required only for WRITE operations or for READ operations as well (defaults to 'READ_WRITE') | `${REST_SECURITY_MODE}` | False
+|`REST_EXTENDED_HEADERS` | `REST_EXTENDED_HEADERS` |  | `${REST_EXTENDED_HEADERS}` | False
+|`JDG_JGROUPS_ENCRYPT_SECRET` | `JDG_JGROUPS_ENCRYPT_SECRET` | The name of the secret containing the keystore file | `${JDG_JGROUPS_ENCRYPT_SECRET}` | False
+|`JDG_JGROUPS_ENCRYPT_KEYSTORE` | `JDG_JGROUPS_ENCRYPT_KEYSTORE` | The name of the keystore file within the secret | `${JDG_JGROUPS_ENCRYPT_KEYSTORE}` | False
+|`JDG_JGROUPS_ENCRYPT_NAME` | `JDG_JGROUPS_ENCRYPT_NAME` | The name associated with the server certificate | `${JDG_JGROUPS_ENCRYPT_NAME}` | False
+|`JDG_JGROUPS_ENCRYPT_PASSWORD` | `JDG_JGROUPS_ENCRYPT_PASSWORD` | The password for the keystore and certificate | `${JDG_JGROUPS_ENCRYPT_PASSWORD}` | False
+|`JGROUPS_CLUSTER_PASSWORD` | `JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}` | True
 |=======================================================================
 
 
@@ -66,10 +138,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-https` | TLS passthrough | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-memcached` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-hotrod` | none | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
+|`${APPLICATION_NAME}-https` | TLS passthrough | `${HOSTNAME_HTTPS}`
 |=============
 
 
@@ -151,7 +221,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.5+| `${APPLICATION_NAME}`
+.6+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |https | 8443 | `TCP`
 |ping | 8888 | `TCP`
@@ -166,13 +237,69 @@ information.
 |=======================================================================
 |Deployment |Variable name |Description |Example value
 
-.6+| `${APPLICATION_NAME}`
+.62+| `${APPLICATION_NAME}`
+|`JDG_SIMPLE_AUTHENTICATION` | Flag to enable/disable user authentication | `${JDG_SIMPLE_AUTHENTICATION}`
+|`JDG_USERNAME` | User name for JDG user. If left empty, it will be generated. | `${JDG_USERNAME}`
+|`JDG_PASSWORD` | Password for JDG user. If left empty, it will be generated. | `${JDG_PASSWORD}`
+|`JDG_SECDOMAIN_NAME` | Security domain name for user authentication | `${JDG_SECDOMAIN_NAME}`
 |`JDG_HTTPS_KEYSTORE_DIR` | The name of the keystore file within the secret | `/etc/datagrid-secret-volume`
 |`JDG_HTTPS_KEYSTORE` | The name of the keystore file within the secret | `${JDG_HTTPS_KEYSTORE}`
 |`JDG_HTTPS_NAME` | The name associated with the server certificate | `${JDG_HTTPS_NAME}`
 |`JDG_HTTPS_PASSWORD` | The password for the keystore and certificate | `${JDG_HTTPS_PASSWORD}`
 |`OPENSHIFT_KUBE_PING_LABELS` | -- | `application=${APPLICATION_NAME}`
 |`OPENSHIFT_KUBE_PING_NAMESPACE` | -- | --
+|`INFINISPAN_CONNECTORS` | Comma-separated list of connector types that should be configured (defaults to 'memcached,hotrod,rest') | `${INFINISPAN_CONNECTORS}`
+|`HOTROD_CACHE_CONTAINER` | The cache container used by the Hot Rod connector (defaults to 'clustered') | `${HOTROD_CACHE_CONTAINER}`
+|`HOTROD_SOCKET_BINDING` | The socket binding port used by the Hot Rod connector (defaults to 'hotrod') | `${HOTROD_SOCKET_BINDING}`
+|`HOTROD_NAME` |  | `${HOTROD_NAME}`
+|`HOTROD_WORKER_THREADS` | The number of worker threads available for the Hot Rod connector (defaults to 160) | `${HOTROD_WORKER_THREADS}`
+|`HOTROD_IDLE_TIMEOUT` | The time (in milliseconds) the connector can remain idle before the connection times out (defaults to -1 - no timeout) | `${HOTROD_IDLE_TIMEOUT}`
+|`HOTROD_TCP_NODELAY` | Whether TCP packets will be delayed and sent out in batches (defaults to true) | `${HOTROD_TCP_NODELAY}`
+|`HOTROD_SEND_BUFFER_SIZE` | The size of the send buffer for the Hot Rod connector (defaults to size of the TCP stack buffer) | `${HOTROD_SEND_BUFFER_SIZE}`
+|`HOTROD_RECEIVE_BUFFER_SIZE` | The size of the receive buffer for the Hot Rod connector (defaults to size of the TCP stack buffer) | `${HOTROD_RECEIVE_BUFFER_SIZE}`
+|`TOPOLOGY_CACHE_SUFFIX` |  | `${TOPOLOGY_CACHE_SUFFIX}`
+|`TOPOLOGY_LOCK_TIMEOUT` | The time (in milliseconds) after which the operation attempting to obtain a lock times out (defaults to 10 seconds) | `${TOPOLOGY_LOCK_TIMEOUT}`
+|`TOPOLOGY_REPLICATION_TIMEOUT` | The time (in milliseconds) after which the replication operation times out (defaults to 10 seconds) | `${TOPOLOGY_REPLICATION_TIMEOUT}`
+|`TOPOLOGY_EXTERNAL_HOST` | The hostname sent by the Hot Rod server to clients listed in the topology information (defaults to the host address) | `${TOPOLOGY_EXTERNAL_HOST}`
+|`TOPOLOGY_EXTERNAL_PORT` | The port sent by the Hot Rod server to clients listed in the topology information (defaults to the configured port) | `${TOPOLOGY_EXTERNAL_PORT}`
+|`TOPOLOGY_LAZY_RETRIEVAL` | Whether the Hot Rod connector will carry out retrieval operations lazily (defaults to true) | `${TOPOLOGY_LAZY_RETRIEVAL}`
+|`TOPOLOGY_AWAIT_INITIAL_TRANSFER` | Whether the initial state retrieval happens immediately at startup; applies only when TOPOLOGY_LAZY_RETRIEVAL is set to false (defaults to true) | `${TOPOLOGY_AWAIT_INITIAL_TRANSFER}`
+|`AUTHENTICATION_SECURITY_REALM` |  | `${AUTHENTICATION_SECURITY_REALM}`
+|`SASL_SERVER_NAME` |  | `${SASL_SERVER_NAME}`
+|`SASL_SECURITY_CONTEXT_NAME` |  | `${SASL_SECURITY_CONTEXT_NAME}`
+|`SASL_MECHANISMS` |  | `${SASL_MECHANISMS}`
+|`SASL_QOP` |  | `${SASL_QOP}`
+|`SASL_STRENGTH` |  | `${SASL_STRENGTH}`
+|`SASL_POLICY_FORWARD_SECRECY` |  | `${SASL_POLICY_FORWARD_SECRECY}`
+|`SASL_POLICY_NO_ACTIVE` |  | `${SASL_POLICY_NO_ACTIVE}`
+|`SASL_POLICY_NO_ANONYMOUS` |  | `${SASL_POLICY_NO_ANONYMOUS}`
+|`SASL_POLICY_NO_DICTIONARY` |  | `${SASL_POLICY_NO_DICTIONARY}`
+|`SASL_POLICY_NO_PLAIN_TEXT` |  | `${SASL_POLICY_NO_PLAIN_TEXT}`
+|`SASL_POLICY_PASS_CREDENTIALS` |  | `${SASL_POLICY_PASS_CREDENTIALS}`
+|`SASL_PROPERTIES` |  | `${SASL_PROPERTIES}`
+|`ENCRYPTION_SECURITY_REALM` |  | `${ENCRYPTION_SECURITY_REALM}`
+|`ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH` |  | `${ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH}`
+|`MEMCACHED_CACHE_CONTAINER` | The cache container used by the memcached connector (defaults to 'clustered') | `${MEMCACHED_CACHE_CONTAINER}`
+|`MEMCACHED_CACHE` | The cache container used by the memcached connector (defaults to 'clustered') | `${MEMCACHED_CACHE}`
+|`MEMCACHED_SOCKET_BINDING` | The socked binding port used by the memcached connector (defaults to 'memcached') | `${MEMCACHED_SOCKET_BINDING}`
+|`MEMCACHED_NAME` | The name of this memcached connector (defaults to 'memcached') | `${MEMCACHED_NAME}`
+|`MEMCACHED_WORKER_THREADS` | The number of worker threads available for the memcached connector (defaults to 160) | `${MEMCACHED_WORKER_THREADS}`
+|`MEMCACHED_IDLE_TIMEOUT` | The time (in milliseconds) the connector can remain idle before the connection times out (defaults to -1 - no timeout) | `${MEMCACHED_IDLE_TIMEOUT}`
+|`MEMCACHED_TCP_NODELAY` | Whether TCP packets will be delayed and sent out in batches (defaults to true) | `${MEMCACHED_TCP_NODELAY}`
+|`MEMCACHED_SEND_BUFFER_SIZE` | The size of the send buffer for the memcached connector (defaults to the size of the TCP stack buffer) | `${MEMCACHED_SEND_BUFFER_SIZE}`
+|`MEMCACHED_RECEIVE_BUFFER_SIZE` | The size of the receive buffer for the memcached connector (defaults to the size of the TCP stack buffer) | `${MEMCACHED_RECEIVE_BUFFER_SIZE}`
+|`REST_VIRTUAL_SERVER` | The virtual server used by the REST connector (defaults to 'default-host') | `${REST_VIRTUAL_SERVER}`
+|`REST_CACHE_CONTAINER` | The cache container used by the REST connector (defaults to 'clustered') | `${REST_CACHE_CONTAINER}`
+|`REST_CONTEXT_PATH` | The context path for the REST connector (defaults to '') | `${REST_CONTEXT_PATH}`
+|`REST_SECURITY_DOMAIN` | The domain, declared in the security subsystem, that should be used to authenticate access to the REST endpoint | `${REST_SECURITY_DOMAIN}`
+|`REST_AUTH_METHOD` | The method used to retrieve credentials for the REST endpoint (defaults to 'BASIC') | `${REST_AUTH_METHOD}`
+|`REST_SECURITY_MODE` | Whether authentication is required only for WRITE operations or for READ operations as well (defaults to 'READ_WRITE') | `${REST_SECURITY_MODE}`
+|`REST_EXTENDED_HEADERS` |  | `${REST_EXTENDED_HEADERS}`
+|`JDG_JGROUPS_ENCRYPT_SECRET` | The name of the secret containing the keystore file | `${JDG_JGROUPS_ENCRYPT_SECRET}`
+|`JDG_JGROUPS_ENCRYPT_KEYSTORE` | The name of the keystore file within the secret | `${JDG_JGROUPS_ENCRYPT_KEYSTORE}`
+|`JDG_JGROUPS_ENCRYPT_NAME` | The name associated with the server certificate | `${JDG_JGROUPS_ENCRYPT_NAME}`
+|`JDG_JGROUPS_ENCRYPT_PASSWORD` | The password for the keystore and certificate | `${JDG_JGROUPS_ENCRYPT_PASSWORD}`
+|`JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}`
 |=======================================================================
 
 

--- a/docs/datagrid/datagrid65-mysql-persistent.adoc
+++ b/docs/datagrid/datagrid65-mysql-persistent.adoc
@@ -11,6 +11,21 @@
 
 Application template for JDG 6.5 and MySQL applications with persistent storage.
 
+For simple authentication, set
+
+  JDG_SIMPLE_AUTHENTICATION=true
+  JDG_USERNAME=<username>
+  JDG_PASSWORD=<password>
+
+This will enable user authentication with the datagrid. Provided username and password will be used to access the cache over both HTTPS and HotRod. With this case, the user will have all permissions configured.
+
+Restrictions for password:
+
+  at least 8 characters
+  at least 1 digit
+  at least 1 non-alphanumeric symbol
+
+
 toc::[]
 
 
@@ -24,7 +39,12 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |Variable name |Image Environment Variable |Description |Example value |Required
 
 |`APPLICATION_NAME` | -- | The name for the application. | datagrid-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
+|`HOSTNAME_HTTPS` | -- | Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-<project>.<default-domain-suffix> | -- | False
+|`JDG_SIMPLE_AUTHENTICATION` | `JDG_SIMPLE_AUTHENTICATION` | Flag to enable/disable user authentication | false | False
+|`JDG_SECDOMAIN_NAME` | `JDG_SECDOMAIN_NAME` | Security domain name for user authentication | jdg-openshift | False
+|`JDG_USERNAME` | `JDG_USERNAME` | User name for JDG user. If left empty, it will be generated. | `${JDG_USERNAME}` | False
+|`JDG_PASSWORD` | `JDG_PASSWORD` | Password for JDG user. If left empty, it will be generated. | `${JDG_PASSWORD}` | False
 |`JDG_HTTPS_SECRET` | -- | The name of the secret containing the keystore file | datagrid-app-secret | True
 |`JDG_HTTPS_KEYSTORE` | `JDG_HTTPS_KEYSTORE_DIR` | The name of the keystore file within the secret | keystore.jks | False
 |`JDG_HTTPS_NAME` | `JDG_HTTPS_NAME` | The name associated with the server certificate | `${JDG_HTTPS_NAME}` | False
@@ -43,6 +63,58 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`MYSQL_AIO` | `MYSQL_AIO` | Controls the innodb_use_native_aio setting value if the native AIO is broken. | `${MYSQL_AIO}` | False
 |`VOLUME_CAPACITY` | -- | Size of persistent storage for database volume. | 512Mi | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
+|`INFINISPAN_CONNECTORS` | `INFINISPAN_CONNECTORS` | Comma-separated list of connector types that should be configured (defaults to 'memcached,hotrod,rest') | hotrod,memcached,rest | False
+|`HOTROD_CACHE_CONTAINER` | `HOTROD_CACHE_CONTAINER` | The cache container used by the Hot Rod connector (defaults to 'clustered') | clustered | True
+|`HOTROD_SOCKET_BINDING` | `HOTROD_SOCKET_BINDING` | The socket binding port used by the Hot Rod connector (defaults to 'hotrod') | hotrod | True
+|`HOTROD_NAME` | `HOTROD_NAME` |  | `${HOTROD_NAME}` | False
+|`HOTROD_WORKER_THREADS` | `HOTROD_WORKER_THREADS` | The number of worker threads available for the Hot Rod connector (defaults to 160) | `${HOTROD_WORKER_THREADS}` | False
+|`HOTROD_IDLE_TIMEOUT` | `HOTROD_IDLE_TIMEOUT` | The time (in milliseconds) the connector can remain idle before the connection times out (defaults to -1 - no timeout) | `${HOTROD_IDLE_TIMEOUT}` | False
+|`HOTROD_TCP_NODELAY` | `HOTROD_TCP_NODELAY` | Whether TCP packets will be delayed and sent out in batches (defaults to true) | `${HOTROD_TCP_NODELAY}` | False
+|`HOTROD_SEND_BUFFER_SIZE` | `HOTROD_SEND_BUFFER_SIZE` | The size of the send buffer for the Hot Rod connector (defaults to size of the TCP stack buffer) | `${HOTROD_SEND_BUFFER_SIZE}` | False
+|`HOTROD_RECEIVE_BUFFER_SIZE` | `HOTROD_RECEIVE_BUFFER_SIZE` | The size of the receive buffer for the Hot Rod connector (defaults to size of the TCP stack buffer) | `${HOTROD_RECEIVE_BUFFER_SIZE}` | False
+|`TOPOLOGY_CACHE_SUFFIX` | `TOPOLOGY_CACHE_SUFFIX` |  | `${TOPOLOGY_CACHE_SUFFIX}` | False
+|`TOPOLOGY_LOCK_TIMEOUT` | `TOPOLOGY_LOCK_TIMEOUT` | The time (in milliseconds) after which the operation attempting to obtain a lock times out (defaults to 10 seconds) | `${TOPOLOGY_LOCK_TIMEOUT}` | False
+|`TOPOLOGY_REPLICATION_TIMEOUT` | `TOPOLOGY_REPLICATION_TIMEOUT` | The time (in milliseconds) after which the replication operation times out (defaults to 10 seconds) | `${TOPOLOGY_REPLICATION_TIMEOUT}` | False
+|`TOPOLOGY_EXTERNAL_HOST` | `TOPOLOGY_EXTERNAL_HOST` | The hostname sent by the Hot Rod server to clients listed in the topology information (defaults to the host address) | `${TOPOLOGY_EXTERNAL_HOST}` | False
+|`TOPOLOGY_EXTERNAL_PORT` | `TOPOLOGY_EXTERNAL_PORT` | The port sent by the Hot Rod server to clients listed in the topology information (defaults to the configured port) | `${TOPOLOGY_EXTERNAL_PORT}` | False
+|`TOPOLOGY_LAZY_RETRIEVAL` | `TOPOLOGY_LAZY_RETRIEVAL` | Whether the Hot Rod connector will carry out retrieval operations lazily (defaults to true) | `${TOPOLOGY_LAZY_RETRIEVAL}` | False
+|`TOPOLOGY_AWAIT_INITIAL_TRANSFER` | `TOPOLOGY_AWAIT_INITIAL_TRANSFER` | Whether the initial state retrieval happens immediately at startup; applies only when TOPOLOGY_LAZY_RETRIEVAL is set to false (defaults to true) | `${TOPOLOGY_AWAIT_INITIAL_TRANSFER}` | False
+|`AUTHENTICATION_SECURITY_REALM` | `AUTHENTICATION_SECURITY_REALM` |  | `${AUTHENTICATION_SECURITY_REALM}` | False
+|`SASL_SERVER_NAME` | `SASL_SERVER_NAME` |  | `${SASL_SERVER_NAME}` | False
+|`SASL_SECURITY_CONTEXT_NAME` | `SASL_SECURITY_CONTEXT_NAME` |  | `${SASL_SECURITY_CONTEXT_NAME}` | False
+|`SASL_MECHANISMS` | `SASL_MECHANISMS` |  | `${SASL_MECHANISMS}` | False
+|`SASL_QOP` | `SASL_QOP` |  | `${SASL_QOP}` | False
+|`SASL_STRENGTH` | `SASL_STRENGTH` |  | `${SASL_STRENGTH}` | False
+|`SASL_POLICY_FORWARD_SECRECY` | `SASL_POLICY_FORWARD_SECRECY` |  | `${SASL_POLICY_FORWARD_SECRECY}` | False
+|`SASL_POLICY_NO_ACTIVE` | `SASL_POLICY_NO_ACTIVE` |  | `${SASL_POLICY_NO_ACTIVE}` | False
+|`SASL_POLICY_NO_ANONYMOUS` | `SASL_POLICY_NO_ANONYMOUS` |  | `${SASL_POLICY_NO_ANONYMOUS}` | False
+|`SASL_POLICY_NO_DICTIONARY` | `SASL_POLICY_NO_DICTIONARY` |  | `${SASL_POLICY_NO_DICTIONARY}` | False
+|`SASL_POLICY_NO_PLAIN_TEXT` | `SASL_POLICY_NO_PLAIN_TEXT` |  | `${SASL_POLICY_NO_PLAIN_TEXT}` | False
+|`SASL_POLICY_PASS_CREDENTIALS` | `SASL_POLICY_PASS_CREDENTIALS` |  | `${SASL_POLICY_PASS_CREDENTIALS}` | False
+|`SASL_PROPERTIES` | `SASL_PROPERTIES` |  | `${SASL_PROPERTIES}` | False
+|`ENCRYPTION_SECURITY_REALM` | `ENCRYPTION_SECURITY_REALM` |  | `${ENCRYPTION_SECURITY_REALM}` | False
+|`ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH` | `ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH` |  | `${ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH}` | False
+|`MEMCACHED_CACHE_CONTAINER` | `MEMCACHED_CACHE_CONTAINER` | The cache container used by the memcached connector (defaults to 'clustered') | clustered | True
+|`MEMCACHED_CACHE` | `MEMCACHED_CACHE_CONTAINER` | The name of the cache to expose through this memcached connector (defaults to 'default') | default | False
+|`MEMCACHED_SOCKET_BINDING` | `MEMCACHED_SOCKET_BINDING` | The socked binding port used by the memcached connector (defaults to 'memcached') | memcached | True
+|`MEMCACHED_NAME` | `MEMCACHED_NAME` | The name of this memcached connector (defaults to 'memcached') | memcached | False
+|`MEMCACHED_WORKER_THREADS` | `MEMCACHED_WORKER_THREADS` | The number of worker threads available for the memcached connector (defaults to 160) | `${MEMCACHED_WORKER_THREADS}` | False
+|`MEMCACHED_IDLE_TIMEOUT` | `MEMCACHED_IDLE_TIMEOUT` | The time (in milliseconds) the connector can remain idle before the connection times out (defaults to -1 - no timeout) | `${MEMCACHED_IDLE_TIMEOUT}` | False
+|`MEMCACHED_TCP_NODELAY` | `MEMCACHED_TCP_NODELAY` | Whether TCP packets will be delayed and sent out in batches (defaults to true) | `${MEMCACHED_TCP_NODELAY}` | False
+|`MEMCACHED_SEND_BUFFER_SIZE` | `MEMCACHED_SEND_BUFFER_SIZE` | The size of the send buffer for the memcached connector (defaults to the size of the TCP stack buffer) | `${MEMCACHED_SEND_BUFFER_SIZE}` | False
+|`MEMCACHED_RECEIVE_BUFFER_SIZE` | `MEMCACHED_RECEIVE_BUFFER_SIZE` | The size of the receive buffer for the memcached connector (defaults to the size of the TCP stack buffer) | `${MEMCACHED_RECEIVE_BUFFER_SIZE}` | False
+|`REST_VIRTUAL_SERVER` | `REST_VIRTUAL_SERVER` | The virtual server used by the REST connector (defaults to 'default-host') | `${REST_VIRTUAL_SERVER}` | False
+|`REST_CACHE_CONTAINER` | `REST_CACHE_CONTAINER` | The cache container used by the REST connector (defaults to 'clustered') | clustered | True
+|`REST_CONTEXT_PATH` | `REST_CONTEXT_PATH` | The context path for the REST connector (defaults to '') | `${REST_CONTEXT_PATH}` | False
+|`REST_SECURITY_DOMAIN` | `REST_SECURITY_DOMAIN` | The domain, declared in the security subsystem, that should be used to authenticate access to the REST endpoint | `${REST_SECURITY_DOMAIN}` | False
+|`REST_AUTH_METHOD` | `REST_AUTH_METHOD` | The method used to retrieve credentials for the REST endpoint (defaults to 'BASIC') | `${REST_AUTH_METHOD}` | False
+|`REST_SECURITY_MODE` | `REST_SECURITY_MODE` | Whether authentication is required only for WRITE operations or for READ operations as well (defaults to 'READ_WRITE') | `${REST_SECURITY_MODE}` | False
+|`REST_EXTENDED_HEADERS` | `REST_EXTENDED_HEADERS` |  | `${REST_EXTENDED_HEADERS}` | False
+|`JDG_JGROUPS_ENCRYPT_SECRET` | `JDG_JGROUPS_ENCRYPT_SECRET` | The name of the secret containing the keystore file | `${JDG_JGROUPS_ENCRYPT_SECRET}` | False
+|`JDG_JGROUPS_ENCRYPT_KEYSTORE` | `JDG_JGROUPS_ENCRYPT_KEYSTORE` | The name of the keystore file within the secret | `${JDG_JGROUPS_ENCRYPT_KEYSTORE}` | False
+|`JDG_JGROUPS_ENCRYPT_NAME` | `JDG_JGROUPS_ENCRYPT_NAME` | The name associated with the server certificate | `${JDG_JGROUPS_ENCRYPT_NAME}` | False
+|`JDG_JGROUPS_ENCRYPT_PASSWORD` | `JDG_JGROUPS_ENCRYPT_PASSWORD` | The password for the keystore and certificate | `${JDG_JGROUPS_ENCRYPT_PASSWORD}` | False
+|`JGROUPS_CLUSTER_PASSWORD` | `JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}` | True
 |=======================================================================
 
 
@@ -80,10 +152,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-https` | TLS passthrough | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-memcached` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-hotrod` | none | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
+|`${APPLICATION_NAME}-https` | TLS passthrough | `${HOSTNAME_HTTPS}`
 |=============
 
 
@@ -168,7 +238,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.5+| `${APPLICATION_NAME}`
+.6+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |https | 8443 | `TCP`
 |ping | 8888 | `TCP`
@@ -185,7 +256,11 @@ information.
 |=======================================================================
 |Deployment |Variable name |Description |Example value
 
-.15+| `${APPLICATION_NAME}`
+.71+| `${APPLICATION_NAME}`
+|`JDG_SIMPLE_AUTHENTICATION` | Flag to enable/disable user authentication | `${JDG_SIMPLE_AUTHENTICATION}`
+|`JDG_USERNAME` | User name for JDG user. If left empty, it will be generated. | `${JDG_USERNAME}`
+|`JDG_PASSWORD` | Password for JDG user. If left empty, it will be generated. | `${JDG_PASSWORD}`
+|`JDG_SECDOMAIN_NAME` | Security domain name for user authentication | `${JDG_SECDOMAIN_NAME}`
 |`JDG_HTTPS_KEYSTORE_DIR` | The name of the keystore file within the secret | `/etc/datagrid-secret-volume`
 |`JDG_HTTPS_KEYSTORE` | The name of the keystore file within the secret | `${JDG_HTTPS_KEYSTORE}`
 |`JDG_HTTPS_NAME` | The name associated with the server certificate | `${JDG_HTTPS_NAME}`
@@ -201,6 +276,58 @@ information.
 |`DB_TX_ISOLATION` | Sets transaction-isolation for the configured datasource. | `${DB_TX_ISOLATION}`
 |`OPENSHIFT_KUBE_PING_LABELS` | -- | `application=${APPLICATION_NAME}`
 |`OPENSHIFT_KUBE_PING_NAMESPACE` | -- | --
+|`INFINISPAN_CONNECTORS` | Comma-separated list of connector types that should be configured (defaults to 'memcached,hotrod,rest') | `${INFINISPAN_CONNECTORS}`
+|`HOTROD_CACHE_CONTAINER` | The cache container used by the Hot Rod connector (defaults to 'clustered') | `${HOTROD_CACHE_CONTAINER}`
+|`HOTROD_SOCKET_BINDING` | The socket binding port used by the Hot Rod connector (defaults to 'hotrod') | `${HOTROD_SOCKET_BINDING}`
+|`HOTROD_NAME` |  | `${HOTROD_NAME}`
+|`HOTROD_WORKER_THREADS` | The number of worker threads available for the Hot Rod connector (defaults to 160) | `${HOTROD_WORKER_THREADS}`
+|`HOTROD_IDLE_TIMEOUT` | The time (in milliseconds) the connector can remain idle before the connection times out (defaults to -1 - no timeout) | `${HOTROD_IDLE_TIMEOUT}`
+|`HOTROD_TCP_NODELAY` | Whether TCP packets will be delayed and sent out in batches (defaults to true) | `${HOTROD_TCP_NODELAY}`
+|`HOTROD_SEND_BUFFER_SIZE` | The size of the send buffer for the Hot Rod connector (defaults to size of the TCP stack buffer) | `${HOTROD_SEND_BUFFER_SIZE}`
+|`HOTROD_RECEIVE_BUFFER_SIZE` | The size of the receive buffer for the Hot Rod connector (defaults to size of the TCP stack buffer) | `${HOTROD_RECEIVE_BUFFER_SIZE}`
+|`TOPOLOGY_CACHE_SUFFIX` |  | `${TOPOLOGY_CACHE_SUFFIX}`
+|`TOPOLOGY_LOCK_TIMEOUT` | The time (in milliseconds) after which the operation attempting to obtain a lock times out (defaults to 10 seconds) | `${TOPOLOGY_LOCK_TIMEOUT}`
+|`TOPOLOGY_REPLICATION_TIMEOUT` | The time (in milliseconds) after which the replication operation times out (defaults to 10 seconds) | `${TOPOLOGY_REPLICATION_TIMEOUT}`
+|`TOPOLOGY_EXTERNAL_HOST` | The hostname sent by the Hot Rod server to clients listed in the topology information (defaults to the host address) | `${TOPOLOGY_EXTERNAL_HOST}`
+|`TOPOLOGY_EXTERNAL_PORT` | The port sent by the Hot Rod server to clients listed in the topology information (defaults to the configured port) | `${TOPOLOGY_EXTERNAL_PORT}`
+|`TOPOLOGY_LAZY_RETRIEVAL` | Whether the Hot Rod connector will carry out retrieval operations lazily (defaults to true) | `${TOPOLOGY_LAZY_RETRIEVAL}`
+|`TOPOLOGY_AWAIT_INITIAL_TRANSFER` | Whether the initial state retrieval happens immediately at startup; applies only when TOPOLOGY_LAZY_RETRIEVAL is set to false (defaults to true) | `${TOPOLOGY_AWAIT_INITIAL_TRANSFER}`
+|`AUTHENTICATION_SECURITY_REALM` |  | `${AUTHENTICATION_SECURITY_REALM}`
+|`SASL_SERVER_NAME` |  | `${SASL_SERVER_NAME}`
+|`SASL_SECURITY_CONTEXT_NAME` |  | `${SASL_SECURITY_CONTEXT_NAME}`
+|`SASL_MECHANISMS` |  | `${SASL_MECHANISMS}`
+|`SASL_QOP` |  | `${SASL_QOP}`
+|`SASL_STRENGTH` |  | `${SASL_STRENGTH}`
+|`SASL_POLICY_FORWARD_SECRECY` |  | `${SASL_POLICY_FORWARD_SECRECY}`
+|`SASL_POLICY_NO_ACTIVE` |  | `${SASL_POLICY_NO_ACTIVE}`
+|`SASL_POLICY_NO_ANONYMOUS` |  | `${SASL_POLICY_NO_ANONYMOUS}`
+|`SASL_POLICY_NO_DICTIONARY` |  | `${SASL_POLICY_NO_DICTIONARY}`
+|`SASL_POLICY_NO_PLAIN_TEXT` |  | `${SASL_POLICY_NO_PLAIN_TEXT}`
+|`SASL_POLICY_PASS_CREDENTIALS` |  | `${SASL_POLICY_PASS_CREDENTIALS}`
+|`SASL_PROPERTIES` |  | `${SASL_PROPERTIES}`
+|`ENCRYPTION_SECURITY_REALM` |  | `${ENCRYPTION_SECURITY_REALM}`
+|`ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH` |  | `${ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH}`
+|`MEMCACHED_CACHE_CONTAINER` | The cache container used by the memcached connector (defaults to 'clustered') | `${MEMCACHED_CACHE_CONTAINER}`
+|`MEMCACHED_CACHE` | The cache container used by the memcached connector (defaults to 'clustered') | `${MEMCACHED_CACHE}`
+|`MEMCACHED_SOCKET_BINDING` | The socked binding port used by the memcached connector (defaults to 'memcached') | `${MEMCACHED_SOCKET_BINDING}`
+|`MEMCACHED_NAME` | The name of this memcached connector (defaults to 'memcached') | `${MEMCACHED_NAME}`
+|`MEMCACHED_WORKER_THREADS` | The number of worker threads available for the memcached connector (defaults to 160) | `${MEMCACHED_WORKER_THREADS}`
+|`MEMCACHED_IDLE_TIMEOUT` | The time (in milliseconds) the connector can remain idle before the connection times out (defaults to -1 - no timeout) | `${MEMCACHED_IDLE_TIMEOUT}`
+|`MEMCACHED_TCP_NODELAY` | Whether TCP packets will be delayed and sent out in batches (defaults to true) | `${MEMCACHED_TCP_NODELAY}`
+|`MEMCACHED_SEND_BUFFER_SIZE` | The size of the send buffer for the memcached connector (defaults to the size of the TCP stack buffer) | `${MEMCACHED_SEND_BUFFER_SIZE}`
+|`MEMCACHED_RECEIVE_BUFFER_SIZE` | The size of the receive buffer for the memcached connector (defaults to the size of the TCP stack buffer) | `${MEMCACHED_RECEIVE_BUFFER_SIZE}`
+|`REST_VIRTUAL_SERVER` | The virtual server used by the REST connector (defaults to 'default-host') | `${REST_VIRTUAL_SERVER}`
+|`REST_CACHE_CONTAINER` | The cache container used by the REST connector (defaults to 'clustered') | `${REST_CACHE_CONTAINER}`
+|`REST_CONTEXT_PATH` | The context path for the REST connector (defaults to '') | `${REST_CONTEXT_PATH}`
+|`REST_SECURITY_DOMAIN` | The domain, declared in the security subsystem, that should be used to authenticate access to the REST endpoint | `${REST_SECURITY_DOMAIN}`
+|`REST_AUTH_METHOD` | The method used to retrieve credentials for the REST endpoint (defaults to 'BASIC') | `${REST_AUTH_METHOD}`
+|`REST_SECURITY_MODE` | Whether authentication is required only for WRITE operations or for READ operations as well (defaults to 'READ_WRITE') | `${REST_SECURITY_MODE}`
+|`REST_EXTENDED_HEADERS` |  | `${REST_EXTENDED_HEADERS}`
+|`JDG_JGROUPS_ENCRYPT_SECRET` | The name of the secret containing the keystore file | `${JDG_JGROUPS_ENCRYPT_SECRET}`
+|`JDG_JGROUPS_ENCRYPT_KEYSTORE` | The name of the keystore file within the secret | `${JDG_JGROUPS_ENCRYPT_KEYSTORE}`
+|`JDG_JGROUPS_ENCRYPT_NAME` | The name associated with the server certificate | `${JDG_JGROUPS_ENCRYPT_NAME}`
+|`JDG_JGROUPS_ENCRYPT_PASSWORD` | The password for the keystore and certificate | `${JDG_JGROUPS_ENCRYPT_PASSWORD}`
+|`JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}`
 .8+| `${APPLICATION_NAME}-mysql`
 |`MYSQL_USER` | -- | `${DB_USERNAME}`
 |`MYSQL_PASSWORD` | -- | `${DB_PASSWORD}`

--- a/docs/datagrid/datagrid65-mysql.adoc
+++ b/docs/datagrid/datagrid65-mysql.adoc
@@ -11,6 +11,21 @@
 
 Application template for JDG 6.5 and MySQL applications.
 
+For simple authentication, set
+
+  JDG_SIMPLE_AUTHENTICATION=true
+  JDG_USERNAME=<username>
+  JDG_PASSWORD=<password>
+
+This will enable user authentication with the datagrid. Provided username and password will be used to access the cache over both HTTPS and HotRod. With this case, the user will have all permissions configured.
+
+Restrictions for password:
+
+  at least 8 characters
+  at least 1 digit
+  at least 1 non-alphanumeric symbol
+
+
 toc::[]
 
 
@@ -24,7 +39,12 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |Variable name |Image Environment Variable |Description |Example value |Required
 
 |`APPLICATION_NAME` | -- | The name for the application. | datagrid-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
+|`HOSTNAME_HTTPS` | -- | Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-<project>.<default-domain-suffix> | -- | False
+|`JDG_SIMPLE_AUTHENTICATION` | `JDG_SIMPLE_AUTHENTICATION` | Flag to enable/disable user authentication | false | False
+|`JDG_SECDOMAIN_NAME` | `JDG_SECDOMAIN_NAME` | Security domain name for user authentication | jdg-openshift | False
+|`JDG_USERNAME` | `JDG_USERNAME` | User name for JDG user. If left empty, it will be generated. | `${JDG_USERNAME}` | False
+|`JDG_PASSWORD` | `JDG_PASSWORD` | Password for JDG user. If left empty, it will be generated. | `${JDG_PASSWORD}` | False
 |`JDG_HTTPS_SECRET` | -- | The name of the secret containing the keystore file | datagrid-app-secret | True
 |`JDG_HTTPS_KEYSTORE` | `JDG_HTTPS_KEYSTORE_DIR` | The name of the keystore file within the secret | keystore.jks | False
 |`JDG_HTTPS_NAME` | `JDG_HTTPS_NAME` | The name associated with the server certificate | `${JDG_HTTPS_NAME}` | False
@@ -42,6 +62,58 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`MYSQL_FT_MAX_WORD_LEN` | `MYSQL_FT_MAX_WORD_LEN` | The maximum length of the word to be included in a FULLTEXT index. | `${MYSQL_FT_MAX_WORD_LEN}` | False
 |`MYSQL_AIO` | `MYSQL_AIO` | Controls the innodb_use_native_aio setting value if the native AIO is broken. | `${MYSQL_AIO}` | False
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
+|`INFINISPAN_CONNECTORS` | `INFINISPAN_CONNECTORS` | Comma-separated list of connector types that should be configured (defaults to 'memcached,hotrod,rest') | hotrod,memcached,rest | False
+|`HOTROD_CACHE_CONTAINER` | `HOTROD_CACHE_CONTAINER` | The cache container used by the Hot Rod connector (defaults to 'clustered') | clustered | True
+|`HOTROD_SOCKET_BINDING` | `HOTROD_SOCKET_BINDING` | The socket binding port used by the Hot Rod connector (defaults to 'hotrod') | hotrod | True
+|`HOTROD_NAME` | `HOTROD_NAME` |  | `${HOTROD_NAME}` | False
+|`HOTROD_WORKER_THREADS` | `HOTROD_WORKER_THREADS` | The number of worker threads available for the Hot Rod connector (defaults to 160) | `${HOTROD_WORKER_THREADS}` | False
+|`HOTROD_IDLE_TIMEOUT` | `HOTROD_IDLE_TIMEOUT` | The time (in milliseconds) the connector can remain idle before the connection times out (defaults to -1 - no timeout) | `${HOTROD_IDLE_TIMEOUT}` | False
+|`HOTROD_TCP_NODELAY` | `HOTROD_TCP_NODELAY` | Whether TCP packets will be delayed and sent out in batches (defaults to true) | `${HOTROD_TCP_NODELAY}` | False
+|`HOTROD_SEND_BUFFER_SIZE` | `HOTROD_SEND_BUFFER_SIZE` | The size of the send buffer for the Hot Rod connector (defaults to size of the TCP stack buffer) | `${HOTROD_SEND_BUFFER_SIZE}` | False
+|`HOTROD_RECEIVE_BUFFER_SIZE` | `HOTROD_RECEIVE_BUFFER_SIZE` | The size of the receive buffer for the Hot Rod connector (defaults to size of the TCP stack buffer) | `${HOTROD_RECEIVE_BUFFER_SIZE}` | False
+|`TOPOLOGY_CACHE_SUFFIX` | `TOPOLOGY_CACHE_SUFFIX` |  | `${TOPOLOGY_CACHE_SUFFIX}` | False
+|`TOPOLOGY_LOCK_TIMEOUT` | `TOPOLOGY_LOCK_TIMEOUT` | The time (in milliseconds) after which the operation attempting to obtain a lock times out (defaults to 10 seconds) | `${TOPOLOGY_LOCK_TIMEOUT}` | False
+|`TOPOLOGY_REPLICATION_TIMEOUT` | `TOPOLOGY_REPLICATION_TIMEOUT` | The time (in milliseconds) after which the replication operation times out (defaults to 10 seconds) | `${TOPOLOGY_REPLICATION_TIMEOUT}` | False
+|`TOPOLOGY_EXTERNAL_HOST` | `TOPOLOGY_EXTERNAL_HOST` | The hostname sent by the Hot Rod server to clients listed in the topology information (defaults to the host address) | `${TOPOLOGY_EXTERNAL_HOST}` | False
+|`TOPOLOGY_EXTERNAL_PORT` | `TOPOLOGY_EXTERNAL_PORT` | The port sent by the Hot Rod server to clients listed in the topology information (defaults to the configured port) | `${TOPOLOGY_EXTERNAL_PORT}` | False
+|`TOPOLOGY_LAZY_RETRIEVAL` | `TOPOLOGY_LAZY_RETRIEVAL` | Whether the Hot Rod connector will carry out retrieval operations lazily (defaults to true) | `${TOPOLOGY_LAZY_RETRIEVAL}` | False
+|`TOPOLOGY_AWAIT_INITIAL_TRANSFER` | `TOPOLOGY_AWAIT_INITIAL_TRANSFER` | Whether the initial state retrieval happens immediately at startup; applies only when TOPOLOGY_LAZY_RETRIEVAL is set to false (defaults to true) | `${TOPOLOGY_AWAIT_INITIAL_TRANSFER}` | False
+|`AUTHENTICATION_SECURITY_REALM` | `AUTHENTICATION_SECURITY_REALM` |  | `${AUTHENTICATION_SECURITY_REALM}` | False
+|`SASL_SERVER_NAME` | `SASL_SERVER_NAME` |  | `${SASL_SERVER_NAME}` | False
+|`SASL_SECURITY_CONTEXT_NAME` | `SASL_SECURITY_CONTEXT_NAME` |  | `${SASL_SECURITY_CONTEXT_NAME}` | False
+|`SASL_MECHANISMS` | `SASL_MECHANISMS` |  | `${SASL_MECHANISMS}` | False
+|`SASL_QOP` | `SASL_QOP` |  | `${SASL_QOP}` | False
+|`SASL_STRENGTH` | `SASL_STRENGTH` |  | `${SASL_STRENGTH}` | False
+|`SASL_POLICY_FORWARD_SECRECY` | `SASL_POLICY_FORWARD_SECRECY` |  | `${SASL_POLICY_FORWARD_SECRECY}` | False
+|`SASL_POLICY_NO_ACTIVE` | `SASL_POLICY_NO_ACTIVE` |  | `${SASL_POLICY_NO_ACTIVE}` | False
+|`SASL_POLICY_NO_ANONYMOUS` | `SASL_POLICY_NO_ANONYMOUS` |  | `${SASL_POLICY_NO_ANONYMOUS}` | False
+|`SASL_POLICY_NO_DICTIONARY` | `SASL_POLICY_NO_DICTIONARY` |  | `${SASL_POLICY_NO_DICTIONARY}` | False
+|`SASL_POLICY_NO_PLAIN_TEXT` | `SASL_POLICY_NO_PLAIN_TEXT` |  | `${SASL_POLICY_NO_PLAIN_TEXT}` | False
+|`SASL_POLICY_PASS_CREDENTIALS` | `SASL_POLICY_PASS_CREDENTIALS` |  | `${SASL_POLICY_PASS_CREDENTIALS}` | False
+|`SASL_PROPERTIES` | `SASL_PROPERTIES` |  | `${SASL_PROPERTIES}` | False
+|`ENCRYPTION_SECURITY_REALM` | `ENCRYPTION_SECURITY_REALM` |  | `${ENCRYPTION_SECURITY_REALM}` | False
+|`ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH` | `ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH` |  | `${ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH}` | False
+|`MEMCACHED_CACHE_CONTAINER` | `MEMCACHED_CACHE_CONTAINER` | The cache container used by the memcached connector (defaults to 'clustered') | clustered | True
+|`MEMCACHED_CACHE` | `MEMCACHED_CACHE_CONTAINER` | The name of the cache to expose through this memcached connector (defaults to 'default') | default | False
+|`MEMCACHED_SOCKET_BINDING` | `MEMCACHED_SOCKET_BINDING` | The socked binding port used by the memcached connector (defaults to 'memcached') | memcached | True
+|`MEMCACHED_NAME` | `MEMCACHED_NAME` | The name of this memcached connector (defaults to 'memcached') | memcached | False
+|`MEMCACHED_WORKER_THREADS` | `MEMCACHED_WORKER_THREADS` | The number of worker threads available for the memcached connector (defaults to 160) | `${MEMCACHED_WORKER_THREADS}` | False
+|`MEMCACHED_IDLE_TIMEOUT` | `MEMCACHED_IDLE_TIMEOUT` | The time (in milliseconds) the connector can remain idle before the connection times out (defaults to -1 - no timeout) | `${MEMCACHED_IDLE_TIMEOUT}` | False
+|`MEMCACHED_TCP_NODELAY` | `MEMCACHED_TCP_NODELAY` | Whether TCP packets will be delayed and sent out in batches (defaults to true) | `${MEMCACHED_TCP_NODELAY}` | False
+|`MEMCACHED_SEND_BUFFER_SIZE` | `MEMCACHED_SEND_BUFFER_SIZE` | The size of the send buffer for the memcached connector (defaults to the size of the TCP stack buffer) | `${MEMCACHED_SEND_BUFFER_SIZE}` | False
+|`MEMCACHED_RECEIVE_BUFFER_SIZE` | `MEMCACHED_RECEIVE_BUFFER_SIZE` | The size of the receive buffer for the memcached connector (defaults to the size of the TCP stack buffer) | `${MEMCACHED_RECEIVE_BUFFER_SIZE}` | False
+|`REST_VIRTUAL_SERVER` | `REST_VIRTUAL_SERVER` | The virtual server used by the REST connector (defaults to 'default-host') | `${REST_VIRTUAL_SERVER}` | False
+|`REST_CACHE_CONTAINER` | `REST_CACHE_CONTAINER` | The cache container used by the REST connector (defaults to 'clustered') | clustered | True
+|`REST_CONTEXT_PATH` | `REST_CONTEXT_PATH` | The context path for the REST connector (defaults to '') | `${REST_CONTEXT_PATH}` | False
+|`REST_SECURITY_DOMAIN` | `REST_SECURITY_DOMAIN` | The domain, declared in the security subsystem, that should be used to authenticate access to the REST endpoint | `${REST_SECURITY_DOMAIN}` | False
+|`REST_AUTH_METHOD` | `REST_AUTH_METHOD` | The method used to retrieve credentials for the REST endpoint (defaults to 'BASIC') | `${REST_AUTH_METHOD}` | False
+|`REST_SECURITY_MODE` | `REST_SECURITY_MODE` | Whether authentication is required only for WRITE operations or for READ operations as well (defaults to 'READ_WRITE') | `${REST_SECURITY_MODE}` | False
+|`REST_EXTENDED_HEADERS` | `REST_EXTENDED_HEADERS` |  | `${REST_EXTENDED_HEADERS}` | False
+|`JDG_JGROUPS_ENCRYPT_SECRET` | `JDG_JGROUPS_ENCRYPT_SECRET` | The name of the secret containing the keystore file | `${JDG_JGROUPS_ENCRYPT_SECRET}` | False
+|`JDG_JGROUPS_ENCRYPT_KEYSTORE` | `JDG_JGROUPS_ENCRYPT_KEYSTORE` | The name of the keystore file within the secret | `${JDG_JGROUPS_ENCRYPT_KEYSTORE}` | False
+|`JDG_JGROUPS_ENCRYPT_NAME` | `JDG_JGROUPS_ENCRYPT_NAME` | The name associated with the server certificate | `${JDG_JGROUPS_ENCRYPT_NAME}` | False
+|`JDG_JGROUPS_ENCRYPT_PASSWORD` | `JDG_JGROUPS_ENCRYPT_PASSWORD` | The password for the keystore and certificate | `${JDG_JGROUPS_ENCRYPT_PASSWORD}` | False
+|`JGROUPS_CLUSTER_PASSWORD` | `JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}` | True
 |=======================================================================
 
 
@@ -79,10 +151,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-https` | TLS passthrough | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-memcached` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-hotrod` | none | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
+|`${APPLICATION_NAME}-https` | TLS passthrough | `${HOSTNAME_HTTPS}`
 |=============
 
 
@@ -167,7 +237,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.5+| `${APPLICATION_NAME}`
+.6+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |https | 8443 | `TCP`
 |ping | 8888 | `TCP`
@@ -184,7 +255,11 @@ information.
 |=======================================================================
 |Deployment |Variable name |Description |Example value
 
-.15+| `${APPLICATION_NAME}`
+.71+| `${APPLICATION_NAME}`
+|`JDG_SIMPLE_AUTHENTICATION` | Flag to enable/disable user authentication | `${JDG_SIMPLE_AUTHENTICATION}`
+|`JDG_USERNAME` | User name for JDG user. If left empty, it will be generated. | `${JDG_USERNAME}`
+|`JDG_PASSWORD` | Password for JDG user. If left empty, it will be generated. | `${JDG_PASSWORD}`
+|`JDG_SECDOMAIN_NAME` | Security domain name for user authentication | `${JDG_SECDOMAIN_NAME}`
 |`JDG_HTTPS_KEYSTORE_DIR` | The name of the keystore file within the secret | `/etc/datagrid-secret-volume`
 |`JDG_HTTPS_KEYSTORE` | The name of the keystore file within the secret | `${JDG_HTTPS_KEYSTORE}`
 |`JDG_HTTPS_NAME` | The name associated with the server certificate | `${JDG_HTTPS_NAME}`
@@ -200,6 +275,58 @@ information.
 |`DB_TX_ISOLATION` | Sets transaction-isolation for the configured datasource. | `${DB_TX_ISOLATION}`
 |`OPENSHIFT_KUBE_PING_LABELS` | -- | `application=${APPLICATION_NAME}`
 |`OPENSHIFT_KUBE_PING_NAMESPACE` | -- | --
+|`INFINISPAN_CONNECTORS` | Comma-separated list of connector types that should be configured (defaults to 'memcached,hotrod,rest') | `${INFINISPAN_CONNECTORS}`
+|`HOTROD_CACHE_CONTAINER` | The cache container used by the Hot Rod connector (defaults to 'clustered') | `${HOTROD_CACHE_CONTAINER}`
+|`HOTROD_SOCKET_BINDING` | The socket binding port used by the Hot Rod connector (defaults to 'hotrod') | `${HOTROD_SOCKET_BINDING}`
+|`HOTROD_NAME` |  | `${HOTROD_NAME}`
+|`HOTROD_WORKER_THREADS` | The number of worker threads available for the Hot Rod connector (defaults to 160) | `${HOTROD_WORKER_THREADS}`
+|`HOTROD_IDLE_TIMEOUT` | The time (in milliseconds) the connector can remain idle before the connection times out (defaults to -1 - no timeout) | `${HOTROD_IDLE_TIMEOUT}`
+|`HOTROD_TCP_NODELAY` | Whether TCP packets will be delayed and sent out in batches (defaults to true) | `${HOTROD_TCP_NODELAY}`
+|`HOTROD_SEND_BUFFER_SIZE` | The size of the send buffer for the Hot Rod connector (defaults to size of the TCP stack buffer) | `${HOTROD_SEND_BUFFER_SIZE}`
+|`HOTROD_RECEIVE_BUFFER_SIZE` | The size of the receive buffer for the Hot Rod connector (defaults to size of the TCP stack buffer) | `${HOTROD_RECEIVE_BUFFER_SIZE}`
+|`TOPOLOGY_CACHE_SUFFIX` |  | `${TOPOLOGY_CACHE_SUFFIX}`
+|`TOPOLOGY_LOCK_TIMEOUT` | The time (in milliseconds) after which the operation attempting to obtain a lock times out (defaults to 10 seconds) | `${TOPOLOGY_LOCK_TIMEOUT}`
+|`TOPOLOGY_REPLICATION_TIMEOUT` | The time (in milliseconds) after which the replication operation times out (defaults to 10 seconds) | `${TOPOLOGY_REPLICATION_TIMEOUT}`
+|`TOPOLOGY_EXTERNAL_HOST` | The hostname sent by the Hot Rod server to clients listed in the topology information (defaults to the host address) | `${TOPOLOGY_EXTERNAL_HOST}`
+|`TOPOLOGY_EXTERNAL_PORT` | The port sent by the Hot Rod server to clients listed in the topology information (defaults to the configured port) | `${TOPOLOGY_EXTERNAL_PORT}`
+|`TOPOLOGY_LAZY_RETRIEVAL` | Whether the Hot Rod connector will carry out retrieval operations lazily (defaults to true) | `${TOPOLOGY_LAZY_RETRIEVAL}`
+|`TOPOLOGY_AWAIT_INITIAL_TRANSFER` | Whether the initial state retrieval happens immediately at startup; applies only when TOPOLOGY_LAZY_RETRIEVAL is set to false (defaults to true) | `${TOPOLOGY_AWAIT_INITIAL_TRANSFER}`
+|`AUTHENTICATION_SECURITY_REALM` |  | `${AUTHENTICATION_SECURITY_REALM}`
+|`SASL_SERVER_NAME` |  | `${SASL_SERVER_NAME}`
+|`SASL_SECURITY_CONTEXT_NAME` |  | `${SASL_SECURITY_CONTEXT_NAME}`
+|`SASL_MECHANISMS` |  | `${SASL_MECHANISMS}`
+|`SASL_QOP` |  | `${SASL_QOP}`
+|`SASL_STRENGTH` |  | `${SASL_STRENGTH}`
+|`SASL_POLICY_FORWARD_SECRECY` |  | `${SASL_POLICY_FORWARD_SECRECY}`
+|`SASL_POLICY_NO_ACTIVE` |  | `${SASL_POLICY_NO_ACTIVE}`
+|`SASL_POLICY_NO_ANONYMOUS` |  | `${SASL_POLICY_NO_ANONYMOUS}`
+|`SASL_POLICY_NO_DICTIONARY` |  | `${SASL_POLICY_NO_DICTIONARY}`
+|`SASL_POLICY_NO_PLAIN_TEXT` |  | `${SASL_POLICY_NO_PLAIN_TEXT}`
+|`SASL_POLICY_PASS_CREDENTIALS` |  | `${SASL_POLICY_PASS_CREDENTIALS}`
+|`SASL_PROPERTIES` |  | `${SASL_PROPERTIES}`
+|`ENCRYPTION_SECURITY_REALM` |  | `${ENCRYPTION_SECURITY_REALM}`
+|`ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH` |  | `${ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH}`
+|`MEMCACHED_CACHE_CONTAINER` | The cache container used by the memcached connector (defaults to 'clustered') | `${MEMCACHED_CACHE_CONTAINER}`
+|`MEMCACHED_CACHE` | The cache container used by the memcached connector (defaults to 'clustered') | `${MEMCACHED_CACHE}`
+|`MEMCACHED_SOCKET_BINDING` | The socked binding port used by the memcached connector (defaults to 'memcached') | `${MEMCACHED_SOCKET_BINDING}`
+|`MEMCACHED_NAME` | The name of this memcached connector (defaults to 'memcached') | `${MEMCACHED_NAME}`
+|`MEMCACHED_WORKER_THREADS` | The number of worker threads available for the memcached connector (defaults to 160) | `${MEMCACHED_WORKER_THREADS}`
+|`MEMCACHED_IDLE_TIMEOUT` | The time (in milliseconds) the connector can remain idle before the connection times out (defaults to -1 - no timeout) | `${MEMCACHED_IDLE_TIMEOUT}`
+|`MEMCACHED_TCP_NODELAY` | Whether TCP packets will be delayed and sent out in batches (defaults to true) | `${MEMCACHED_TCP_NODELAY}`
+|`MEMCACHED_SEND_BUFFER_SIZE` | The size of the send buffer for the memcached connector (defaults to the size of the TCP stack buffer) | `${MEMCACHED_SEND_BUFFER_SIZE}`
+|`MEMCACHED_RECEIVE_BUFFER_SIZE` | The size of the receive buffer for the memcached connector (defaults to the size of the TCP stack buffer) | `${MEMCACHED_RECEIVE_BUFFER_SIZE}`
+|`REST_VIRTUAL_SERVER` | The virtual server used by the REST connector (defaults to 'default-host') | `${REST_VIRTUAL_SERVER}`
+|`REST_CACHE_CONTAINER` | The cache container used by the REST connector (defaults to 'clustered') | `${REST_CACHE_CONTAINER}`
+|`REST_CONTEXT_PATH` | The context path for the REST connector (defaults to '') | `${REST_CONTEXT_PATH}`
+|`REST_SECURITY_DOMAIN` | The domain, declared in the security subsystem, that should be used to authenticate access to the REST endpoint | `${REST_SECURITY_DOMAIN}`
+|`REST_AUTH_METHOD` | The method used to retrieve credentials for the REST endpoint (defaults to 'BASIC') | `${REST_AUTH_METHOD}`
+|`REST_SECURITY_MODE` | Whether authentication is required only for WRITE operations or for READ operations as well (defaults to 'READ_WRITE') | `${REST_SECURITY_MODE}`
+|`REST_EXTENDED_HEADERS` |  | `${REST_EXTENDED_HEADERS}`
+|`JDG_JGROUPS_ENCRYPT_SECRET` | The name of the secret containing the keystore file | `${JDG_JGROUPS_ENCRYPT_SECRET}`
+|`JDG_JGROUPS_ENCRYPT_KEYSTORE` | The name of the keystore file within the secret | `${JDG_JGROUPS_ENCRYPT_KEYSTORE}`
+|`JDG_JGROUPS_ENCRYPT_NAME` | The name associated with the server certificate | `${JDG_JGROUPS_ENCRYPT_NAME}`
+|`JDG_JGROUPS_ENCRYPT_PASSWORD` | The password for the keystore and certificate | `${JDG_JGROUPS_ENCRYPT_PASSWORD}`
+|`JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}`
 .8+| `${APPLICATION_NAME}-mysql`
 |`MYSQL_USER` | -- | `${DB_USERNAME}`
 |`MYSQL_PASSWORD` | -- | `${DB_PASSWORD}`

--- a/docs/datagrid/datagrid65-postgresql-persistent.adoc
+++ b/docs/datagrid/datagrid65-postgresql-persistent.adoc
@@ -11,6 +11,21 @@
 
 Application template for JDG 6.5 and PostgreSQL applications with persistent storage.
 
+For simple authentication, set
+
+  JDG_SIMPLE_AUTHENTICATION=true
+  JDG_USERNAME=<username>
+  JDG_PASSWORD=<password>
+
+This will enable user authentication with the datagrid. Provided username and password will be used to access the cache over both HTTPS and HotRod. With this case, the user will have all permissions configured.
+
+Restrictions for password:
+
+  at least 8 characters
+  at least 1 digit
+  at least 1 non-alphanumeric symbol
+
+
 toc::[]
 
 
@@ -24,7 +39,12 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |Variable name |Image Environment Variable |Description |Example value |Required
 
 |`APPLICATION_NAME` | -- | The name for the application. | datagrid-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
+|`HOSTNAME_HTTPS` | -- | Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-<project>.<default-domain-suffix> | -- | False
+|`JDG_SIMPLE_AUTHENTICATION` | `JDG_SIMPLE_AUTHENTICATION` | Flag to enable/disable user authentication | false | False
+|`JDG_SECDOMAIN_NAME` | `JDG_SECDOMAIN_NAME` | Security domain name for user authentication | jdg-openshift | False
+|`JDG_USERNAME` | `JDG_USERNAME` | User name for JDG user. If left empty, it will be generated. | `${JDG_USERNAME}` | False
+|`JDG_PASSWORD` | `JDG_PASSWORD` | Password for JDG user. If left empty, it will be generated. | `${JDG_PASSWORD}` | False
 |`JDG_HTTPS_SECRET` | -- | The name of the secret containing the keystore file | datagrid-app-secret | True
 |`JDG_HTTPS_KEYSTORE` | `JDG_HTTPS_KEYSTORE_DIR` | The name of the keystore file within the secret | keystore.jks | False
 |`JDG_HTTPS_NAME` | `JDG_HTTPS_NAME` | The name associated with the server certificate | `${JDG_HTTPS_NAME}` | False
@@ -40,6 +60,58 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`POSTGRESQL_SHARED_BUFFERS` | `POSTGRESQL_SHARED_BUFFERS` | Configures how much memory is dedicated to PostgreSQL for caching data. | `${POSTGRESQL_SHARED_BUFFERS}` | False
 |`VOLUME_CAPACITY` | -- | Size of persistent storage for database volume. | 512Mi | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
+|`INFINISPAN_CONNECTORS` | `INFINISPAN_CONNECTORS` | Comma-separated list of connector types that should be configured (defaults to 'memcached,hotrod,rest') | hotrod,memcached,rest | False
+|`HOTROD_CACHE_CONTAINER` | `HOTROD_CACHE_CONTAINER` | The cache container used by the Hot Rod connector (defaults to 'clustered') | clustered | True
+|`HOTROD_SOCKET_BINDING` | `HOTROD_SOCKET_BINDING` | The socket binding port used by the Hot Rod connector (defaults to 'hotrod') | hotrod | True
+|`HOTROD_NAME` | `HOTROD_NAME` |  | `${HOTROD_NAME}` | False
+|`HOTROD_WORKER_THREADS` | `HOTROD_WORKER_THREADS` | The number of worker threads available for the Hot Rod connector (defaults to 160) | `${HOTROD_WORKER_THREADS}` | False
+|`HOTROD_IDLE_TIMEOUT` | `HOTROD_IDLE_TIMEOUT` | The time (in milliseconds) the connector can remain idle before the connection times out (defaults to -1 - no timeout) | `${HOTROD_IDLE_TIMEOUT}` | False
+|`HOTROD_TCP_NODELAY` | `HOTROD_TCP_NODELAY` | Whether TCP packets will be delayed and sent out in batches (defaults to true) | `${HOTROD_TCP_NODELAY}` | False
+|`HOTROD_SEND_BUFFER_SIZE` | `HOTROD_SEND_BUFFER_SIZE` | The size of the send buffer for the Hot Rod connector (defaults to size of the TCP stack buffer) | `${HOTROD_SEND_BUFFER_SIZE}` | False
+|`HOTROD_RECEIVE_BUFFER_SIZE` | `HOTROD_RECEIVE_BUFFER_SIZE` | The size of the receive buffer for the Hot Rod connector (defaults to size of the TCP stack buffer) | `${HOTROD_RECEIVE_BUFFER_SIZE}` | False
+|`TOPOLOGY_CACHE_SUFFIX` | `TOPOLOGY_CACHE_SUFFIX` |  | `${TOPOLOGY_CACHE_SUFFIX}` | False
+|`TOPOLOGY_LOCK_TIMEOUT` | `TOPOLOGY_LOCK_TIMEOUT` | The time (in milliseconds) after which the operation attempting to obtain a lock times out (defaults to 10 seconds) | `${TOPOLOGY_LOCK_TIMEOUT}` | False
+|`TOPOLOGY_REPLICATION_TIMEOUT` | `TOPOLOGY_REPLICATION_TIMEOUT` | The time (in milliseconds) after which the replication operation times out (defaults to 10 seconds) | `${TOPOLOGY_REPLICATION_TIMEOUT}` | False
+|`TOPOLOGY_EXTERNAL_HOST` | `TOPOLOGY_EXTERNAL_HOST` | The hostname sent by the Hot Rod server to clients listed in the topology information (defaults to the host address) | `${TOPOLOGY_EXTERNAL_HOST}` | False
+|`TOPOLOGY_EXTERNAL_PORT` | `TOPOLOGY_EXTERNAL_PORT` | The port sent by the Hot Rod server to clients listed in the topology information (defaults to the configured port) | `${TOPOLOGY_EXTERNAL_PORT}` | False
+|`TOPOLOGY_LAZY_RETRIEVAL` | `TOPOLOGY_LAZY_RETRIEVAL` | Whether the Hot Rod connector will carry out retrieval operations lazily (defaults to true) | `${TOPOLOGY_LAZY_RETRIEVAL}` | False
+|`TOPOLOGY_AWAIT_INITIAL_TRANSFER` | `TOPOLOGY_AWAIT_INITIAL_TRANSFER` | Whether the initial state retrieval happens immediately at startup; applies only when TOPOLOGY_LAZY_RETRIEVAL is set to false (defaults to true) | `${TOPOLOGY_AWAIT_INITIAL_TRANSFER}` | False
+|`AUTHENTICATION_SECURITY_REALM` | `AUTHENTICATION_SECURITY_REALM` |  | `${AUTHENTICATION_SECURITY_REALM}` | False
+|`SASL_SERVER_NAME` | `SASL_SERVER_NAME` |  | `${SASL_SERVER_NAME}` | False
+|`SASL_SECURITY_CONTEXT_NAME` | `SASL_SECURITY_CONTEXT_NAME` |  | `${SASL_SECURITY_CONTEXT_NAME}` | False
+|`SASL_MECHANISMS` | `SASL_MECHANISMS` |  | `${SASL_MECHANISMS}` | False
+|`SASL_QOP` | `SASL_QOP` |  | `${SASL_QOP}` | False
+|`SASL_STRENGTH` | `SASL_STRENGTH` |  | `${SASL_STRENGTH}` | False
+|`SASL_POLICY_FORWARD_SECRECY` | `SASL_POLICY_FORWARD_SECRECY` |  | `${SASL_POLICY_FORWARD_SECRECY}` | False
+|`SASL_POLICY_NO_ACTIVE` | `SASL_POLICY_NO_ACTIVE` |  | `${SASL_POLICY_NO_ACTIVE}` | False
+|`SASL_POLICY_NO_ANONYMOUS` | `SASL_POLICY_NO_ANONYMOUS` |  | `${SASL_POLICY_NO_ANONYMOUS}` | False
+|`SASL_POLICY_NO_DICTIONARY` | `SASL_POLICY_NO_DICTIONARY` |  | `${SASL_POLICY_NO_DICTIONARY}` | False
+|`SASL_POLICY_NO_PLAIN_TEXT` | `SASL_POLICY_NO_PLAIN_TEXT` |  | `${SASL_POLICY_NO_PLAIN_TEXT}` | False
+|`SASL_POLICY_PASS_CREDENTIALS` | `SASL_POLICY_PASS_CREDENTIALS` |  | `${SASL_POLICY_PASS_CREDENTIALS}` | False
+|`SASL_PROPERTIES` | `SASL_PROPERTIES` |  | `${SASL_PROPERTIES}` | False
+|`ENCRYPTION_SECURITY_REALM` | `ENCRYPTION_SECURITY_REALM` |  | `${ENCRYPTION_SECURITY_REALM}` | False
+|`ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH` | `ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH` |  | `${ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH}` | False
+|`MEMCACHED_CACHE_CONTAINER` | `MEMCACHED_CACHE_CONTAINER` | The cache container used by the memcached connector (defaults to 'clustered') | clustered | True
+|`MEMCACHED_CACHE` | `MEMCACHED_CACHE_CONTAINER` | The name of the cache to expose through this memcached connector (defaults to 'default') | default | False
+|`MEMCACHED_SOCKET_BINDING` | `MEMCACHED_SOCKET_BINDING` | The socked binding port used by the memcached connector (defaults to 'memcached') | memcached | True
+|`MEMCACHED_NAME` | `MEMCACHED_NAME` | The name of this memcached connector (defaults to 'memcached') | memcached | False
+|`MEMCACHED_WORKER_THREADS` | `MEMCACHED_WORKER_THREADS` | The number of worker threads available for the memcached connector (defaults to 160) | `${MEMCACHED_WORKER_THREADS}` | False
+|`MEMCACHED_IDLE_TIMEOUT` | `MEMCACHED_IDLE_TIMEOUT` | The time (in milliseconds) the connector can remain idle before the connection times out (defaults to -1 - no timeout) | `${MEMCACHED_IDLE_TIMEOUT}` | False
+|`MEMCACHED_TCP_NODELAY` | `MEMCACHED_TCP_NODELAY` | Whether TCP packets will be delayed and sent out in batches (defaults to true) | `${MEMCACHED_TCP_NODELAY}` | False
+|`MEMCACHED_SEND_BUFFER_SIZE` | `MEMCACHED_SEND_BUFFER_SIZE` | The size of the send buffer for the memcached connector (defaults to the size of the TCP stack buffer) | `${MEMCACHED_SEND_BUFFER_SIZE}` | False
+|`MEMCACHED_RECEIVE_BUFFER_SIZE` | `MEMCACHED_RECEIVE_BUFFER_SIZE` | The size of the receive buffer for the memcached connector (defaults to the size of the TCP stack buffer) | `${MEMCACHED_RECEIVE_BUFFER_SIZE}` | False
+|`REST_VIRTUAL_SERVER` | `REST_VIRTUAL_SERVER` | The virtual server used by the REST connector (defaults to 'default-host') | `${REST_VIRTUAL_SERVER}` | False
+|`REST_CACHE_CONTAINER` | `REST_CACHE_CONTAINER` | The cache container used by the REST connector (defaults to 'clustered') | clustered | True
+|`REST_CONTEXT_PATH` | `REST_CONTEXT_PATH` | The context path for the REST connector (defaults to '') | `${REST_CONTEXT_PATH}` | False
+|`REST_SECURITY_DOMAIN` | `REST_SECURITY_DOMAIN` | The domain, declared in the security subsystem, that should be used to authenticate access to the REST endpoint | `${REST_SECURITY_DOMAIN}` | False
+|`REST_AUTH_METHOD` | `REST_AUTH_METHOD` | The method used to retrieve credentials for the REST endpoint (defaults to 'BASIC') | `${REST_AUTH_METHOD}` | False
+|`REST_SECURITY_MODE` | `REST_SECURITY_MODE` | Whether authentication is required only for WRITE operations or for READ operations as well (defaults to 'READ_WRITE') | `${REST_SECURITY_MODE}` | False
+|`REST_EXTENDED_HEADERS` | `REST_EXTENDED_HEADERS` |  | `${REST_EXTENDED_HEADERS}` | False
+|`JDG_JGROUPS_ENCRYPT_SECRET` | `JDG_JGROUPS_ENCRYPT_SECRET` | The name of the secret containing the keystore file | `${JDG_JGROUPS_ENCRYPT_SECRET}` | False
+|`JDG_JGROUPS_ENCRYPT_KEYSTORE` | `JDG_JGROUPS_ENCRYPT_KEYSTORE` | The name of the keystore file within the secret | `${JDG_JGROUPS_ENCRYPT_KEYSTORE}` | False
+|`JDG_JGROUPS_ENCRYPT_NAME` | `JDG_JGROUPS_ENCRYPT_NAME` | The name associated with the server certificate | `${JDG_JGROUPS_ENCRYPT_NAME}` | False
+|`JDG_JGROUPS_ENCRYPT_PASSWORD` | `JDG_JGROUPS_ENCRYPT_PASSWORD` | The password for the keystore and certificate | `${JDG_JGROUPS_ENCRYPT_PASSWORD}` | False
+|`JGROUPS_CLUSTER_PASSWORD` | `JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}` | True
 |=======================================================================
 
 
@@ -77,10 +149,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-https` | TLS passthrough | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-memcached` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-hotrod` | none | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
+|`${APPLICATION_NAME}-https` | TLS passthrough | `${HOSTNAME_HTTPS}`
 |=============
 
 
@@ -165,7 +235,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.5+| `${APPLICATION_NAME}`
+.6+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |https | 8443 | `TCP`
 |ping | 8888 | `TCP`
@@ -182,7 +253,11 @@ information.
 |=======================================================================
 |Deployment |Variable name |Description |Example value
 
-.15+| `${APPLICATION_NAME}`
+.71+| `${APPLICATION_NAME}`
+|`JDG_SIMPLE_AUTHENTICATION` | Flag to enable/disable user authentication | `${JDG_SIMPLE_AUTHENTICATION}`
+|`JDG_USERNAME` | User name for JDG user. If left empty, it will be generated. | `${JDG_USERNAME}`
+|`JDG_PASSWORD` | Password for JDG user. If left empty, it will be generated. | `${JDG_PASSWORD}`
+|`JDG_SECDOMAIN_NAME` | Security domain name for user authentication | `${JDG_SECDOMAIN_NAME}`
 |`JDG_HTTPS_KEYSTORE_DIR` | The name of the keystore file within the secret | `/etc/datagrid-secret-volume`
 |`JDG_HTTPS_KEYSTORE` | The name of the keystore file within the secret | `${JDG_HTTPS_KEYSTORE}`
 |`JDG_HTTPS_NAME` | The name associated with the server certificate | `${JDG_HTTPS_NAME}`
@@ -198,6 +273,58 @@ information.
 |`DB_TX_ISOLATION` | Sets transaction-isolation for the configured datasource. | `${DB_TX_ISOLATION}`
 |`OPENSHIFT_KUBE_PING_LABELS` | -- | `application=${APPLICATION_NAME}`
 |`OPENSHIFT_KUBE_PING_NAMESPACE` | -- | --
+|`INFINISPAN_CONNECTORS` | Comma-separated list of connector types that should be configured (defaults to 'memcached,hotrod,rest') | `${INFINISPAN_CONNECTORS}`
+|`HOTROD_CACHE_CONTAINER` | The cache container used by the Hot Rod connector (defaults to 'clustered') | `${HOTROD_CACHE_CONTAINER}`
+|`HOTROD_SOCKET_BINDING` | The socket binding port used by the Hot Rod connector (defaults to 'hotrod') | `${HOTROD_SOCKET_BINDING}`
+|`HOTROD_NAME` |  | `${HOTROD_NAME}`
+|`HOTROD_WORKER_THREADS` | The number of worker threads available for the Hot Rod connector (defaults to 160) | `${HOTROD_WORKER_THREADS}`
+|`HOTROD_IDLE_TIMEOUT` | The time (in milliseconds) the connector can remain idle before the connection times out (defaults to -1 - no timeout) | `${HOTROD_IDLE_TIMEOUT}`
+|`HOTROD_TCP_NODELAY` | Whether TCP packets will be delayed and sent out in batches (defaults to true) | `${HOTROD_TCP_NODELAY}`
+|`HOTROD_SEND_BUFFER_SIZE` | The size of the send buffer for the Hot Rod connector (defaults to size of the TCP stack buffer) | `${HOTROD_SEND_BUFFER_SIZE}`
+|`HOTROD_RECEIVE_BUFFER_SIZE` | The size of the receive buffer for the Hot Rod connector (defaults to size of the TCP stack buffer) | `${HOTROD_RECEIVE_BUFFER_SIZE}`
+|`TOPOLOGY_CACHE_SUFFIX` |  | `${TOPOLOGY_CACHE_SUFFIX}`
+|`TOPOLOGY_LOCK_TIMEOUT` | The time (in milliseconds) after which the operation attempting to obtain a lock times out (defaults to 10 seconds) | `${TOPOLOGY_LOCK_TIMEOUT}`
+|`TOPOLOGY_REPLICATION_TIMEOUT` | The time (in milliseconds) after which the replication operation times out (defaults to 10 seconds) | `${TOPOLOGY_REPLICATION_TIMEOUT}`
+|`TOPOLOGY_EXTERNAL_HOST` | The hostname sent by the Hot Rod server to clients listed in the topology information (defaults to the host address) | `${TOPOLOGY_EXTERNAL_HOST}`
+|`TOPOLOGY_EXTERNAL_PORT` | The port sent by the Hot Rod server to clients listed in the topology information (defaults to the configured port) | `${TOPOLOGY_EXTERNAL_PORT}`
+|`TOPOLOGY_LAZY_RETRIEVAL` | Whether the Hot Rod connector will carry out retrieval operations lazily (defaults to true) | `${TOPOLOGY_LAZY_RETRIEVAL}`
+|`TOPOLOGY_AWAIT_INITIAL_TRANSFER` | Whether the initial state retrieval happens immediately at startup; applies only when TOPOLOGY_LAZY_RETRIEVAL is set to false (defaults to true) | `${TOPOLOGY_AWAIT_INITIAL_TRANSFER}`
+|`AUTHENTICATION_SECURITY_REALM` |  | `${AUTHENTICATION_SECURITY_REALM}`
+|`SASL_SERVER_NAME` |  | `${SASL_SERVER_NAME}`
+|`SASL_SECURITY_CONTEXT_NAME` |  | `${SASL_SECURITY_CONTEXT_NAME}`
+|`SASL_MECHANISMS` |  | `${SASL_MECHANISMS}`
+|`SASL_QOP` |  | `${SASL_QOP}`
+|`SASL_STRENGTH` |  | `${SASL_STRENGTH}`
+|`SASL_POLICY_FORWARD_SECRECY` |  | `${SASL_POLICY_FORWARD_SECRECY}`
+|`SASL_POLICY_NO_ACTIVE` |  | `${SASL_POLICY_NO_ACTIVE}`
+|`SASL_POLICY_NO_ANONYMOUS` |  | `${SASL_POLICY_NO_ANONYMOUS}`
+|`SASL_POLICY_NO_DICTIONARY` |  | `${SASL_POLICY_NO_DICTIONARY}`
+|`SASL_POLICY_NO_PLAIN_TEXT` |  | `${SASL_POLICY_NO_PLAIN_TEXT}`
+|`SASL_POLICY_PASS_CREDENTIALS` |  | `${SASL_POLICY_PASS_CREDENTIALS}`
+|`SASL_PROPERTIES` |  | `${SASL_PROPERTIES}`
+|`ENCRYPTION_SECURITY_REALM` |  | `${ENCRYPTION_SECURITY_REALM}`
+|`ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH` |  | `${ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH}`
+|`MEMCACHED_CACHE_CONTAINER` | The cache container used by the memcached connector (defaults to 'clustered') | `${MEMCACHED_CACHE_CONTAINER}`
+|`MEMCACHED_CACHE` | The cache container used by the memcached connector (defaults to 'clustered') | `${MEMCACHED_CACHE}`
+|`MEMCACHED_SOCKET_BINDING` | The socked binding port used by the memcached connector (defaults to 'memcached') | `${MEMCACHED_SOCKET_BINDING}`
+|`MEMCACHED_NAME` | The name of this memcached connector (defaults to 'memcached') | `${MEMCACHED_NAME}`
+|`MEMCACHED_WORKER_THREADS` | The number of worker threads available for the memcached connector (defaults to 160) | `${MEMCACHED_WORKER_THREADS}`
+|`MEMCACHED_IDLE_TIMEOUT` | The time (in milliseconds) the connector can remain idle before the connection times out (defaults to -1 - no timeout) | `${MEMCACHED_IDLE_TIMEOUT}`
+|`MEMCACHED_TCP_NODELAY` | Whether TCP packets will be delayed and sent out in batches (defaults to true) | `${MEMCACHED_TCP_NODELAY}`
+|`MEMCACHED_SEND_BUFFER_SIZE` | The size of the send buffer for the memcached connector (defaults to the size of the TCP stack buffer) | `${MEMCACHED_SEND_BUFFER_SIZE}`
+|`MEMCACHED_RECEIVE_BUFFER_SIZE` | The size of the receive buffer for the memcached connector (defaults to the size of the TCP stack buffer) | `${MEMCACHED_RECEIVE_BUFFER_SIZE}`
+|`REST_VIRTUAL_SERVER` | The virtual server used by the REST connector (defaults to 'default-host') | `${REST_VIRTUAL_SERVER}`
+|`REST_CACHE_CONTAINER` | The cache container used by the REST connector (defaults to 'clustered') | `${REST_CACHE_CONTAINER}`
+|`REST_CONTEXT_PATH` | The context path for the REST connector (defaults to '') | `${REST_CONTEXT_PATH}`
+|`REST_SECURITY_DOMAIN` | The domain, declared in the security subsystem, that should be used to authenticate access to the REST endpoint | `${REST_SECURITY_DOMAIN}`
+|`REST_AUTH_METHOD` | The method used to retrieve credentials for the REST endpoint (defaults to 'BASIC') | `${REST_AUTH_METHOD}`
+|`REST_SECURITY_MODE` | Whether authentication is required only for WRITE operations or for READ operations as well (defaults to 'READ_WRITE') | `${REST_SECURITY_MODE}`
+|`REST_EXTENDED_HEADERS` |  | `${REST_EXTENDED_HEADERS}`
+|`JDG_JGROUPS_ENCRYPT_SECRET` | The name of the secret containing the keystore file | `${JDG_JGROUPS_ENCRYPT_SECRET}`
+|`JDG_JGROUPS_ENCRYPT_KEYSTORE` | The name of the keystore file within the secret | `${JDG_JGROUPS_ENCRYPT_KEYSTORE}`
+|`JDG_JGROUPS_ENCRYPT_NAME` | The name associated with the server certificate | `${JDG_JGROUPS_ENCRYPT_NAME}`
+|`JDG_JGROUPS_ENCRYPT_PASSWORD` | The password for the keystore and certificate | `${JDG_JGROUPS_ENCRYPT_PASSWORD}`
+|`JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}`
 .5+| `${APPLICATION_NAME}-postgresql`
 |`POSTGRESQL_USER` | -- | `${DB_USERNAME}`
 |`POSTGRESQL_PASSWORD` | -- | `${DB_PASSWORD}`

--- a/docs/datagrid/datagrid65-postgresql.adoc
+++ b/docs/datagrid/datagrid65-postgresql.adoc
@@ -11,6 +11,21 @@
 
 Application template for JDG 6.5 and PostgreSQL applications built using.
 
+For simple authentication, set
+
+  JDG_SIMPLE_AUTHENTICATION=true
+  JDG_USERNAME=<username>
+  JDG_PASSWORD=<password>
+
+This will enable user authentication with the datagrid. Provided username and password will be used to access the cache over both HTTPS and HotRod. With this case, the user will have all permissions configured.
+
+Restrictions for password:
+
+  at least 8 characters
+  at least 1 digit
+  at least 1 non-alphanumeric symbol
+
+
 toc::[]
 
 
@@ -24,7 +39,12 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |Variable name |Image Environment Variable |Description |Example value |Required
 
 |`APPLICATION_NAME` | -- | The name for the application. | datagrid-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
+|`HOSTNAME_HTTPS` | -- | Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-<project>.<default-domain-suffix> | -- | False
+|`JDG_SIMPLE_AUTHENTICATION` | `JDG_SIMPLE_AUTHENTICATION` | Flag to enable/disable user authentication | false | False
+|`JDG_SECDOMAIN_NAME` | `JDG_SECDOMAIN_NAME` | Security domain name for user authentication | jdg-openshift | False
+|`JDG_USERNAME` | `JDG_USERNAME` | User name for JDG user. If left empty, it will be generated. | `${JDG_USERNAME}` | False
+|`JDG_PASSWORD` | `JDG_PASSWORD` | Password for JDG user. If left empty, it will be generated. | `${JDG_PASSWORD}` | False
 |`JDG_HTTPS_SECRET` | -- | The name of the secret containing the keystore file | datagrid-app-secret | True
 |`JDG_HTTPS_KEYSTORE` | `JDG_HTTPS_KEYSTORE_DIR` | The name of the keystore file within the secret | keystore.jks | False
 |`JDG_HTTPS_NAME` | `JDG_HTTPS_NAME` | The name associated with the server certificate | `${JDG_HTTPS_NAME}` | False
@@ -39,6 +59,58 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`POSTGRESQL_MAX_CONNECTIONS` | `POSTGRESQL_MAX_CONNECTIONS` | The maximum number of client connections allowed. This also sets the maximum number of prepared transactions. | `${POSTGRESQL_MAX_CONNECTIONS}` | False
 |`POSTGRESQL_SHARED_BUFFERS` | `POSTGRESQL_SHARED_BUFFERS` | Configures how much memory is dedicated to PostgreSQL for caching data. | `${POSTGRESQL_SHARED_BUFFERS}` | False
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
+|`INFINISPAN_CONNECTORS` | `INFINISPAN_CONNECTORS` | Comma-separated list of connector types that should be configured (defaults to 'memcached,hotrod,rest') | hotrod,memcached,rest | False
+|`HOTROD_CACHE_CONTAINER` | `HOTROD_CACHE_CONTAINER` | The cache container used by the Hot Rod connector (defaults to 'clustered') | clustered | True
+|`HOTROD_SOCKET_BINDING` | `HOTROD_SOCKET_BINDING` | The socket binding port used by the Hot Rod connector (defaults to 'hotrod') | hotrod | True
+|`HOTROD_NAME` | `HOTROD_NAME` |  | `${HOTROD_NAME}` | False
+|`HOTROD_WORKER_THREADS` | `HOTROD_WORKER_THREADS` | The number of worker threads available for the Hot Rod connector (defaults to 160) | `${HOTROD_WORKER_THREADS}` | False
+|`HOTROD_IDLE_TIMEOUT` | `HOTROD_IDLE_TIMEOUT` | The time (in milliseconds) the connector can remain idle before the connection times out (defaults to -1 - no timeout) | `${HOTROD_IDLE_TIMEOUT}` | False
+|`HOTROD_TCP_NODELAY` | `HOTROD_TCP_NODELAY` | Whether TCP packets will be delayed and sent out in batches (defaults to true) | `${HOTROD_TCP_NODELAY}` | False
+|`HOTROD_SEND_BUFFER_SIZE` | `HOTROD_SEND_BUFFER_SIZE` | The size of the send buffer for the Hot Rod connector (defaults to size of the TCP stack buffer) | `${HOTROD_SEND_BUFFER_SIZE}` | False
+|`HOTROD_RECEIVE_BUFFER_SIZE` | `HOTROD_RECEIVE_BUFFER_SIZE` | The size of the receive buffer for the Hot Rod connector (defaults to size of the TCP stack buffer) | `${HOTROD_RECEIVE_BUFFER_SIZE}` | False
+|`TOPOLOGY_CACHE_SUFFIX` | `TOPOLOGY_CACHE_SUFFIX` |  | `${TOPOLOGY_CACHE_SUFFIX}` | False
+|`TOPOLOGY_LOCK_TIMEOUT` | `TOPOLOGY_LOCK_TIMEOUT` | The time (in milliseconds) after which the operation attempting to obtain a lock times out (defaults to 10 seconds) | `${TOPOLOGY_LOCK_TIMEOUT}` | False
+|`TOPOLOGY_REPLICATION_TIMEOUT` | `TOPOLOGY_REPLICATION_TIMEOUT` | The time (in milliseconds) after which the replication operation times out (defaults to 10 seconds) | `${TOPOLOGY_REPLICATION_TIMEOUT}` | False
+|`TOPOLOGY_EXTERNAL_HOST` | `TOPOLOGY_EXTERNAL_HOST` | The hostname sent by the Hot Rod server to clients listed in the topology information (defaults to the host address) | `${TOPOLOGY_EXTERNAL_HOST}` | False
+|`TOPOLOGY_EXTERNAL_PORT` | `TOPOLOGY_EXTERNAL_PORT` | The port sent by the Hot Rod server to clients listed in the topology information (defaults to the configured port) | `${TOPOLOGY_EXTERNAL_PORT}` | False
+|`TOPOLOGY_LAZY_RETRIEVAL` | `TOPOLOGY_LAZY_RETRIEVAL` | Whether the Hot Rod connector will carry out retrieval operations lazily (defaults to true) | `${TOPOLOGY_LAZY_RETRIEVAL}` | False
+|`TOPOLOGY_AWAIT_INITIAL_TRANSFER` | `TOPOLOGY_AWAIT_INITIAL_TRANSFER` | Whether the initial state retrieval happens immediately at startup; applies only when TOPOLOGY_LAZY_RETRIEVAL is set to false (defaults to true) | `${TOPOLOGY_AWAIT_INITIAL_TRANSFER}` | False
+|`AUTHENTICATION_SECURITY_REALM` | `AUTHENTICATION_SECURITY_REALM` |  | `${AUTHENTICATION_SECURITY_REALM}` | False
+|`SASL_SERVER_NAME` | `SASL_SERVER_NAME` |  | `${SASL_SERVER_NAME}` | False
+|`SASL_SECURITY_CONTEXT_NAME` | `SASL_SECURITY_CONTEXT_NAME` |  | `${SASL_SECURITY_CONTEXT_NAME}` | False
+|`SASL_MECHANISMS` | `SASL_MECHANISMS` |  | `${SASL_MECHANISMS}` | False
+|`SASL_QOP` | `SASL_QOP` |  | `${SASL_QOP}` | False
+|`SASL_STRENGTH` | `SASL_STRENGTH` |  | `${SASL_STRENGTH}` | False
+|`SASL_POLICY_FORWARD_SECRECY` | `SASL_POLICY_FORWARD_SECRECY` |  | `${SASL_POLICY_FORWARD_SECRECY}` | False
+|`SASL_POLICY_NO_ACTIVE` | `SASL_POLICY_NO_ACTIVE` |  | `${SASL_POLICY_NO_ACTIVE}` | False
+|`SASL_POLICY_NO_ANONYMOUS` | `SASL_POLICY_NO_ANONYMOUS` |  | `${SASL_POLICY_NO_ANONYMOUS}` | False
+|`SASL_POLICY_NO_DICTIONARY` | `SASL_POLICY_NO_DICTIONARY` |  | `${SASL_POLICY_NO_DICTIONARY}` | False
+|`SASL_POLICY_NO_PLAIN_TEXT` | `SASL_POLICY_NO_PLAIN_TEXT` |  | `${SASL_POLICY_NO_PLAIN_TEXT}` | False
+|`SASL_POLICY_PASS_CREDENTIALS` | `SASL_POLICY_PASS_CREDENTIALS` |  | `${SASL_POLICY_PASS_CREDENTIALS}` | False
+|`SASL_PROPERTIES` | `SASL_PROPERTIES` |  | `${SASL_PROPERTIES}` | False
+|`ENCRYPTION_SECURITY_REALM` | `ENCRYPTION_SECURITY_REALM` |  | `${ENCRYPTION_SECURITY_REALM}` | False
+|`ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH` | `ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH` |  | `${ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH}` | False
+|`MEMCACHED_CACHE_CONTAINER` | `MEMCACHED_CACHE_CONTAINER` | The cache container used by the memcached connector (defaults to 'clustered') | clustered | True
+|`MEMCACHED_CACHE` | `MEMCACHED_CACHE_CONTAINER` | The name of the cache to expose through this memcached connector (defaults to 'default') | default | False
+|`MEMCACHED_SOCKET_BINDING` | `MEMCACHED_SOCKET_BINDING` | The socked binding port used by the memcached connector (defaults to 'memcached') | memcached | True
+|`MEMCACHED_NAME` | `MEMCACHED_NAME` | The name of this memcached connector (defaults to 'memcached') | memcached | False
+|`MEMCACHED_WORKER_THREADS` | `MEMCACHED_WORKER_THREADS` | The number of worker threads available for the memcached connector (defaults to 160) | `${MEMCACHED_WORKER_THREADS}` | False
+|`MEMCACHED_IDLE_TIMEOUT` | `MEMCACHED_IDLE_TIMEOUT` | The time (in milliseconds) the connector can remain idle before the connection times out (defaults to -1 - no timeout) | `${MEMCACHED_IDLE_TIMEOUT}` | False
+|`MEMCACHED_TCP_NODELAY` | `MEMCACHED_TCP_NODELAY` | Whether TCP packets will be delayed and sent out in batches (defaults to true) | `${MEMCACHED_TCP_NODELAY}` | False
+|`MEMCACHED_SEND_BUFFER_SIZE` | `MEMCACHED_SEND_BUFFER_SIZE` | The size of the send buffer for the memcached connector (defaults to the size of the TCP stack buffer) | `${MEMCACHED_SEND_BUFFER_SIZE}` | False
+|`MEMCACHED_RECEIVE_BUFFER_SIZE` | `MEMCACHED_RECEIVE_BUFFER_SIZE` | The size of the receive buffer for the memcached connector (defaults to the size of the TCP stack buffer) | `${MEMCACHED_RECEIVE_BUFFER_SIZE}` | False
+|`REST_VIRTUAL_SERVER` | `REST_VIRTUAL_SERVER` | The virtual server used by the REST connector (defaults to 'default-host') | `${REST_VIRTUAL_SERVER}` | False
+|`REST_CACHE_CONTAINER` | `REST_CACHE_CONTAINER` | The cache container used by the REST connector (defaults to 'clustered') | clustered | True
+|`REST_CONTEXT_PATH` | `REST_CONTEXT_PATH` | The context path for the REST connector (defaults to '') | `${REST_CONTEXT_PATH}` | False
+|`REST_SECURITY_DOMAIN` | `REST_SECURITY_DOMAIN` | The domain, declared in the security subsystem, that should be used to authenticate access to the REST endpoint | `${REST_SECURITY_DOMAIN}` | False
+|`REST_AUTH_METHOD` | `REST_AUTH_METHOD` | The method used to retrieve credentials for the REST endpoint (defaults to 'BASIC') | `${REST_AUTH_METHOD}` | False
+|`REST_SECURITY_MODE` | `REST_SECURITY_MODE` | Whether authentication is required only for WRITE operations or for READ operations as well (defaults to 'READ_WRITE') | `${REST_SECURITY_MODE}` | False
+|`REST_EXTENDED_HEADERS` | `REST_EXTENDED_HEADERS` |  | `${REST_EXTENDED_HEADERS}` | False
+|`JDG_JGROUPS_ENCRYPT_SECRET` | `JDG_JGROUPS_ENCRYPT_SECRET` | The name of the secret containing the keystore file | `${JDG_JGROUPS_ENCRYPT_SECRET}` | False
+|`JDG_JGROUPS_ENCRYPT_KEYSTORE` | `JDG_JGROUPS_ENCRYPT_KEYSTORE` | The name of the keystore file within the secret | `${JDG_JGROUPS_ENCRYPT_KEYSTORE}` | False
+|`JDG_JGROUPS_ENCRYPT_NAME` | `JDG_JGROUPS_ENCRYPT_NAME` | The name associated with the server certificate | `${JDG_JGROUPS_ENCRYPT_NAME}` | False
+|`JDG_JGROUPS_ENCRYPT_PASSWORD` | `JDG_JGROUPS_ENCRYPT_PASSWORD` | The password for the keystore and certificate | `${JDG_JGROUPS_ENCRYPT_PASSWORD}` | False
+|`JGROUPS_CLUSTER_PASSWORD` | `JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}` | True
 |=======================================================================
 
 
@@ -76,10 +148,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-https` | TLS passthrough | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-memcached` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-hotrod` | none | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
+|`${APPLICATION_NAME}-https` | TLS passthrough | `${HOSTNAME_HTTPS}`
 |=============
 
 
@@ -164,7 +234,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.5+| `${APPLICATION_NAME}`
+.6+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |https | 8443 | `TCP`
 |ping | 8888 | `TCP`
@@ -181,7 +252,11 @@ information.
 |=======================================================================
 |Deployment |Variable name |Description |Example value
 
-.15+| `${APPLICATION_NAME}`
+.71+| `${APPLICATION_NAME}`
+|`JDG_SIMPLE_AUTHENTICATION` | Flag to enable/disable user authentication | `${JDG_SIMPLE_AUTHENTICATION}`
+|`JDG_USERNAME` | User name for JDG user. If left empty, it will be generated. | `${JDG_USERNAME}`
+|`JDG_PASSWORD` | Password for JDG user. If left empty, it will be generated. | `${JDG_PASSWORD}`
+|`JDG_SECDOMAIN_NAME` | Security domain name for user authentication | `${JDG_SECDOMAIN_NAME}`
 |`JDG_HTTPS_KEYSTORE_DIR` | The name of the keystore file within the secret | `/etc/datagrid-secret-volume`
 |`JDG_HTTPS_KEYSTORE` | The name of the keystore file within the secret | `${JDG_HTTPS_KEYSTORE}`
 |`JDG_HTTPS_NAME` | The name associated with the server certificate | `${JDG_HTTPS_NAME}`
@@ -197,6 +272,58 @@ information.
 |`DB_TX_ISOLATION` | Sets transaction-isolation for the configured datasource. | `${DB_TX_ISOLATION}`
 |`OPENSHIFT_KUBE_PING_LABELS` | -- | `application=${APPLICATION_NAME}`
 |`OPENSHIFT_KUBE_PING_NAMESPACE` | -- | --
+|`INFINISPAN_CONNECTORS` | Comma-separated list of connector types that should be configured (defaults to 'memcached,hotrod,rest') | `${INFINISPAN_CONNECTORS}`
+|`HOTROD_CACHE_CONTAINER` | The cache container used by the Hot Rod connector (defaults to 'clustered') | `${HOTROD_CACHE_CONTAINER}`
+|`HOTROD_SOCKET_BINDING` | The socket binding port used by the Hot Rod connector (defaults to 'hotrod') | `${HOTROD_SOCKET_BINDING}`
+|`HOTROD_NAME` |  | `${HOTROD_NAME}`
+|`HOTROD_WORKER_THREADS` | The number of worker threads available for the Hot Rod connector (defaults to 160) | `${HOTROD_WORKER_THREADS}`
+|`HOTROD_IDLE_TIMEOUT` | The time (in milliseconds) the connector can remain idle before the connection times out (defaults to -1 - no timeout) | `${HOTROD_IDLE_TIMEOUT}`
+|`HOTROD_TCP_NODELAY` | Whether TCP packets will be delayed and sent out in batches (defaults to true) | `${HOTROD_TCP_NODELAY}`
+|`HOTROD_SEND_BUFFER_SIZE` | The size of the send buffer for the Hot Rod connector (defaults to size of the TCP stack buffer) | `${HOTROD_SEND_BUFFER_SIZE}`
+|`HOTROD_RECEIVE_BUFFER_SIZE` | The size of the receive buffer for the Hot Rod connector (defaults to size of the TCP stack buffer) | `${HOTROD_RECEIVE_BUFFER_SIZE}`
+|`TOPOLOGY_CACHE_SUFFIX` |  | `${TOPOLOGY_CACHE_SUFFIX}`
+|`TOPOLOGY_LOCK_TIMEOUT` | The time (in milliseconds) after which the operation attempting to obtain a lock times out (defaults to 10 seconds) | `${TOPOLOGY_LOCK_TIMEOUT}`
+|`TOPOLOGY_REPLICATION_TIMEOUT` | The time (in milliseconds) after which the replication operation times out (defaults to 10 seconds) | `${TOPOLOGY_REPLICATION_TIMEOUT}`
+|`TOPOLOGY_EXTERNAL_HOST` | The hostname sent by the Hot Rod server to clients listed in the topology information (defaults to the host address) | `${TOPOLOGY_EXTERNAL_HOST}`
+|`TOPOLOGY_EXTERNAL_PORT` | The port sent by the Hot Rod server to clients listed in the topology information (defaults to the configured port) | `${TOPOLOGY_EXTERNAL_PORT}`
+|`TOPOLOGY_LAZY_RETRIEVAL` | Whether the Hot Rod connector will carry out retrieval operations lazily (defaults to true) | `${TOPOLOGY_LAZY_RETRIEVAL}`
+|`TOPOLOGY_AWAIT_INITIAL_TRANSFER` | Whether the initial state retrieval happens immediately at startup; applies only when TOPOLOGY_LAZY_RETRIEVAL is set to false (defaults to true) | `${TOPOLOGY_AWAIT_INITIAL_TRANSFER}`
+|`AUTHENTICATION_SECURITY_REALM` |  | `${AUTHENTICATION_SECURITY_REALM}`
+|`SASL_SERVER_NAME` |  | `${SASL_SERVER_NAME}`
+|`SASL_SECURITY_CONTEXT_NAME` |  | `${SASL_SECURITY_CONTEXT_NAME}`
+|`SASL_MECHANISMS` |  | `${SASL_MECHANISMS}`
+|`SASL_QOP` |  | `${SASL_QOP}`
+|`SASL_STRENGTH` |  | `${SASL_STRENGTH}`
+|`SASL_POLICY_FORWARD_SECRECY` |  | `${SASL_POLICY_FORWARD_SECRECY}`
+|`SASL_POLICY_NO_ACTIVE` |  | `${SASL_POLICY_NO_ACTIVE}`
+|`SASL_POLICY_NO_ANONYMOUS` |  | `${SASL_POLICY_NO_ANONYMOUS}`
+|`SASL_POLICY_NO_DICTIONARY` |  | `${SASL_POLICY_NO_DICTIONARY}`
+|`SASL_POLICY_NO_PLAIN_TEXT` |  | `${SASL_POLICY_NO_PLAIN_TEXT}`
+|`SASL_POLICY_PASS_CREDENTIALS` |  | `${SASL_POLICY_PASS_CREDENTIALS}`
+|`SASL_PROPERTIES` |  | `${SASL_PROPERTIES}`
+|`ENCRYPTION_SECURITY_REALM` |  | `${ENCRYPTION_SECURITY_REALM}`
+|`ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH` |  | `${ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH}`
+|`MEMCACHED_CACHE_CONTAINER` | The cache container used by the memcached connector (defaults to 'clustered') | `${MEMCACHED_CACHE_CONTAINER}`
+|`MEMCACHED_CACHE` | The cache container used by the memcached connector (defaults to 'clustered') | `${MEMCACHED_CACHE}`
+|`MEMCACHED_SOCKET_BINDING` | The socked binding port used by the memcached connector (defaults to 'memcached') | `${MEMCACHED_SOCKET_BINDING}`
+|`MEMCACHED_NAME` | The name of this memcached connector (defaults to 'memcached') | `${MEMCACHED_NAME}`
+|`MEMCACHED_WORKER_THREADS` | The number of worker threads available for the memcached connector (defaults to 160) | `${MEMCACHED_WORKER_THREADS}`
+|`MEMCACHED_IDLE_TIMEOUT` | The time (in milliseconds) the connector can remain idle before the connection times out (defaults to -1 - no timeout) | `${MEMCACHED_IDLE_TIMEOUT}`
+|`MEMCACHED_TCP_NODELAY` | Whether TCP packets will be delayed and sent out in batches (defaults to true) | `${MEMCACHED_TCP_NODELAY}`
+|`MEMCACHED_SEND_BUFFER_SIZE` | The size of the send buffer for the memcached connector (defaults to the size of the TCP stack buffer) | `${MEMCACHED_SEND_BUFFER_SIZE}`
+|`MEMCACHED_RECEIVE_BUFFER_SIZE` | The size of the receive buffer for the memcached connector (defaults to the size of the TCP stack buffer) | `${MEMCACHED_RECEIVE_BUFFER_SIZE}`
+|`REST_VIRTUAL_SERVER` | The virtual server used by the REST connector (defaults to 'default-host') | `${REST_VIRTUAL_SERVER}`
+|`REST_CACHE_CONTAINER` | The cache container used by the REST connector (defaults to 'clustered') | `${REST_CACHE_CONTAINER}`
+|`REST_CONTEXT_PATH` | The context path for the REST connector (defaults to '') | `${REST_CONTEXT_PATH}`
+|`REST_SECURITY_DOMAIN` | The domain, declared in the security subsystem, that should be used to authenticate access to the REST endpoint | `${REST_SECURITY_DOMAIN}`
+|`REST_AUTH_METHOD` | The method used to retrieve credentials for the REST endpoint (defaults to 'BASIC') | `${REST_AUTH_METHOD}`
+|`REST_SECURITY_MODE` | Whether authentication is required only for WRITE operations or for READ operations as well (defaults to 'READ_WRITE') | `${REST_SECURITY_MODE}`
+|`REST_EXTENDED_HEADERS` |  | `${REST_EXTENDED_HEADERS}`
+|`JDG_JGROUPS_ENCRYPT_SECRET` | The name of the secret containing the keystore file | `${JDG_JGROUPS_ENCRYPT_SECRET}`
+|`JDG_JGROUPS_ENCRYPT_KEYSTORE` | The name of the keystore file within the secret | `${JDG_JGROUPS_ENCRYPT_KEYSTORE}`
+|`JDG_JGROUPS_ENCRYPT_NAME` | The name associated with the server certificate | `${JDG_JGROUPS_ENCRYPT_NAME}`
+|`JDG_JGROUPS_ENCRYPT_PASSWORD` | The password for the keystore and certificate | `${JDG_JGROUPS_ENCRYPT_PASSWORD}`
+|`JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}`
 .5+| `${APPLICATION_NAME}-postgresql`
 |`POSTGRESQL_USER` | -- | `${DB_USERNAME}`
 |`POSTGRESQL_PASSWORD` | -- | `${DB_PASSWORD}`

--- a/docs/datagrid/datagrid65-remote-cache.adoc
+++ b/docs/datagrid/datagrid65-remote-cache.adoc
@@ -11,6 +11,21 @@
 
 Application template for JDG 6.5 applications.
 
+For simple authentication, set
+
+  JDG_SIMPLE_AUTHENTICATION=true
+  JDG_USERNAME=<username>
+  JDG_PASSWORD=<password>
+
+This will enable user authentication with the datagrid. Provided username and password will be used to access the cache over both HTTPS and HotRod. With this case, the user will have all permissions configured.
+
+Restrictions for password:
+
+  at least 8 characters
+  at least 1 digit
+  at least 1 non-alphanumeric symbol
+
+
 toc::[]
 
 
@@ -24,7 +39,12 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |Variable name |Image Environment Variable |Description |Example value |Required
 
 |`APPLICATION_NAME` | -- | The name for the application. | datagrid-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
+|`HOSTNAME_HTTPS` | -- | Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-<project>.<default-domain-suffix> | -- | False
+|`JDG_SIMPLE_AUTHENTICATION` | `JDG_SIMPLE_AUTHENTICATION` | Flag to enable/disable user authentication | false | False
+|`JDG_SECDOMAIN_NAME` | `JDG_SECDOMAIN_NAME` | Security domain name for user authentication | jdg-openshift | False
+|`JDG_USERNAME` | `JDG_USERNAME` | User name for JDG user. If left empty, it will be generated. | `${JDG_USERNAME}` | False
+|`JDG_PASSWORD` | `JDG_PASSWORD` | Password for JDG user. If left empty, it will be generated. | `${JDG_PASSWORD}` | False
 |`JDG_HTTPS_SECRET` | -- | The name of the secret containing the keystore file | datagrid-app-secret | True
 |`JDG_HTTPS_KEYSTORE` | `JDG_HTTPS_KEYSTORE_DIR` | The name of the keystore file within the secret | keystore.jks | False
 |`JDG_HTTPS_NAME` | `JDG_HTTPS_NAME` | The name associated with the server certificate | `${JDG_HTTPS_NAME}` | False
@@ -51,6 +71,58 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`REMOTE_HOTROD_DESTINATION_HOST` | -- | Remote Hot Rod destination host | -- | False
 |`REMOTE_HOTROD_DESTINATION_PORT` | -- | Remote Hot Rod destination port | 11222 | False
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
+|`INFINISPAN_CONNECTORS` | `INFINISPAN_CONNECTORS` | Comma-separated list of connector types that should be configured (defaults to 'memcached,hotrod,rest') | hotrod,memcached,rest | False
+|`HOTROD_CACHE_CONTAINER` | `HOTROD_CACHE_CONTAINER` | The cache container used by the Hot Rod connector (defaults to 'clustered') | clustered | True
+|`HOTROD_SOCKET_BINDING` | `HOTROD_SOCKET_BINDING` | The socket binding port used by the Hot Rod connector (defaults to 'hotrod') | hotrod | True
+|`HOTROD_NAME` | `HOTROD_NAME` |  | `${HOTROD_NAME}` | False
+|`HOTROD_WORKER_THREADS` | `HOTROD_WORKER_THREADS` | The number of worker threads available for the Hot Rod connector (defaults to 160) | `${HOTROD_WORKER_THREADS}` | False
+|`HOTROD_IDLE_TIMEOUT` | `HOTROD_IDLE_TIMEOUT` | The time (in milliseconds) the connector can remain idle before the connection times out (defaults to -1 - no timeout) | `${HOTROD_IDLE_TIMEOUT}` | False
+|`HOTROD_TCP_NODELAY` | `HOTROD_TCP_NODELAY` | Whether TCP packets will be delayed and sent out in batches (defaults to true) | `${HOTROD_TCP_NODELAY}` | False
+|`HOTROD_SEND_BUFFER_SIZE` | `HOTROD_SEND_BUFFER_SIZE` | The size of the send buffer for the Hot Rod connector (defaults to size of the TCP stack buffer) | `${HOTROD_SEND_BUFFER_SIZE}` | False
+|`HOTROD_RECEIVE_BUFFER_SIZE` | `HOTROD_RECEIVE_BUFFER_SIZE` | The size of the receive buffer for the Hot Rod connector (defaults to size of the TCP stack buffer) | `${HOTROD_RECEIVE_BUFFER_SIZE}` | False
+|`TOPOLOGY_CACHE_SUFFIX` | `TOPOLOGY_CACHE_SUFFIX` |  | `${TOPOLOGY_CACHE_SUFFIX}` | False
+|`TOPOLOGY_LOCK_TIMEOUT` | `TOPOLOGY_LOCK_TIMEOUT` | The time (in milliseconds) after which the operation attempting to obtain a lock times out (defaults to 10 seconds) | `${TOPOLOGY_LOCK_TIMEOUT}` | False
+|`TOPOLOGY_REPLICATION_TIMEOUT` | `TOPOLOGY_REPLICATION_TIMEOUT` | The time (in milliseconds) after which the replication operation times out (defaults to 10 seconds) | `${TOPOLOGY_REPLICATION_TIMEOUT}` | False
+|`TOPOLOGY_EXTERNAL_HOST` | `TOPOLOGY_EXTERNAL_HOST` | The hostname sent by the Hot Rod server to clients listed in the topology information (defaults to the host address) | `${TOPOLOGY_EXTERNAL_HOST}` | False
+|`TOPOLOGY_EXTERNAL_PORT` | `TOPOLOGY_EXTERNAL_PORT` | The port sent by the Hot Rod server to clients listed in the topology information (defaults to the configured port) | `${TOPOLOGY_EXTERNAL_PORT}` | False
+|`TOPOLOGY_LAZY_RETRIEVAL` | `TOPOLOGY_LAZY_RETRIEVAL` | Whether the Hot Rod connector will carry out retrieval operations lazily (defaults to true) | `${TOPOLOGY_LAZY_RETRIEVAL}` | False
+|`TOPOLOGY_AWAIT_INITIAL_TRANSFER` | `TOPOLOGY_AWAIT_INITIAL_TRANSFER` | Whether the initial state retrieval happens immediately at startup; applies only when TOPOLOGY_LAZY_RETRIEVAL is set to false (defaults to true) | `${TOPOLOGY_AWAIT_INITIAL_TRANSFER}` | False
+|`AUTHENTICATION_SECURITY_REALM` | `AUTHENTICATION_SECURITY_REALM` |  | `${AUTHENTICATION_SECURITY_REALM}` | False
+|`SASL_SERVER_NAME` | `SASL_SERVER_NAME` |  | `${SASL_SERVER_NAME}` | False
+|`SASL_SECURITY_CONTEXT_NAME` | `SASL_SECURITY_CONTEXT_NAME` |  | `${SASL_SECURITY_CONTEXT_NAME}` | False
+|`SASL_MECHANISMS` | `SASL_MECHANISMS` |  | `${SASL_MECHANISMS}` | False
+|`SASL_QOP` | `SASL_QOP` |  | `${SASL_QOP}` | False
+|`SASL_STRENGTH` | `SASL_STRENGTH` |  | `${SASL_STRENGTH}` | False
+|`SASL_POLICY_FORWARD_SECRECY` | `SASL_POLICY_FORWARD_SECRECY` |  | `${SASL_POLICY_FORWARD_SECRECY}` | False
+|`SASL_POLICY_NO_ACTIVE` | `SASL_POLICY_NO_ACTIVE` |  | `${SASL_POLICY_NO_ACTIVE}` | False
+|`SASL_POLICY_NO_ANONYMOUS` | `SASL_POLICY_NO_ANONYMOUS` |  | `${SASL_POLICY_NO_ANONYMOUS}` | False
+|`SASL_POLICY_NO_DICTIONARY` | `SASL_POLICY_NO_DICTIONARY` |  | `${SASL_POLICY_NO_DICTIONARY}` | False
+|`SASL_POLICY_NO_PLAIN_TEXT` | `SASL_POLICY_NO_PLAIN_TEXT` |  | `${SASL_POLICY_NO_PLAIN_TEXT}` | False
+|`SASL_POLICY_PASS_CREDENTIALS` | `SASL_POLICY_PASS_CREDENTIALS` |  | `${SASL_POLICY_PASS_CREDENTIALS}` | False
+|`SASL_PROPERTIES` | `SASL_PROPERTIES` |  | `${SASL_PROPERTIES}` | False
+|`ENCRYPTION_SECURITY_REALM` | `ENCRYPTION_SECURITY_REALM` |  | `${ENCRYPTION_SECURITY_REALM}` | False
+|`ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH` | `ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH` |  | `${ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH}` | False
+|`MEMCACHED_CACHE_CONTAINER` | `MEMCACHED_CACHE_CONTAINER` | The cache container used by the memcached connector (defaults to 'clustered') | clustered | True
+|`MEMCACHED_CACHE` | `MEMCACHED_CACHE_CONTAINER` | The name of the cache to expose through this memcached connector (defaults to 'default') | default | False
+|`MEMCACHED_SOCKET_BINDING` | `MEMCACHED_SOCKET_BINDING` | The socked binding port used by the memcached connector (defaults to 'memcached') | memcached | True
+|`MEMCACHED_NAME` | `MEMCACHED_NAME` | The name of this memcached connector (defaults to 'memcached') | memcached | False
+|`MEMCACHED_WORKER_THREADS` | `MEMCACHED_WORKER_THREADS` | The number of worker threads available for the memcached connector (defaults to 160) | `${MEMCACHED_WORKER_THREADS}` | False
+|`MEMCACHED_IDLE_TIMEOUT` | `MEMCACHED_IDLE_TIMEOUT` | The time (in milliseconds) the connector can remain idle before the connection times out (defaults to -1 - no timeout) | `${MEMCACHED_IDLE_TIMEOUT}` | False
+|`MEMCACHED_TCP_NODELAY` | `MEMCACHED_TCP_NODELAY` | Whether TCP packets will be delayed and sent out in batches (defaults to true) | `${MEMCACHED_TCP_NODELAY}` | False
+|`MEMCACHED_SEND_BUFFER_SIZE` | `MEMCACHED_SEND_BUFFER_SIZE` | The size of the send buffer for the memcached connector (defaults to the size of the TCP stack buffer) | `${MEMCACHED_SEND_BUFFER_SIZE}` | False
+|`MEMCACHED_RECEIVE_BUFFER_SIZE` | `MEMCACHED_RECEIVE_BUFFER_SIZE` | The size of the receive buffer for the memcached connector (defaults to the size of the TCP stack buffer) | `${MEMCACHED_RECEIVE_BUFFER_SIZE}` | False
+|`REST_VIRTUAL_SERVER` | `REST_VIRTUAL_SERVER` | The virtual server used by the REST connector (defaults to 'default-host') | `${REST_VIRTUAL_SERVER}` | False
+|`REST_CACHE_CONTAINER` | `REST_CACHE_CONTAINER` | The cache container used by the REST connector (defaults to 'clustered') | clustered | True
+|`REST_CONTEXT_PATH` | `REST_CONTEXT_PATH` | The context path for the REST connector (defaults to '') | `${REST_CONTEXT_PATH}` | False
+|`REST_SECURITY_DOMAIN` | `REST_SECURITY_DOMAIN` | The domain, declared in the security subsystem, that should be used to authenticate access to the REST endpoint | `${REST_SECURITY_DOMAIN}` | False
+|`REST_AUTH_METHOD` | `REST_AUTH_METHOD` | The method used to retrieve credentials for the REST endpoint (defaults to 'BASIC') | `${REST_AUTH_METHOD}` | False
+|`REST_SECURITY_MODE` | `REST_SECURITY_MODE` | Whether authentication is required only for WRITE operations or for READ operations as well (defaults to 'READ_WRITE') | `${REST_SECURITY_MODE}` | False
+|`REST_EXTENDED_HEADERS` | `REST_EXTENDED_HEADERS` |  | `${REST_EXTENDED_HEADERS}` | False
+|`JDG_JGROUPS_ENCRYPT_SECRET` | `JDG_JGROUPS_ENCRYPT_SECRET` | The name of the secret containing the keystore file | `${JDG_JGROUPS_ENCRYPT_SECRET}` | False
+|`JDG_JGROUPS_ENCRYPT_KEYSTORE` | `JDG_JGROUPS_ENCRYPT_KEYSTORE` | The name of the keystore file within the secret | `${JDG_JGROUPS_ENCRYPT_KEYSTORE}` | False
+|`JDG_JGROUPS_ENCRYPT_NAME` | `JDG_JGROUPS_ENCRYPT_NAME` | The name associated with the server certificate | `${JDG_JGROUPS_ENCRYPT_NAME}` | False
+|`JDG_JGROUPS_ENCRYPT_PASSWORD` | `JDG_JGROUPS_ENCRYPT_PASSWORD` | The password for the keystore and certificate | `${JDG_JGROUPS_ENCRYPT_PASSWORD}` | False
+|`JGROUPS_CLUSTER_PASSWORD` | `JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}` | True
 |=======================================================================
 
 
@@ -87,10 +159,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-https` | TLS passthrough | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-memcached` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-hotrod` | none | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
+|`${APPLICATION_NAME}-https` | TLS passthrough | `${HOSTNAME_HTTPS}`
 |=============
 
 
@@ -172,7 +242,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.5+| `${APPLICATION_NAME}`
+.6+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |https | 8443 | `TCP`
 |ping | 8888 | `TCP`
@@ -187,7 +258,11 @@ information.
 |=======================================================================
 |Deployment |Variable name |Description |Example value
 
-.29+| `${APPLICATION_NAME}`
+.85+| `${APPLICATION_NAME}`
+|`JDG_SIMPLE_AUTHENTICATION` | Flag to enable/disable user authentication | `${JDG_SIMPLE_AUTHENTICATION}`
+|`JDG_USERNAME` | User name for JDG user. If left empty, it will be generated. | `${JDG_USERNAME}`
+|`JDG_PASSWORD` | Password for JDG user. If left empty, it will be generated. | `${JDG_PASSWORD}`
+|`JDG_SECDOMAIN_NAME` | Security domain name for user authentication | `${JDG_SECDOMAIN_NAME}`
 |`JDG_HTTPS_KEYSTORE_DIR` | The name of the keystore file within the secret | `/etc/datagrid-secret-volume`
 |`JDG_HTTPS_KEYSTORE` | The name of the keystore file within the secret | `${JDG_HTTPS_KEYSTORE}`
 |`JDG_HTTPS_NAME` | The name associated with the server certificate | `${JDG_HTTPS_NAME}`
@@ -217,6 +292,58 @@ information.
 |remotestorehotrodserver_REMOTE_DESTINATION_PORT | -- | `${REMOTE_HOTROD_DESTINATION_PORT}`
 |`OPENSHIFT_KUBE_PING_LABELS` | -- | `application=${APPLICATION_NAME}`
 |`OPENSHIFT_KUBE_PING_NAMESPACE` | -- | --
+|`INFINISPAN_CONNECTORS` | Comma-separated list of connector types that should be configured (defaults to 'memcached,hotrod,rest') | `${INFINISPAN_CONNECTORS}`
+|`HOTROD_CACHE_CONTAINER` | The cache container used by the Hot Rod connector (defaults to 'clustered') | `${HOTROD_CACHE_CONTAINER}`
+|`HOTROD_SOCKET_BINDING` | The socket binding port used by the Hot Rod connector (defaults to 'hotrod') | `${HOTROD_SOCKET_BINDING}`
+|`HOTROD_NAME` |  | `${HOTROD_NAME}`
+|`HOTROD_WORKER_THREADS` | The number of worker threads available for the Hot Rod connector (defaults to 160) | `${HOTROD_WORKER_THREADS}`
+|`HOTROD_IDLE_TIMEOUT` | The time (in milliseconds) the connector can remain idle before the connection times out (defaults to -1 - no timeout) | `${HOTROD_IDLE_TIMEOUT}`
+|`HOTROD_TCP_NODELAY` | Whether TCP packets will be delayed and sent out in batches (defaults to true) | `${HOTROD_TCP_NODELAY}`
+|`HOTROD_SEND_BUFFER_SIZE` | The size of the send buffer for the Hot Rod connector (defaults to size of the TCP stack buffer) | `${HOTROD_SEND_BUFFER_SIZE}`
+|`HOTROD_RECEIVE_BUFFER_SIZE` | The size of the receive buffer for the Hot Rod connector (defaults to size of the TCP stack buffer) | `${HOTROD_RECEIVE_BUFFER_SIZE}`
+|`TOPOLOGY_CACHE_SUFFIX` |  | `${TOPOLOGY_CACHE_SUFFIX}`
+|`TOPOLOGY_LOCK_TIMEOUT` | The time (in milliseconds) after which the operation attempting to obtain a lock times out (defaults to 10 seconds) | `${TOPOLOGY_LOCK_TIMEOUT}`
+|`TOPOLOGY_REPLICATION_TIMEOUT` | The time (in milliseconds) after which the replication operation times out (defaults to 10 seconds) | `${TOPOLOGY_REPLICATION_TIMEOUT}`
+|`TOPOLOGY_EXTERNAL_HOST` | The hostname sent by the Hot Rod server to clients listed in the topology information (defaults to the host address) | `${TOPOLOGY_EXTERNAL_HOST}`
+|`TOPOLOGY_EXTERNAL_PORT` | The port sent by the Hot Rod server to clients listed in the topology information (defaults to the configured port) | `${TOPOLOGY_EXTERNAL_PORT}`
+|`TOPOLOGY_LAZY_RETRIEVAL` | Whether the Hot Rod connector will carry out retrieval operations lazily (defaults to true) | `${TOPOLOGY_LAZY_RETRIEVAL}`
+|`TOPOLOGY_AWAIT_INITIAL_TRANSFER` | Whether the initial state retrieval happens immediately at startup; applies only when TOPOLOGY_LAZY_RETRIEVAL is set to false (defaults to true) | `${TOPOLOGY_AWAIT_INITIAL_TRANSFER}`
+|`AUTHENTICATION_SECURITY_REALM` |  | `${AUTHENTICATION_SECURITY_REALM}`
+|`SASL_SERVER_NAME` |  | `${SASL_SERVER_NAME}`
+|`SASL_SECURITY_CONTEXT_NAME` |  | `${SASL_SECURITY_CONTEXT_NAME}`
+|`SASL_MECHANISMS` |  | `${SASL_MECHANISMS}`
+|`SASL_QOP` |  | `${SASL_QOP}`
+|`SASL_STRENGTH` |  | `${SASL_STRENGTH}`
+|`SASL_POLICY_FORWARD_SECRECY` |  | `${SASL_POLICY_FORWARD_SECRECY}`
+|`SASL_POLICY_NO_ACTIVE` |  | `${SASL_POLICY_NO_ACTIVE}`
+|`SASL_POLICY_NO_ANONYMOUS` |  | `${SASL_POLICY_NO_ANONYMOUS}`
+|`SASL_POLICY_NO_DICTIONARY` |  | `${SASL_POLICY_NO_DICTIONARY}`
+|`SASL_POLICY_NO_PLAIN_TEXT` |  | `${SASL_POLICY_NO_PLAIN_TEXT}`
+|`SASL_POLICY_PASS_CREDENTIALS` |  | `${SASL_POLICY_PASS_CREDENTIALS}`
+|`SASL_PROPERTIES` |  | `${SASL_PROPERTIES}`
+|`ENCRYPTION_SECURITY_REALM` |  | `${ENCRYPTION_SECURITY_REALM}`
+|`ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH` |  | `${ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH}`
+|`MEMCACHED_CACHE_CONTAINER` | The cache container used by the memcached connector (defaults to 'clustered') | `${MEMCACHED_CACHE_CONTAINER}`
+|`MEMCACHED_CACHE` | The cache container used by the memcached connector (defaults to 'clustered') | `${MEMCACHED_CACHE}`
+|`MEMCACHED_SOCKET_BINDING` | The socked binding port used by the memcached connector (defaults to 'memcached') | `${MEMCACHED_SOCKET_BINDING}`
+|`MEMCACHED_NAME` | The name of this memcached connector (defaults to 'memcached') | `${MEMCACHED_NAME}`
+|`MEMCACHED_WORKER_THREADS` | The number of worker threads available for the memcached connector (defaults to 160) | `${MEMCACHED_WORKER_THREADS}`
+|`MEMCACHED_IDLE_TIMEOUT` | The time (in milliseconds) the connector can remain idle before the connection times out (defaults to -1 - no timeout) | `${MEMCACHED_IDLE_TIMEOUT}`
+|`MEMCACHED_TCP_NODELAY` | Whether TCP packets will be delayed and sent out in batches (defaults to true) | `${MEMCACHED_TCP_NODELAY}`
+|`MEMCACHED_SEND_BUFFER_SIZE` | The size of the send buffer for the memcached connector (defaults to the size of the TCP stack buffer) | `${MEMCACHED_SEND_BUFFER_SIZE}`
+|`MEMCACHED_RECEIVE_BUFFER_SIZE` | The size of the receive buffer for the memcached connector (defaults to the size of the TCP stack buffer) | `${MEMCACHED_RECEIVE_BUFFER_SIZE}`
+|`REST_VIRTUAL_SERVER` | The virtual server used by the REST connector (defaults to 'default-host') | `${REST_VIRTUAL_SERVER}`
+|`REST_CACHE_CONTAINER` | The cache container used by the REST connector (defaults to 'clustered') | `${REST_CACHE_CONTAINER}`
+|`REST_CONTEXT_PATH` | The context path for the REST connector (defaults to '') | `${REST_CONTEXT_PATH}`
+|`REST_SECURITY_DOMAIN` | The domain, declared in the security subsystem, that should be used to authenticate access to the REST endpoint | `${REST_SECURITY_DOMAIN}`
+|`REST_AUTH_METHOD` | The method used to retrieve credentials for the REST endpoint (defaults to 'BASIC') | `${REST_AUTH_METHOD}`
+|`REST_SECURITY_MODE` | Whether authentication is required only for WRITE operations or for READ operations as well (defaults to 'READ_WRITE') | `${REST_SECURITY_MODE}`
+|`REST_EXTENDED_HEADERS` |  | `${REST_EXTENDED_HEADERS}`
+|`JDG_JGROUPS_ENCRYPT_SECRET` | The name of the secret containing the keystore file | `${JDG_JGROUPS_ENCRYPT_SECRET}`
+|`JDG_JGROUPS_ENCRYPT_KEYSTORE` | The name of the keystore file within the secret | `${JDG_JGROUPS_ENCRYPT_KEYSTORE}`
+|`JDG_JGROUPS_ENCRYPT_NAME` | The name associated with the server certificate | `${JDG_JGROUPS_ENCRYPT_NAME}`
+|`JDG_JGROUPS_ENCRYPT_PASSWORD` | The password for the keystore and certificate | `${JDG_JGROUPS_ENCRYPT_PASSWORD}`
+|`JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}`
 |=======================================================================
 
 

--- a/docs/decisionserver/decisionserver62-basic-s2i.adoc
+++ b/docs/decisionserver/decisionserver62-basic-s2i.adoc
@@ -23,11 +23,11 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |=======================================================================
 |Variable name |Image Environment Variable |Description |Example value |Required
 
-|`KIE_CONTAINER_DEPLOYMENT` | `KIE_CONTAINER_DEPLOYMENT` | The KIE Container deployment configuration in format: containerId=groupId:artifactId:version|c2=g2:a2:v2 | `${KIE_CONTAINER_DEPLOYMENT}` | True
-|`KIE_SERVER_USER` | `KIE_SERVER_USER` | The user name to access the KIE Server REST interface. | kieserver | False
-|`KIE_SERVER_PASSWORD` | `KIE_SERVER_PASSWORD` | The password to access the KIE Server REST interface. | `${KIE_SERVER_PASSWORD}` | False
+|`KIE_CONTAINER_DEPLOYMENT` | `KIE_CONTAINER_DEPLOYMENT` | The KIE Container deployment configuration in format: containerId=groupId:artifactId:version|c2=g2:a2:v2 | HelloRulesContainer=org.openshift.quickstarts:decisionserver-hellorules:1.0.0-SNAPSHOT | False
+|`KIE_SERVER_USER` | `KIE_SERVER_USER` | The user name to access the KIE Server REST or JMS interface. | kieserver | False
+|`KIE_SERVER_PASSWORD` | `KIE_SERVER_PASSWORD` | The password to access the KIE Server REST or JMS interface. Must be different than username; must not be root, admin, or administrator; must contain at least 8 characters, 1 alphabetic character(s), 1 digit(s), and 1 non-alphanumeric symbol(s). | `${KIE_SERVER_PASSWORD}` | False
 |`APPLICATION_NAME` | -- | The name for the application. | kie-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
 |`SOURCE_REPOSITORY_URL` | -- | Git source URI for application | https://github.com/jboss-openshift/openshift-quickstarts.git | True
 |`SOURCE_REPOSITORY_REF` | -- | Git branch/tag reference | master | False
 |`CONTEXT_DIR` | -- | Path within Git project to build; empty for root project directory. | decisionserver/hellorules | False
@@ -70,7 +70,7 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
 |=============
 
 
@@ -164,7 +164,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.2+| `${APPLICATION_NAME}`
+.3+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |ping | 8888 | `TCP`
 |=============
@@ -178,8 +179,8 @@ information.
 
 .6+| `${APPLICATION_NAME}`
 |`KIE_CONTAINER_DEPLOYMENT` | The KIE Container deployment configuration in format: containerId=groupId:artifactId:version|c2=g2:a2:v2 | `${KIE_CONTAINER_DEPLOYMENT}`
-|`KIE_SERVER_USER` | The user name to access the KIE Server REST interface. | `${KIE_SERVER_USER}`
-|`KIE_SERVER_PASSWORD` | The password to access the KIE Server REST interface. | `${KIE_SERVER_PASSWORD}`
+|`KIE_SERVER_USER` | The user name to access the KIE Server REST or JMS interface. | `${KIE_SERVER_USER}`
+|`KIE_SERVER_PASSWORD` | The password to access the KIE Server REST or JMS interface. Must be different than username; must not be root, admin, or administrator; must contain at least 8 characters, 1 alphabetic character(s), 1 digit(s), and 1 non-alphanumeric symbol(s). | `${KIE_SERVER_PASSWORD}`
 |`HORNETQ_CLUSTER_PASSWORD` | HornetQ cluster admin password | `${HORNETQ_CLUSTER_PASSWORD}`
 |`HORNETQ_QUEUES` | Queue names | `${HORNETQ_QUEUES}`
 |`HORNETQ_TOPICS` | Topic names | `${HORNETQ_TOPICS}`

--- a/docs/decisionserver/decisionserver62-https-s2i.adoc
+++ b/docs/decisionserver/decisionserver62-https-s2i.adoc
@@ -9,7 +9,7 @@
 :toc-placement!:
 :toclevels: 5
 
-Application template for BRMS Realtime Decision Server 6 applications built using S2I.
+Application template for BRMS Realtime Decision Server 6 HTTPS applications built using S2I.
 
 toc::[]
 
@@ -23,13 +23,14 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |=======================================================================
 |Variable name |Image Environment Variable |Description |Example value |Required
 
-|`KIE_CONTAINER_DEPLOYMENT` | `KIE_CONTAINER_DEPLOYMENT` | The KIE Container deployment configuration in format: containerId=groupId:artifactId:version|c2=g2:a2:v2 | `${KIE_CONTAINER_DEPLOYMENT}` | True
+|`KIE_CONTAINER_DEPLOYMENT` | `KIE_CONTAINER_DEPLOYMENT` | The KIE Container deployment configuration in format: containerId=groupId:artifactId:version|c2=g2:a2:v2 | HelloRulesContainer=org.openshift.quickstarts:decisionserver-hellorules:1.0.0-SNAPSHOT | False
 |`KIE_SERVER_PROTOCOL` | `KIE_SERVER_PROTOCOL` | The protocol to access the KIE Server REST interface. | https | False
 |`KIE_SERVER_PORT` | `KIE_SERVER_PORT` | The port to access the KIE Server REST interface. | 8443 | False
-|`KIE_SERVER_USER` | `KIE_SERVER_USER` | The user name to access the KIE Server REST interface. | kieserver | False
-|`KIE_SERVER_PASSWORD` | `KIE_SERVER_PASSWORD` | The password to access the KIE Server REST interface. | `${KIE_SERVER_PASSWORD}` | False
+|`KIE_SERVER_USER` | `KIE_SERVER_USER` | The user name to access the KIE Server REST or JMS interface. | kieserver | False
+|`KIE_SERVER_PASSWORD` | `KIE_SERVER_PASSWORD` | The password to access the KIE Server REST or JMS interface. Must be different than username; must not be root, admin, or administrator; must contain at least 8 characters, 1 alphabetic character(s), 1 digit(s), and 1 non-alphanumeric symbol(s). | `${KIE_SERVER_PASSWORD}` | False
 |`APPLICATION_NAME` | -- | The name for the application. | kie-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
+|`HOSTNAME_HTTPS` | -- | Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-<project>.<default-domain-suffix> | -- | False
 |`SOURCE_REPOSITORY_URL` | -- | Git source URI for application | https://github.com/jboss-openshift/openshift-quickstarts.git | True
 |`SOURCE_REPOSITORY_REF` | -- | Git branch/tag reference | master | False
 |`CONTEXT_DIR` | -- | Path within Git project to build; empty for root project directory. | decisionserver/hellorules | False
@@ -37,8 +38,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`HORNETQ_TOPICS` | `HORNETQ_TOPICS` | Topic names | `${HORNETQ_TOPICS}` | False
 |`EAP_HTTPS_SECRET` | -- | The name of the secret containing the keystore file | eap-app-secret | True
 |`EAP_HTTPS_KEYSTORE` | `EAP_HTTPS_KEYSTORE_DIR` | The name of the keystore file within the secret | keystore.jks | False
-|`EAP_HTTPS_NAME` | `EAP_HTTPS_NAME` | The name associated with the server certificate | `${EAP_HTTPS_NAME}` | False
-|`EAP_HTTPS_PASSWORD` | `EAP_HTTPS_PASSWORD` | The password for the keystore and certificate | `${EAP_HTTPS_PASSWORD}` | False
+|`EAP_HTTPS_NAME` | `EAP_HTTPS_NAME` | The name associated with the server certificate | jboss | False
+|`EAP_HTTPS_PASSWORD` | `EAP_HTTPS_PASSWORD` | The password for the keystore and certificate | mykeystorepass | False
 |`HORNETQ_CLUSTER_PASSWORD` | `HORNETQ_CLUSTER_PASSWORD` | HornetQ cluster admin password | `${HORNETQ_CLUSTER_PASSWORD}` | True
 |`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
 |`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
@@ -77,8 +78,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-https` | TLS passthrough | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
+|`${APPLICATION_NAME}-https` | TLS passthrough | `${HOSTNAME_HTTPS}`
 |=============
 
 
@@ -173,7 +174,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.3+| `${APPLICATION_NAME}`
+.4+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |https | 8443 | `TCP`
 |ping | 8888 | `TCP`
@@ -190,8 +192,8 @@ information.
 |`KIE_CONTAINER_DEPLOYMENT` | The KIE Container deployment configuration in format: containerId=groupId:artifactId:version|c2=g2:a2:v2 | `${KIE_CONTAINER_DEPLOYMENT}`
 |`KIE_SERVER_PROTOCOL` | The protocol to access the KIE Server REST interface. | `${KIE_SERVER_PROTOCOL}`
 |`KIE_SERVER_PORT` | The port to access the KIE Server REST interface. | `${KIE_SERVER_PORT}`
-|`KIE_SERVER_USER` | The user name to access the KIE Server REST interface. | `${KIE_SERVER_USER}`
-|`KIE_SERVER_PASSWORD` | The password to access the KIE Server REST interface. | `${KIE_SERVER_PASSWORD}`
+|`KIE_SERVER_USER` | The user name to access the KIE Server REST or JMS interface. | `${KIE_SERVER_USER}`
+|`KIE_SERVER_PASSWORD` | The password to access the KIE Server REST or JMS interface. Must be different than username; must not be root, admin, or administrator; must contain at least 8 characters, 1 alphabetic character(s), 1 digit(s), and 1 non-alphanumeric symbol(s). | `${KIE_SERVER_PASSWORD}`
 |`EAP_HTTPS_KEYSTORE_DIR` | The name of the keystore file within the secret | `/etc/eap-secret-volume`
 |`EAP_HTTPS_KEYSTORE` | The name of the keystore file within the secret | `${EAP_HTTPS_KEYSTORE}`
 |`EAP_HTTPS_NAME` | The name associated with the server certificate | `${EAP_HTTPS_NAME}`

--- a/docs/eap/eap64-amq-persistent-s2i.adoc
+++ b/docs/eap/eap64-amq-persistent-s2i.adoc
@@ -24,9 +24,10 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |Variable name |Image Environment Variable |Description |Example value |Required
 
 |`APPLICATION_NAME` | -- | The name for the application. | eap-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
-|`SOURCE_REPOSITORY_URL` | -- | Git source URI for application | https://github.com/jboss-openshift/openshift-quickstarts.git | True
-|`SOURCE_REPOSITORY_REF` | -- | Git branch/tag reference | 1.1 | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
+|`HOSTNAME_HTTPS` | -- | Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-<project>.<default-domain-suffix> | -- | False
+|`SOURCE_REPOSITORY_URL` | -- | Git source URI for application | https://github.com/jboss-developer/jboss-eap-quickstarts.git | True
+|`SOURCE_REPOSITORY_REF` | -- | Git branch/tag reference | 6.4.x | False
 |`CONTEXT_DIR` | -- | Path within Git project to build; empty for root project directory. | helloworld-mdb | False
 |`VOLUME_CAPACITY` | -- | Size of persistent storage for database volume. | 512Mi | True
 |`MQ_JNDI` | `MQ_JNDI` | JNDI name for connection factory used by applications to connect to the broker, e.g. java:/ConnectionFactory | java:/ConnectionFactory | False
@@ -44,6 +45,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
 |`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
+|`JGROUPS_CLUSTER_PASSWORD` | `JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}` | True
 |=======================================================================
 
 
@@ -79,8 +81,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-https` | TLS passthrough | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
+|`${APPLICATION_NAME}-https` | TLS passthrough | `${HOSTNAME_HTTPS}`
 |=============
 
 
@@ -183,7 +185,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.3+| `${APPLICATION_NAME}`
+.4+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |https | 8443 | `TCP`
 |ping | 8888 | `TCP`
@@ -204,7 +207,7 @@ information.
 |=======================================================================
 |Deployment |Variable name |Description |Example value
 
-.13+| `${APPLICATION_NAME}`
+.14+| `${APPLICATION_NAME}`
 |`MQ_SERVICE_PREFIX_MAPPING` | -- | `${APPLICATION_NAME}-amq=MQ`
 |`MQ_JNDI` | JNDI name for connection factory used by applications to connect to the broker, e.g. java:/ConnectionFactory | `${MQ_JNDI}`
 |`MQ_USERNAME` | User name for standard broker user. It is required for connecting to the broker. If left empty, it will be generated. | `${MQ_USERNAME}`
@@ -218,6 +221,7 @@ information.
 |`EAP_HTTPS_KEYSTORE` | The name of the keystore file within the secret | `${EAP_HTTPS_KEYSTORE}`
 |`EAP_HTTPS_NAME` | The name associated with the server certificate | `${EAP_HTTPS_NAME}`
 |`EAP_HTTPS_PASSWORD` | The password for the keystore and certificate | `${EAP_HTTPS_PASSWORD}`
+|`JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}`
 .7+| `${APPLICATION_NAME}-amq`
 |`AMQ_USER` | User name for standard broker user. It is required for connecting to the broker. If left empty, it will be generated. | `${MQ_USERNAME}`
 |`AMQ_PASSWORD` | Password for standard broker user. It is required for connecting to the broker. If left empty, it will be generated. | `${MQ_PASSWORD}`

--- a/docs/eap/eap64-amq-s2i.adoc
+++ b/docs/eap/eap64-amq-s2i.adoc
@@ -24,9 +24,10 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |Variable name |Image Environment Variable |Description |Example value |Required
 
 |`APPLICATION_NAME` | -- | The name for the application. | eap-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
-|`SOURCE_REPOSITORY_URL` | -- | Git source URI for application | https://github.com/jboss-openshift/openshift-quickstarts.git | True
-|`SOURCE_REPOSITORY_REF` | -- | Git branch/tag reference | 1.1 | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
+|`HOSTNAME_HTTPS` | -- | Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-<project>.<default-domain-suffix> | -- | False
+|`SOURCE_REPOSITORY_URL` | -- | Git source URI for application | https://github.com/jboss-developer/jboss-eap-quickstarts.git | True
+|`SOURCE_REPOSITORY_REF` | -- | Git branch/tag reference | 6.4.x | False
 |`CONTEXT_DIR` | -- | Path within Git project to build; empty for root project directory. | helloworld-mdb | False
 |`MQ_JNDI` | `MQ_JNDI` | JNDI name for connection factory used by applications to connect to the broker, e.g. java:/ConnectionFactory | java:/ConnectionFactory | False
 |`MQ_PROTOCOL` | `MQ_PROTOCOL` | Broker protocols to configure, separated by commas. Allowed values are: `openwire`, `amqp`, `stomp` and `mqtt`. Only `openwire` is supported by EAP. | openwire | False
@@ -43,6 +44,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
 |`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
+|`JGROUPS_CLUSTER_PASSWORD` | `JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}` | True
 |=======================================================================
 
 
@@ -78,8 +80,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-https` | TLS passthrough | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
+|`${APPLICATION_NAME}-https` | TLS passthrough | `${HOSTNAME_HTTPS}`
 |=============
 
 
@@ -182,7 +184,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.3+| `${APPLICATION_NAME}`
+.4+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |https | 8443 | `TCP`
 |ping | 8888 | `TCP`
@@ -203,7 +206,7 @@ information.
 |=======================================================================
 |Deployment |Variable name |Description |Example value
 
-.13+| `${APPLICATION_NAME}`
+.14+| `${APPLICATION_NAME}`
 |`MQ_SERVICE_PREFIX_MAPPING` | -- | `${APPLICATION_NAME}-amq=MQ`
 |`MQ_JNDI` | JNDI name for connection factory used by applications to connect to the broker, e.g. java:/ConnectionFactory | `${MQ_JNDI}`
 |`MQ_USERNAME` | User name for standard broker user. It is required for connecting to the broker. If left empty, it will be generated. | `${MQ_USERNAME}`
@@ -217,6 +220,7 @@ information.
 |`EAP_HTTPS_KEYSTORE` | The name of the keystore file within the secret | `${EAP_HTTPS_KEYSTORE}`
 |`EAP_HTTPS_NAME` | The name associated with the server certificate | `${EAP_HTTPS_NAME}`
 |`EAP_HTTPS_PASSWORD` | The password for the keystore and certificate | `${EAP_HTTPS_PASSWORD}`
+|`JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}`
 .7+| `${APPLICATION_NAME}-amq`
 |`AMQ_USER` | User name for standard broker user. It is required for connecting to the broker. If left empty, it will be generated. | `${MQ_USERNAME}`
 |`AMQ_PASSWORD` | Password for standard broker user. It is required for connecting to the broker. If left empty, it will be generated. | `${MQ_PASSWORD}`

--- a/docs/eap/eap64-basic-s2i.adoc
+++ b/docs/eap/eap64-basic-s2i.adoc
@@ -24,7 +24,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |Variable name |Image Environment Variable |Description |Example value |Required
 
 |`APPLICATION_NAME` | -- | The name for the application. | eap-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
 |`SOURCE_REPOSITORY_URL` | -- | Git source URI for application | https://github.com/jboss-developer/jboss-eap-quickstarts | True
 |`SOURCE_REPOSITORY_REF` | -- | Git branch/tag reference | 6.4.x | False
 |`CONTEXT_DIR` | -- | Path within Git project to build; empty for root project directory. | kitchensink | False
@@ -34,6 +34,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
 |`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
+|`JGROUPS_CLUSTER_PASSWORD` | `JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}` | True
 |=======================================================================
 
 
@@ -67,7 +68,7 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
 |=============
 
 
@@ -161,7 +162,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.2+| `${APPLICATION_NAME}`
+.3+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |ping | 8888 | `TCP`
 |=============
@@ -173,12 +175,13 @@ information.
 |=======================================================================
 |Deployment |Variable name |Description |Example value
 
-.5+| `${APPLICATION_NAME}`
+.6+| `${APPLICATION_NAME}`
 |`OPENSHIFT_KUBE_PING_LABELS` | -- | `application=${APPLICATION_NAME}`
 |`OPENSHIFT_KUBE_PING_NAMESPACE` | -- | --
 |`HORNETQ_CLUSTER_PASSWORD` | HornetQ cluster admin password | `${HORNETQ_CLUSTER_PASSWORD}`
 |`HORNETQ_QUEUES` | Queue names | `${HORNETQ_QUEUES}`
 |`HORNETQ_TOPICS` | Topic names | `${HORNETQ_TOPICS}`
+|`JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}`
 |=======================================================================
 
 

--- a/docs/eap/eap64-https-s2i.adoc
+++ b/docs/eap/eap64-https-s2i.adoc
@@ -24,7 +24,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |Variable name |Image Environment Variable |Description |Example value |Required
 
 |`APPLICATION_NAME` | -- | The name for the application. | eap-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
+|`HOSTNAME_HTTPS` | -- | Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-<project>.<default-domain-suffix> | -- | False
 |`SOURCE_REPOSITORY_URL` | -- | Git source URI for application | https://github.com/jboss-developer/jboss-eap-quickstarts | True
 |`SOURCE_REPOSITORY_REF` | -- | Git branch/tag reference | 6.4.x | False
 |`CONTEXT_DIR` | -- | Path within Git project to build; empty for root project directory. | kitchensink | False
@@ -38,6 +39,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
 |`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
+|`JGROUPS_CLUSTER_PASSWORD` | `JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}` | True
 |=======================================================================
 
 
@@ -72,8 +74,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-https` | TLS passthrough | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
+|`${APPLICATION_NAME}-https` | TLS passthrough | `${HOSTNAME_HTTPS}`
 |=============
 
 
@@ -168,7 +170,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.3+| `${APPLICATION_NAME}`
+.4+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |https | 8443 | `TCP`
 |ping | 8888 | `TCP`
@@ -181,7 +184,7 @@ information.
 |=======================================================================
 |Deployment |Variable name |Description |Example value
 
-.9+| `${APPLICATION_NAME}`
+.10+| `${APPLICATION_NAME}`
 |`OPENSHIFT_KUBE_PING_LABELS` | -- | `application=${APPLICATION_NAME}`
 |`OPENSHIFT_KUBE_PING_NAMESPACE` | -- | --
 |`EAP_HTTPS_KEYSTORE_DIR` | The name of the keystore file within the secret | `/etc/eap-secret-volume`
@@ -191,6 +194,7 @@ information.
 |`HORNETQ_CLUSTER_PASSWORD` | HornetQ cluster admin password | `${HORNETQ_CLUSTER_PASSWORD}`
 |`HORNETQ_QUEUES` | Queue names | `${HORNETQ_QUEUES}`
 |`HORNETQ_TOPICS` | Topic names | `${HORNETQ_TOPICS}`
+|`JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}`
 |=======================================================================
 
 

--- a/docs/eap/eap64-mongodb-persistent-s2i.adoc
+++ b/docs/eap/eap64-mongodb-persistent-s2i.adoc
@@ -24,7 +24,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |Variable name |Image Environment Variable |Description |Example value |Required
 
 |`APPLICATION_NAME` | -- | The name for the application. | eap-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
+|`HOSTNAME_HTTPS` | -- | Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-<project>.<default-domain-suffix> | -- | False
 |`SOURCE_REPOSITORY_URL` | -- | Git source URI for application | https://github.com/jboss-openshift/openshift-quickstarts | True
 |`SOURCE_REPOSITORY_REF` | -- | Git branch/tag reference | 1.1 | False
 |`CONTEXT_DIR` | -- | Path within Git project to build; empty for root project directory. | todolist/todolist-mongodb | False
@@ -50,6 +51,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
 |`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
+|`JGROUPS_CLUSTER_PASSWORD` | `JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}` | True
 |=======================================================================
 
 
@@ -85,8 +87,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-https` | TLS passthrough | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
+|`${APPLICATION_NAME}-https` | TLS passthrough | `${HOSTNAME_HTTPS}`
 |=============
 
 
@@ -184,7 +186,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.3+| `${APPLICATION_NAME}`
+.4+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |https | 8443 | `TCP`
 |ping | 8888 | `TCP`
@@ -199,7 +202,7 @@ information.
 |=======================================================================
 |Deployment |Variable name |Description |Example value
 
-.18+| `${APPLICATION_NAME}`
+.19+| `${APPLICATION_NAME}`
 |`DB_SERVICE_PREFIX_MAPPING` | -- | `${APPLICATION_NAME}-mongodb=DB`
 |`DB_JNDI` | Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb | `${DB_JNDI}`
 |`DB_USERNAME` | Database user name | `${DB_USERNAME}`
@@ -218,6 +221,7 @@ information.
 |`HORNETQ_CLUSTER_PASSWORD` | HornetQ cluster admin password | `${HORNETQ_CLUSTER_PASSWORD}`
 |`HORNETQ_QUEUES` | Queue names | `${HORNETQ_QUEUES}`
 |`HORNETQ_TOPICS` | Topic names | `${HORNETQ_TOPICS}`
+|`JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}`
 .7+| `${APPLICATION_NAME}-mongodb`
 |`MONGODB_USER` | -- | `${DB_USERNAME}`
 |`MONGODB_PASSWORD` | Database user password | `${DB_PASSWORD}`

--- a/docs/eap/eap64-mongodb-s2i.adoc
+++ b/docs/eap/eap64-mongodb-s2i.adoc
@@ -24,7 +24,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |Variable name |Image Environment Variable |Description |Example value |Required
 
 |`APPLICATION_NAME` | -- | The name for the application. | eap-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
+|`HOSTNAME_HTTPS` | -- | Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-<project>.<default-domain-suffix> | -- | False
 |`SOURCE_REPOSITORY_URL` | -- | Git source URI for application | https://github.com/jboss-openshift/openshift-quickstarts | True
 |`SOURCE_REPOSITORY_REF` | -- | Git branch/tag reference | 1.1 | False
 |`CONTEXT_DIR` | -- | Path within Git project to build; empty for root project directory. | todolist/todolist-mongodb | False
@@ -49,6 +50,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
 |`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
+|`JGROUPS_CLUSTER_PASSWORD` | `JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}` | True
 |=======================================================================
 
 
@@ -84,8 +86,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-https` | TLS passthrough | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
+|`${APPLICATION_NAME}-https` | TLS passthrough | `${HOSTNAME_HTTPS}`
 |=============
 
 
@@ -183,7 +185,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.3+| `${APPLICATION_NAME}`
+.4+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |https | 8443 | `TCP`
 |ping | 8888 | `TCP`
@@ -198,7 +201,7 @@ information.
 |=======================================================================
 |Deployment |Variable name |Description |Example value
 
-.18+| `${APPLICATION_NAME}`
+.19+| `${APPLICATION_NAME}`
 |`DB_SERVICE_PREFIX_MAPPING` | -- | `${APPLICATION_NAME}-mongodb=DB`
 |`DB_JNDI` | Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb | `${DB_JNDI}`
 |`DB_USERNAME` | Database user name | `${DB_USERNAME}`
@@ -217,6 +220,7 @@ information.
 |`HORNETQ_CLUSTER_PASSWORD` | HornetQ cluster admin password | `${HORNETQ_CLUSTER_PASSWORD}`
 |`HORNETQ_QUEUES` | Queue names | `${HORNETQ_QUEUES}`
 |`HORNETQ_TOPICS` | Topic names | `${HORNETQ_TOPICS}`
+|`JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}`
 .7+| `${APPLICATION_NAME}-mongodb`
 |`MONGODB_USER` | -- | `${DB_USERNAME}`
 |`MONGODB_PASSWORD` | Database user password | `${DB_PASSWORD}`

--- a/docs/eap/eap64-mysql-persistent-s2i.adoc
+++ b/docs/eap/eap64-mysql-persistent-s2i.adoc
@@ -24,7 +24,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |Variable name |Image Environment Variable |Description |Example value |Required
 
 |`APPLICATION_NAME` | -- | The name for the application. | eap-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
+|`HOSTNAME_HTTPS` | -- | Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-<project>.<default-domain-suffix> | -- | False
 |`SOURCE_REPOSITORY_URL` | -- | Git source URI for application | https://github.com/jboss-openshift/openshift-quickstarts | True
 |`SOURCE_REPOSITORY_REF` | -- | Git branch/tag reference | 1.1 | False
 |`CONTEXT_DIR` | -- | Path within Git project to build; empty for root project directory. | todolist/todolist-jdbc | False
@@ -51,6 +52,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
 |`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
+|`JGROUPS_CLUSTER_PASSWORD` | `JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}` | True
 |=======================================================================
 
 
@@ -86,8 +88,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-https` | TLS passthrough | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
+|`${APPLICATION_NAME}-https` | TLS passthrough | `${HOSTNAME_HTTPS}`
 |=============
 
 
@@ -185,7 +187,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.3+| `${APPLICATION_NAME}`
+.4+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |https | 8443 | `TCP`
 |ping | 8888 | `TCP`
@@ -200,7 +203,7 @@ information.
 |=======================================================================
 |Deployment |Variable name |Description |Example value
 
-.18+| `${APPLICATION_NAME}`
+.19+| `${APPLICATION_NAME}`
 |`DB_SERVICE_PREFIX_MAPPING` | -- | `${APPLICATION_NAME}-mysql=DB`
 |`DB_JNDI` | Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mysql | `${DB_JNDI}`
 |`DB_USERNAME` | Database user name | `${DB_USERNAME}`
@@ -219,6 +222,7 @@ information.
 |`HORNETQ_CLUSTER_PASSWORD` | HornetQ cluster admin password | `${HORNETQ_CLUSTER_PASSWORD}`
 |`HORNETQ_QUEUES` | Queue names | `${HORNETQ_QUEUES}`
 |`HORNETQ_TOPICS` | Topic names | `${HORNETQ_TOPICS}`
+|`JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}`
 .8+| `${APPLICATION_NAME}-mysql`
 |`MYSQL_USER` | -- | `${DB_USERNAME}`
 |`MYSQL_PASSWORD` | -- | `${DB_PASSWORD}`

--- a/docs/eap/eap64-mysql-s2i.adoc
+++ b/docs/eap/eap64-mysql-s2i.adoc
@@ -24,7 +24,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |Variable name |Image Environment Variable |Description |Example value |Required
 
 |`APPLICATION_NAME` | -- | The name for the application. | eap-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
+|`HOSTNAME_HTTPS` | -- | Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-<project>.<default-domain-suffix> | -- | False
 |`SOURCE_REPOSITORY_URL` | -- | Git source URI for application | https://github.com/jboss-openshift/openshift-quickstarts | True
 |`SOURCE_REPOSITORY_REF` | -- | Git branch/tag reference | 1.1 | False
 |`CONTEXT_DIR` | -- | Path within Git project to build; empty for root project directory. | todolist/todolist-jdbc | False
@@ -50,6 +51,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
 |`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
+|`JGROUPS_CLUSTER_PASSWORD` | `JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}` | True
 |=======================================================================
 
 
@@ -85,8 +87,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-https` | TLS passthrough | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
+|`${APPLICATION_NAME}-https` | TLS passthrough | `${HOSTNAME_HTTPS}`
 |=============
 
 
@@ -184,7 +186,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.3+| `${APPLICATION_NAME}`
+.4+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |https | 8443 | `TCP`
 |ping | 8888 | `TCP`
@@ -199,7 +202,7 @@ information.
 |=======================================================================
 |Deployment |Variable name |Description |Example value
 
-.18+| `${APPLICATION_NAME}`
+.19+| `${APPLICATION_NAME}`
 |`DB_SERVICE_PREFIX_MAPPING` | -- | `${APPLICATION_NAME}-mysql=DB`
 |`DB_JNDI` | Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mysql | `${DB_JNDI}`
 |`DB_USERNAME` | Database user name | `${DB_USERNAME}`
@@ -218,6 +221,7 @@ information.
 |`HORNETQ_CLUSTER_PASSWORD` | HornetQ cluster admin password | `${HORNETQ_CLUSTER_PASSWORD}`
 |`HORNETQ_QUEUES` | Queue names | `${HORNETQ_QUEUES}`
 |`HORNETQ_TOPICS` | Topic names | `${HORNETQ_TOPICS}`
+|`JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}`
 .8+| `${APPLICATION_NAME}-mysql`
 |`MYSQL_USER` | -- | `${DB_USERNAME}`
 |`MYSQL_PASSWORD` | -- | `${DB_PASSWORD}`

--- a/docs/eap/eap64-postgresql-persistent-s2i.adoc
+++ b/docs/eap/eap64-postgresql-persistent-s2i.adoc
@@ -24,7 +24,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |Variable name |Image Environment Variable |Description |Example value |Required
 
 |`APPLICATION_NAME` | -- | The name for the application. | eap-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
+|`HOSTNAME_HTTPS` | -- | Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-<project>.<default-domain-suffix> | -- | False
 |`SOURCE_REPOSITORY_URL` | -- | Git source URI for application | https://github.com/jboss-openshift/openshift-quickstarts | True
 |`SOURCE_REPOSITORY_REF` | -- | Git branch/tag reference | 1.1 | False
 |`CONTEXT_DIR` | -- | Path within Git project to build; empty for root project directory. | todolist/todolist-jdbc | False
@@ -48,6 +49,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
 |`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
+|`JGROUPS_CLUSTER_PASSWORD` | `JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}` | True
 |=======================================================================
 
 
@@ -83,8 +85,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-https` | TLS passthrough | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
+|`${APPLICATION_NAME}-https` | TLS passthrough | `${HOSTNAME_HTTPS}`
 |=============
 
 
@@ -182,7 +184,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.3+| `${APPLICATION_NAME}`
+.4+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |https | 8443 | `TCP`
 |ping | 8888 | `TCP`
@@ -197,7 +200,7 @@ information.
 |=======================================================================
 |Deployment |Variable name |Description |Example value
 
-.18+| `${APPLICATION_NAME}`
+.19+| `${APPLICATION_NAME}`
 |`DB_SERVICE_PREFIX_MAPPING` | -- | `${APPLICATION_NAME}-postgresql=DB`
 |`DB_JNDI` | Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/postgresql | `${DB_JNDI}`
 |`DB_USERNAME` | Database user name | `${DB_USERNAME}`
@@ -216,6 +219,7 @@ information.
 |`HORNETQ_CLUSTER_PASSWORD` | HornetQ cluster admin password | `${HORNETQ_CLUSTER_PASSWORD}`
 |`HORNETQ_QUEUES` | Queue names | `${HORNETQ_QUEUES}`
 |`HORNETQ_TOPICS` | Topic names | `${HORNETQ_TOPICS}`
+|`JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}`
 .5+| `${APPLICATION_NAME}-postgresql`
 |`POSTGRESQL_USER` | -- | `${DB_USERNAME}`
 |`POSTGRESQL_PASSWORD` | -- | `${DB_PASSWORD}`

--- a/docs/eap/eap64-postgresql-s2i.adoc
+++ b/docs/eap/eap64-postgresql-s2i.adoc
@@ -24,7 +24,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |Variable name |Image Environment Variable |Description |Example value |Required
 
 |`APPLICATION_NAME` | -- | The name for the application. | eap-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
+|`HOSTNAME_HTTPS` | -- | Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-<project>.<default-domain-suffix> | -- | False
 |`SOURCE_REPOSITORY_URL` | -- | Git source URI for application | https://github.com/jboss-openshift/openshift-quickstarts | True
 |`SOURCE_REPOSITORY_REF` | -- | Git branch/tag reference | 1.1 | False
 |`CONTEXT_DIR` | -- | Path within Git project to build; empty for root project directory. | todolist/todolist-jdbc | False
@@ -47,6 +48,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
 |`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
+|`JGROUPS_CLUSTER_PASSWORD` | `JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}` | True
 |=======================================================================
 
 
@@ -82,8 +84,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-https` | TLS passthrough | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
+|`${APPLICATION_NAME}-https` | TLS passthrough | `${HOSTNAME_HTTPS}`
 |=============
 
 
@@ -181,7 +183,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.3+| `${APPLICATION_NAME}`
+.4+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |https | 8443 | `TCP`
 |ping | 8888 | `TCP`
@@ -196,7 +199,7 @@ information.
 |=======================================================================
 |Deployment |Variable name |Description |Example value
 
-.18+| `${APPLICATION_NAME}`
+.19+| `${APPLICATION_NAME}`
 |`DB_SERVICE_PREFIX_MAPPING` | -- | `${APPLICATION_NAME}-postgresql=DB`
 |`DB_JNDI` | Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/postgresql | `${DB_JNDI}`
 |`DB_USERNAME` | Database user name | `${DB_USERNAME}`
@@ -215,6 +218,7 @@ information.
 |`HORNETQ_CLUSTER_PASSWORD` | HornetQ cluster admin password | `${HORNETQ_CLUSTER_PASSWORD}`
 |`HORNETQ_QUEUES` | Queue names | `${HORNETQ_QUEUES}`
 |`HORNETQ_TOPICS` | Topic names | `${HORNETQ_TOPICS}`
+|`JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}`
 .5+| `${APPLICATION_NAME}-postgresql`
 |`POSTGRESQL_USER` | -- | `${DB_USERNAME}`
 |`POSTGRESQL_PASSWORD` | -- | `${DB_PASSWORD}`

--- a/docs/webserver/jws30-tomcat7-basic-s2i.adoc
+++ b/docs/webserver/jws30-tomcat7-basic-s2i.adoc
@@ -24,7 +24,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |Variable name |Image Environment Variable |Description |Example value |Required
 
 |`APPLICATION_NAME` | -- | The name for the application. | jws-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
 |`SOURCE_REPOSITORY_URL` | -- | Git source URI for application | https://github.com/jboss-openshift/openshift-quickstarts.git | True
 |`SOURCE_REPOSITORY_REF` | -- | Git branch/tag reference | 1.1 | False
 |`CONTEXT_DIR` | -- | Path within Git project to build; empty for root project directory. | tomcat-websocket-chat | False
@@ -66,7 +66,7 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
 |=============
 
 
@@ -160,7 +160,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.1+| `${APPLICATION_NAME}`
+.2+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |=============
 

--- a/docs/webserver/jws30-tomcat7-https-s2i.adoc
+++ b/docs/webserver/jws30-tomcat7-https-s2i.adoc
@@ -24,7 +24,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |Variable name |Image Environment Variable |Description |Example value |Required
 
 |`APPLICATION_NAME` | -- | The name for the application. | jws-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
+|`HOSTNAME_HTTPS` | -- | Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-<project>.<default-domain-suffix> | -- | False
 |`SOURCE_REPOSITORY_URL` | -- | Git source URI for application | https://github.com/jboss-openshift/openshift-quickstarts.git | True
 |`SOURCE_REPOSITORY_REF` | -- | Git branch/tag reference | 1.1 | False
 |`CONTEXT_DIR` | -- | Path within Git project to build; empty for root project directory. | tomcat-websocket-chat | False
@@ -71,8 +72,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-https` | TLS passthrough | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
+|`${APPLICATION_NAME}-https` | TLS passthrough | `${HOSTNAME_HTTPS}`
 |=============
 
 
@@ -167,7 +168,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.2+| `${APPLICATION_NAME}`
+.3+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |https | 8443 | `TCP`
 |=============

--- a/docs/webserver/jws30-tomcat7-mongodb-persistent-s2i.adoc
+++ b/docs/webserver/jws30-tomcat7-mongodb-persistent-s2i.adoc
@@ -24,7 +24,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |Variable name |Image Environment Variable |Description |Example value |Required
 
 |`APPLICATION_NAME` | -- | The name for the application. | jws-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
+|`HOSTNAME_HTTPS` | -- | Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-<project>.<default-domain-suffix> | -- | False
 |`SOURCE_REPOSITORY_URL` | -- | Git source URI for application | https://github.com/jboss-openshift/openshift-quickstarts | True
 |`SOURCE_REPOSITORY_REF` | -- | Git branch/tag reference | 1.1 | False
 |`CONTEXT_DIR` | -- | Path within Git project to build; empty for root project directory. | todolist/todolist-mongodb | False
@@ -84,8 +85,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-https` | TLS passthrough | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
+|`${APPLICATION_NAME}-https` | TLS passthrough | `${HOSTNAME_HTTPS}`
 |=============
 
 
@@ -183,7 +184,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.2+| `${APPLICATION_NAME}`
+.3+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |https | 8443 | `TCP`
 .1+| `${APPLICATION_NAME}-mongodb`

--- a/docs/webserver/jws30-tomcat7-mongodb-s2i.adoc
+++ b/docs/webserver/jws30-tomcat7-mongodb-s2i.adoc
@@ -24,7 +24,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |Variable name |Image Environment Variable |Description |Example value |Required
 
 |`APPLICATION_NAME` | -- | The name for the application. | jws-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
+|`HOSTNAME_HTTPS` | -- | Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-<project>.<default-domain-suffix> | -- | False
 |`SOURCE_REPOSITORY_URL` | -- | Git source URI for application | https://github.com/jboss-openshift/openshift-quickstarts | True
 |`SOURCE_REPOSITORY_REF` | -- | Git branch/tag reference | 1.1 | False
 |`CONTEXT_DIR` | -- | Path within Git project to build; empty for root project directory. | todolist/todolist-mongodb | False
@@ -83,8 +84,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-https` | TLS passthrough | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
+|`${APPLICATION_NAME}-https` | TLS passthrough | `${HOSTNAME_HTTPS}`
 |=============
 
 
@@ -182,7 +183,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.2+| `${APPLICATION_NAME}`
+.3+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |https | 8443 | `TCP`
 .1+| `${APPLICATION_NAME}-mongodb`

--- a/docs/webserver/jws30-tomcat7-mysql-persistent-s2i.adoc
+++ b/docs/webserver/jws30-tomcat7-mysql-persistent-s2i.adoc
@@ -24,7 +24,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |Variable name |Image Environment Variable |Description |Example value |Required
 
 |`APPLICATION_NAME` | -- | The name for the application. | jws-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
+|`HOSTNAME_HTTPS` | -- | Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-<project>.<default-domain-suffix> | -- | False
 |`SOURCE_REPOSITORY_URL` | -- | Git source URI for application | https://github.com/jboss-openshift/openshift-quickstarts | True
 |`SOURCE_REPOSITORY_REF` | -- | Git branch/tag reference | 1.1 | False
 |`CONTEXT_DIR` | -- | Path within Git project to build; empty for root project directory. | todolist/todolist-jdbc | False
@@ -85,8 +86,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-https` | TLS passthrough | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
+|`${APPLICATION_NAME}-https` | TLS passthrough | `${HOSTNAME_HTTPS}`
 |=============
 
 
@@ -184,7 +185,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.2+| `${APPLICATION_NAME}`
+.3+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |https | 8443 | `TCP`
 .1+| `${APPLICATION_NAME}-mysql`

--- a/docs/webserver/jws30-tomcat7-mysql-s2i.adoc
+++ b/docs/webserver/jws30-tomcat7-mysql-s2i.adoc
@@ -24,7 +24,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |Variable name |Image Environment Variable |Description |Example value |Required
 
 |`APPLICATION_NAME` | -- | The name for the application. | jws-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
+|`HOSTNAME_HTTPS` | -- | Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-<project>.<default-domain-suffix> | -- | False
 |`SOURCE_REPOSITORY_URL` | -- | Git source URI for application | https://github.com/jboss-openshift/openshift-quickstarts | True
 |`SOURCE_REPOSITORY_REF` | -- | Git branch/tag reference | 1.1 | False
 |`CONTEXT_DIR` | -- | Path within Git project to build; empty for root project directory. | todolist/todolist-jdbc | False
@@ -84,8 +85,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-https` | TLS passthrough | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
+|`${APPLICATION_NAME}-https` | TLS passthrough | `${HOSTNAME_HTTPS}`
 |=============
 
 
@@ -183,7 +184,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.2+| `${APPLICATION_NAME}`
+.3+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |https | 8443 | `TCP`
 .1+| `${APPLICATION_NAME}-mysql`

--- a/docs/webserver/jws30-tomcat7-postgresql-persistent-s2i.adoc
+++ b/docs/webserver/jws30-tomcat7-postgresql-persistent-s2i.adoc
@@ -24,7 +24,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |Variable name |Image Environment Variable |Description |Example value |Required
 
 |`APPLICATION_NAME` | -- | The name for the application. | jws-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
+|`HOSTNAME_HTTPS` | -- | Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-<project>.<default-domain-suffix> | -- | False
 |`SOURCE_REPOSITORY_URL` | -- | Git source URI for application | https://github.com/jboss-openshift/openshift-quickstarts | True
 |`SOURCE_REPOSITORY_REF` | -- | Git branch/tag reference | 1.1 | False
 |`CONTEXT_DIR` | -- | Path within Git project to build; empty for root project directory. | todolist/todolist-jdbc | False
@@ -82,8 +83,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-https` | TLS passthrough | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
+|`${APPLICATION_NAME}-https` | TLS passthrough | `${HOSTNAME_HTTPS}`
 |=============
 
 
@@ -181,7 +182,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.2+| `${APPLICATION_NAME}`
+.3+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |https | 8443 | `TCP`
 .1+| `${APPLICATION_NAME}-postgresql`

--- a/docs/webserver/jws30-tomcat7-postgresql-s2i.adoc
+++ b/docs/webserver/jws30-tomcat7-postgresql-s2i.adoc
@@ -24,7 +24,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |Variable name |Image Environment Variable |Description |Example value |Required
 
 |`APPLICATION_NAME` | -- | The name for the application. | jws-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
+|`HOSTNAME_HTTPS` | -- | Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-<project>.<default-domain-suffix> | -- | False
 |`SOURCE_REPOSITORY_URL` | -- | Git source URI for application | https://github.com/jboss-openshift/openshift-quickstarts | True
 |`SOURCE_REPOSITORY_REF` | -- | Git branch/tag reference | 1.1 | False
 |`CONTEXT_DIR` | -- | Path within Git project to build; empty for root project directory. | todolist/todolist-jdbc | False
@@ -81,8 +82,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-https` | TLS passthrough | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
+|`${APPLICATION_NAME}-https` | TLS passthrough | `${HOSTNAME_HTTPS}`
 |=============
 
 
@@ -180,7 +181,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.2+| `${APPLICATION_NAME}`
+.3+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |https | 8443 | `TCP`
 .1+| `${APPLICATION_NAME}-postgresql`

--- a/docs/webserver/jws30-tomcat8-basic-s2i.adoc
+++ b/docs/webserver/jws30-tomcat8-basic-s2i.adoc
@@ -24,7 +24,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |Variable name |Image Environment Variable |Description |Example value |Required
 
 |`APPLICATION_NAME` | -- | The name for the application. | jws-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
 |`SOURCE_REPOSITORY_URL` | -- | Git source URI for application | https://github.com/jboss-openshift/openshift-quickstarts.git | True
 |`SOURCE_REPOSITORY_REF` | -- | Git branch/tag reference | 1.1 | False
 |`CONTEXT_DIR` | -- | Path within Git project to build; empty for root project directory. | tomcat-websocket-chat | False
@@ -66,7 +66,7 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
 |=============
 
 
@@ -160,7 +160,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.1+| `${APPLICATION_NAME}`
+.2+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |=============
 

--- a/docs/webserver/jws30-tomcat8-https-s2i.adoc
+++ b/docs/webserver/jws30-tomcat8-https-s2i.adoc
@@ -24,7 +24,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |Variable name |Image Environment Variable |Description |Example value |Required
 
 |`APPLICATION_NAME` | -- | The name for the application. | jws-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
+|`HOSTNAME_HTTPS` | -- | Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-<project>.<default-domain-suffix> | -- | False
 |`SOURCE_REPOSITORY_URL` | -- | Git source URI for application | https://github.com/jboss-openshift/openshift-quickstarts.git | True
 |`SOURCE_REPOSITORY_REF` | -- | Git branch/tag reference | 1.1 | False
 |`CONTEXT_DIR` | -- | Path within Git project to build; empty for root project directory. | tomcat-websocket-chat | False
@@ -71,8 +72,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-https` | TLS passthrough | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
+|`${APPLICATION_NAME}-https` | TLS passthrough | `${HOSTNAME_HTTPS}`
 |=============
 
 
@@ -167,7 +168,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.2+| `${APPLICATION_NAME}`
+.3+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |https | 8443 | `TCP`
 |=============

--- a/docs/webserver/jws30-tomcat8-mongodb-persistent-s2i.adoc
+++ b/docs/webserver/jws30-tomcat8-mongodb-persistent-s2i.adoc
@@ -24,7 +24,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |Variable name |Image Environment Variable |Description |Example value |Required
 
 |`APPLICATION_NAME` | -- | The name for the application. | jws-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
+|`HOSTNAME_HTTPS` | -- | Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-<project>.<default-domain-suffix> | -- | False
 |`SOURCE_REPOSITORY_URL` | -- | Git source URI for application | https://github.com/jboss-openshift/openshift-quickstarts | True
 |`SOURCE_REPOSITORY_REF` | -- | Git branch/tag reference | 1.1 | False
 |`CONTEXT_DIR` | -- | Path within Git project to build; empty for root project directory. | todolist/todolist-mongodb | False
@@ -84,8 +85,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-https` | TLS passthrough | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
+|`${APPLICATION_NAME}-https` | TLS passthrough | `${HOSTNAME_HTTPS}`
 |=============
 
 
@@ -183,7 +184,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.2+| `${APPLICATION_NAME}`
+.3+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |https | 8443 | `TCP`
 .1+| `${APPLICATION_NAME}-mongodb`

--- a/docs/webserver/jws30-tomcat8-mongodb-s2i.adoc
+++ b/docs/webserver/jws30-tomcat8-mongodb-s2i.adoc
@@ -24,7 +24,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |Variable name |Image Environment Variable |Description |Example value |Required
 
 |`APPLICATION_NAME` | -- | The name for the application. | jws-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
+|`HOSTNAME_HTTPS` | -- | Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-<project>.<default-domain-suffix> | -- | False
 |`SOURCE_REPOSITORY_URL` | -- | Git source URI for application | https://github.com/jboss-openshift/openshift-quickstarts | True
 |`SOURCE_REPOSITORY_REF` | -- | Git branch/tag reference | 1.1 | False
 |`CONTEXT_DIR` | -- | Path within Git project to build; empty for root project directory. | todolist/todolist-mongodb | False
@@ -83,8 +84,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-https` | TLS passthrough | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
+|`${APPLICATION_NAME}-https` | TLS passthrough | `${HOSTNAME_HTTPS}`
 |=============
 
 
@@ -182,7 +183,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.2+| `${APPLICATION_NAME}`
+.3+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |https | 8443 | `TCP`
 .1+| `${APPLICATION_NAME}-mongodb`

--- a/docs/webserver/jws30-tomcat8-mysql-persistent-s2i.adoc
+++ b/docs/webserver/jws30-tomcat8-mysql-persistent-s2i.adoc
@@ -24,7 +24,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |Variable name |Image Environment Variable |Description |Example value |Required
 
 |`APPLICATION_NAME` | -- | The name for the application. | jws-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
+|`HOSTNAME_HTTPS` | -- | Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-<project>.<default-domain-suffix> | -- | False
 |`SOURCE_REPOSITORY_URL` | -- | Git source URI for application | https://github.com/jboss-openshift/openshift-quickstarts | True
 |`SOURCE_REPOSITORY_REF` | -- | Git branch/tag reference | 1.1 | False
 |`CONTEXT_DIR` | -- | Path within Git project to build; empty for root project directory. | todolist/todolist-jdbc | False
@@ -85,8 +86,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-https` | TLS passthrough | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
+|`${APPLICATION_NAME}-https` | TLS passthrough | `${HOSTNAME_HTTPS}`
 |=============
 
 
@@ -184,7 +185,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.2+| `${APPLICATION_NAME}`
+.3+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |https | 8443 | `TCP`
 .1+| `${APPLICATION_NAME}-mysql`

--- a/docs/webserver/jws30-tomcat8-mysql-s2i.adoc
+++ b/docs/webserver/jws30-tomcat8-mysql-s2i.adoc
@@ -24,7 +24,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |Variable name |Image Environment Variable |Description |Example value |Required
 
 |`APPLICATION_NAME` | -- | The name for the application. | jws-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
+|`HOSTNAME_HTTPS` | -- | Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-<project>.<default-domain-suffix> | -- | False
 |`SOURCE_REPOSITORY_URL` | -- | Git source URI for application | https://github.com/jboss-openshift/openshift-quickstarts | True
 |`SOURCE_REPOSITORY_REF` | -- | Git branch/tag reference | 1.1 | False
 |`CONTEXT_DIR` | -- | Path within Git project to build; empty for root project directory. | todolist/todolist-jdbc | False
@@ -84,8 +85,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-https` | TLS passthrough | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
+|`${APPLICATION_NAME}-https` | TLS passthrough | `${HOSTNAME_HTTPS}`
 |=============
 
 
@@ -183,7 +184,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.2+| `${APPLICATION_NAME}`
+.3+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |https | 8443 | `TCP`
 .1+| `${APPLICATION_NAME}-mysql`

--- a/docs/webserver/jws30-tomcat8-postgresql-persistent-s2i.adoc
+++ b/docs/webserver/jws30-tomcat8-postgresql-persistent-s2i.adoc
@@ -24,7 +24,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |Variable name |Image Environment Variable |Description |Example value |Required
 
 |`APPLICATION_NAME` | -- | The name for the application. | jws-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
+|`HOSTNAME_HTTPS` | -- | Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-<project>.<default-domain-suffix> | -- | False
 |`SOURCE_REPOSITORY_URL` | -- | Git source URI for application | https://github.com/jboss-openshift/openshift-quickstarts | True
 |`SOURCE_REPOSITORY_REF` | -- | Git branch/tag reference | 1.1 | False
 |`CONTEXT_DIR` | -- | Path within Git project to build; empty for root project directory. | todolist/todolist-jdbc | False
@@ -82,8 +83,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-https` | TLS passthrough | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
+|`${APPLICATION_NAME}-https` | TLS passthrough | `${HOSTNAME_HTTPS}`
 |=============
 
 
@@ -181,7 +182,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.2+| `${APPLICATION_NAME}`
+.3+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |https | 8443 | `TCP`
 .1+| `${APPLICATION_NAME}-postgresql`

--- a/docs/webserver/jws30-tomcat8-postgresql-s2i.adoc
+++ b/docs/webserver/jws30-tomcat8-postgresql-s2i.adoc
@@ -24,7 +24,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |Variable name |Image Environment Variable |Description |Example value |Required
 
 |`APPLICATION_NAME` | -- | The name for the application. | jws-app | True
-|`APPLICATION_DOMAIN` | -- | Custom hostname for service routes.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix> | secure-app.test.router.default.local | False
+|`HOSTNAME_HTTP` | -- | Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix> | -- | False
+|`HOSTNAME_HTTPS` | -- | Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-<project>.<default-domain-suffix> | -- | False
 |`SOURCE_REPOSITORY_URL` | -- | Git source URI for application | https://github.com/jboss-openshift/openshift-quickstarts | True
 |`SOURCE_REPOSITORY_REF` | -- | Git branch/tag reference | 1.1 | False
 |`CONTEXT_DIR` | -- | Path within Git project to build; empty for root project directory. | todolist/todolist-jdbc | False
@@ -81,8 +82,8 @@ https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
 |=============
 | Service    | Security | Hostname
 
-|`${APPLICATION_NAME}-http` | none | `${APPLICATION_DOMAIN}`
-|`${APPLICATION_NAME}-https` | TLS passthrough | `${APPLICATION_DOMAIN}`
+|`${APPLICATION_NAME}-http` | none | `${HOSTNAME_HTTP}`
+|`${APPLICATION_NAME}-https` | TLS passthrough | `${HOSTNAME_HTTPS}`
 |=============
 
 
@@ -180,7 +181,8 @@ information.
 |=============
 |Deployments | Name  | Port  | Protocol
 
-.2+| `${APPLICATION_NAME}`
+.3+| `${APPLICATION_NAME}`
+|jolokia | 8778 | `TCP`
 |http | 8080 | `TCP`
 |https | 8443 | `TCP`
 .1+| `${APPLICATION_NAME}-postgresql`

--- a/gen_template_docs.py
+++ b/gen_template_docs.py
@@ -285,8 +285,7 @@ def generate_readme():
                 fh.write("* link:./%s/%s.adoc[%s]\n" % (directory, template, template))
 
         # release notes
-        fh.write('\n= Release Notes\n\n')
-        fh.write('include::./release-notes.adoc[]\n')
+        fh.write(open('./release-notes.adoc.in').read())
 
 # expects to be run from the root of the repository
 if __name__ == "__main__":

--- a/release-notes.adoc.in
+++ b/release-notes.adoc.in
@@ -1,5 +1,12 @@
 
-== Release 1.2.0
+////
+  the source for the release notes part of this page is in the file
+  ./release-notes.adoc.in
+////
+
+== Release Notes
+
+=== Release 1.2.0
  * Added support for JBoss Data Grid
  * Added support for JBoss Decision Server
  * Added liveness probe to EAP templates
@@ -8,7 +15,7 @@
  * Add Jolokia port to templates
  * Renamed APPLICATION_DOMAIN to HOSTNAME_HTTP and HOSTNAME_HTTPS to correspond to http and https routes
 
-== Release 1.1.0
+=== Release 1.1.0
  * Added terminationGracePeriodSeconds to pod templates
  * Renamed templates:
  ** Include product minor version in names (e.g. eap6-basic-s2i => eap64-basic-s2i)
@@ -27,13 +34,13 @@
  * Add missing mqtt+ssl port to A-MQ templates
  * Add parameter to select ImageStream namespace, defaulting to "openshift"
 
-== Release 1.0.2
+=== Release 1.0.2
  * Fix capitalization of GitHub trigger type
 
-== Release 1.0.1
+=== Release 1.0.1
  * Shorten port names
  * update deprecated items in BuildConfig
 
-== Release 1.0.0
+=== Release 1.0.0
  * Initial release with support for JBoss EAP, JBoss Web Server, and JBoss A-MQ
 


### PR DESCRIPTION
It seems `include::` doesn't work on GitHub, so I've adjusted the docs generation to read in the release notes source and write it out to the end of the README file instead.