### PR TITLE
[CLOUD-337] JGroups keystore directory in a variable

### DIFF
--- a/datagrid/datagrid65-https.json
+++ b/datagrid/datagrid65-https.json
@@ -441,6 +441,10 @@
                                         "value": "${JGROUPS_ENCRYPT_KEYSTORE}"
                                     },
                                     {
+                                        "name": "JGROUPS_ENCRYPT_KEYSTORE_DIR",
+                                        "value": "/etc/jgroups-encrypt-secret-volume"
+                                    },
+                                    {
                                         "name": "JGROUPS_ENCRYPT_NAME",
                                         "value": "${JGROUPS_ENCRYPT_NAME}"
                                     },

--- a/datagrid/datagrid65-mysql-persistent.json
+++ b/datagrid/datagrid65-mysql-persistent.json
@@ -572,6 +572,10 @@
                                         "value": "${JGROUPS_ENCRYPT_KEYSTORE}"
                                     },
                                     {
+                                        "name": "JGROUPS_ENCRYPT_KEYSTORE_DIR",
+                                        "value": "/etc/jgroups-encrypt-secret-volume"
+                                    },
+                                    {
                                         "name": "JGROUPS_ENCRYPT_NAME",
                                         "value": "${JGROUPS_ENCRYPT_NAME}"
                                     },

--- a/datagrid/datagrid65-mysql.json
+++ b/datagrid/datagrid65-mysql.json
@@ -567,6 +567,10 @@
                                         "value": "${JGROUPS_ENCRYPT_KEYSTORE}"
                                     },
                                     {
+                                        "name": "JGROUPS_ENCRYPT_KEYSTORE_DIR",
+                                        "value": "/etc/jgroups-encrypt-secret-volume"
+                                    },
+                                    {
                                         "name": "JGROUPS_ENCRYPT_NAME",
                                         "value": "${JGROUPS_ENCRYPT_NAME}"
                                     },

--- a/datagrid/datagrid65-postgresql-persistent.json
+++ b/datagrid/datagrid65-postgresql-persistent.json
@@ -557,6 +557,10 @@
                                         "value": "${JGROUPS_ENCRYPT_KEYSTORE}"
                                     },
                                     {
+                                        "name": "JGROUPS_ENCRYPT_KEYSTORE_DIR",
+                                        "value": "/etc/jgroups-encrypt-secret-volume"
+                                    },
+                                    {
                                         "name": "JGROUPS_ENCRYPT_NAME",
                                         "value": "${JGROUPS_ENCRYPT_NAME}"
                                     },

--- a/datagrid/datagrid65-postgresql.json
+++ b/datagrid/datagrid65-postgresql.json
@@ -551,6 +551,10 @@
                                         "value": "${JGROUPS_ENCRYPT_KEYSTORE}"
                                     },
                                     {
+                                        "name": "JGROUPS_ENCRYPT_KEYSTORE_DIR",
+                                        "value": "/etc/jgroups-encrypt-secret-volume"
+                                    },
+                                    {
                                         "name": "JGROUPS_ENCRYPT_NAME",
                                         "value": "${JGROUPS_ENCRYPT_NAME}"
                                     },

--- a/eap/eap64-amq-persistent-s2i.json
+++ b/eap/eap64-amq-persistent-s2i.json
@@ -534,6 +534,10 @@
                                         "value": "${JGROUPS_ENCRYPT_SECRET}"
                                     },
                                     {
+                                        "name": "JGROUPS_ENCRYPT_KEYSTORE_DIR",
+                                        "value": "/etc/jgroups-encrypt-secret-volume"
+                                    },
+                                    {
                                         "name": "JGROUPS_ENCRYPT_KEYSTORE",
                                         "value": "${JGROUPS_ENCRYPT_KEYSTORE}"
                                     },

--- a/eap/eap64-amq-s2i.json
+++ b/eap/eap64-amq-s2i.json
@@ -528,6 +528,10 @@
                                         "value": "${JGROUPS_ENCRYPT_SECRET}"
                                     },
                                     {
+                                        "name": "JGROUPS_ENCRYPT_KEYSTORE_DIR",
+                                        "value": "/etc/jgroups-encrypt-secret-volume"
+                                    },
+                                    {
                                         "name": "JGROUPS_ENCRYPT_KEYSTORE",
                                         "value": "${JGROUPS_ENCRYPT_KEYSTORE}"
                                     },

