### PR TITLE
CLOUD-430: [JDG] Don't setup SSL in the basic template.

### DIFF
--- a/datagrid/datagrid65-basic.json
+++ b/datagrid/datagrid65-basic.json
@@ -293,6 +293,10 @@
                                 ],
                                 "env": [
                                     {
+                                        "name": "DISABLE_SSL",
+                                        "value": "1"
+                                    },
+                                    {
                                         "name": "USERNAME",
                                         "value": "${USERNAME}"
                                     },


### PR DESCRIPTION
By setting the env var DISABLE_SSL. This tells the image we don't
want SSL, so that it doesn't emit a warning about SSL not being configured
due to lack of some parameters.