--- a/eap/eap64-https-s2i.json
+++ b/eap/eap64-https-s2i.json
@@ -455,6 +455,10 @@
                                         "value": "${JGROUPS_ENCRYPT_SECRET}"
                                     },
                                     {
+                                        "name": "JGROUPS_ENCRYPT_KEYSTORE_DIR",
+                                        "value": "/etc/jgroups-encrypt-secret-volume"
+                                    },
+                                    {
                                         "name": "JGROUPS_ENCRYPT_KEYSTORE",
                                         "value": "${JGROUPS_ENCRYPT_KEYSTORE}"
                                     },

--- a/eap/eap64-mongodb-persistent-s2i.json
+++ b/eap/eap64-mongodb-persistent-s2i.json
@@ -584,6 +584,10 @@
                                         "value": "${JGROUPS_ENCRYPT_SECRET}"
                                     },
                                     {
+                                        "name": "JGROUPS_ENCRYPT_KEYSTORE_DIR",
+                                        "value": "/etc/jgroups-encrypt-secret-volume"
+                                    },
+                                    {
                                         "name": "JGROUPS_ENCRYPT_KEYSTORE",
                                         "value": "${JGROUPS_ENCRYPT_KEYSTORE}"
                                     },

--- a/eap/eap64-mongodb-s2i.json
+++ b/eap/eap64-mongodb-s2i.json
@@ -578,6 +578,10 @@
                                         "value": "${JGROUPS_ENCRYPT_SECRET}"
                                     },
                                     {
+                                        "name": "JGROUPS_ENCRYPT_KEYSTORE_DIR",
+                                        "value": "/etc/jgroups-encrypt-secret-volume"
+                                    },
+                                    {
                                         "name": "JGROUPS_ENCRYPT_KEYSTORE",
                                         "value": "${JGROUPS_ENCRYPT_KEYSTORE}"
                                     },

--- a/eap/eap64-mysql-persistent-s2i.json
+++ b/eap/eap64-mysql-persistent-s2i.json
@@ -587,6 +587,10 @@
                                         "value": "${JGROUPS_ENCRYPT_SECRET}"
                                     },
                                     {
+                                        "name": "JGROUPS_ENCRYPT_KEYSTORE_DIR",
+                                        "value": "/etc/jgroups-encrypt-secret-volume"
+                                    },
+                                    {
                                         "name": "JGROUPS_ENCRYPT_KEYSTORE",
                                         "value": "${JGROUPS_ENCRYPT_KEYSTORE}"
                                     },

--- a/eap/eap64-mysql-s2i.json
+++ b/eap/eap64-mysql-s2i.json
@@ -581,6 +581,10 @@
                                         "value": "${JGROUPS_ENCRYPT_SECRET}"
                                     },
                                     {
+                                        "name": "JGROUPS_ENCRYPT_KEYSTORE_DIR",
+                                        "value": "/etc/jgroups-encrypt-secret-volume"
+                                    },
+                                    {
                                         "name": "JGROUPS_ENCRYPT_KEYSTORE",
                                         "value": "${JGROUPS_ENCRYPT_KEYSTORE}"
                                     },

--- a/eap/eap64-postgresql-persistent-s2i.json
+++ b/eap/eap64-postgresql-persistent-s2i.json
@@ -572,6 +572,10 @@
                                         "value": "${JGROUPS_ENCRYPT_SECRET}"
                                     },
                                     {
+                                        "name": "JGROUPS_ENCRYPT_KEYSTORE_DIR",
+                                        "value": "/etc/jgroups-encrypt-secret-volume"
+                                    },
+                                    {
                                         "name": "JGROUPS_ENCRYPT_KEYSTORE",
                                         "value": "${JGROUPS_ENCRYPT_KEYSTORE}"
                                     },

--- a/eap/eap64-postgresql-s2i.json
+++ b/eap/eap64-postgresql-s2i.json
@@ -566,6 +566,10 @@
                                         "value": "${JGROUPS_ENCRYPT_SECRET}"
                                     },
                                     {
+                                        "name": "JGROUPS_ENCRYPT_KEYSTORE_DIR",
+                                        "value": "/etc/jgroups-encrypt-secret-volume"
+                                    },
+                                    {
                                         "name": "JGROUPS_ENCRYPT_KEYSTORE",
                                         "value": "${JGROUPS_ENCRYPT_KEYSTORE}"
                                     },


### PR DESCRIPTION
I've added env variable JDG_JGROUPS_ENCRYPT_KEYSTORE_DIR to all templates that already use secret for HTTPS and also added mount for that directory. This variable is used further in infinispan-config.sh.

See https://gitlab.mw.lab.eng.bos.redhat.com/cloudenablement/jboss-dockerfiles/merge_requests/409 for reference.