### PR TITLE
CLOUD-641: Add multi-version Container support to KIE Server

### DIFF
--- a/decisionserver/decisionserver63-amq-s2i.json
+++ b/decisionserver/decisionserver63-amq-s2i.json
@@ -22,6 +22,12 @@
             "required": false
         },
         {
+            "description": "Whether KIE Container alias ids will be redirected to generated deployment ids.",
+            "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+            "value": "false",
+            "required": false
+        },
+        {
             "description": "The user name to access the KIE Server REST or JMS interface.",
             "name": "KIE_SERVER_USER",
             "value": "kieserver",
@@ -330,6 +336,10 @@
                             {
                                 "name": "KIE_CONTAINER_DEPLOYMENT",
                                 "value": "${KIE_CONTAINER_DEPLOYMENT}"
+                            },
+                            {
+                                "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+                                "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
                             }
                         ],
                         "forcePull": true,
@@ -471,6 +481,10 @@
                                     {
                                         "name": "KIE_CONTAINER_DEPLOYMENT",
                                         "value": "${KIE_CONTAINER_DEPLOYMENT}"
+                                    },
+                                    {
+                                        "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+                                        "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
                                     },
                                     {
                                         "name": "KIE_SERVER_USER",

--- a/decisionserver/decisionserver63-basic-s2i.json
+++ b/decisionserver/decisionserver63-basic-s2i.json
@@ -22,6 +22,12 @@
             "required": false
         },
         {
+            "description": "Whether KIE Container alias ids will be redirected to generated deployment ids.",
+            "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+            "value": "false",
+            "required": false
+        },
+        {
             "description": "The user name to access the KIE Server REST or JMS interface.",
             "name": "KIE_SERVER_USER",
             "value": "kieserver",
@@ -184,6 +190,10 @@
                             {
                                 "name": "KIE_CONTAINER_DEPLOYMENT",
                                 "value": "${KIE_CONTAINER_DEPLOYMENT}"
+                            },
+                            {
+                                "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+                                "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
                             }
                         ],
                         "forcePull": true,
@@ -312,6 +322,10 @@
                                     {
                                         "name": "KIE_CONTAINER_DEPLOYMENT",
                                         "value": "${KIE_CONTAINER_DEPLOYMENT}"
+                                    },
+                                    {
+                                        "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+                                        "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
                                     },
                                     {
                                         "name": "KIE_SERVER_USER",

--- a/decisionserver/decisionserver63-https-s2i.json
+++ b/decisionserver/decisionserver63-https-s2i.json
@@ -22,6 +22,12 @@
             "required": false
         },
         {
+            "description": "Whether KIE Container alias ids will be redirected to generated deployment ids.",
+            "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+            "value": "false",
+            "required": false
+        },
+        {
             "description": "The protocol to access the KIE Server REST interface.",
             "name": "KIE_SERVER_PROTOCOL",
             "value": "https",
@@ -273,6 +279,10 @@
                             {
                                 "name": "KIE_CONTAINER_DEPLOYMENT",
                                 "value": "${KIE_CONTAINER_DEPLOYMENT}"
+                            },
+                            {
+                                "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+                                "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
                             }
                         ],
                         "forcePull": true,
@@ -414,6 +424,10 @@
                                     {
                                         "name": "KIE_CONTAINER_DEPLOYMENT",
                                         "value": "${KIE_CONTAINER_DEPLOYMENT}"
+                                    },
+                                    {
+                                        "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+                                        "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
                                     },
                                     {
                                         "name": "KIE_SERVER_PROTOCOL",

--- a/processserver/processserver63-amq-mysql-persistent-s2i.json
+++ b/processserver/processserver63-amq-mysql-persistent-s2i.json
@@ -22,6 +22,12 @@
             "required": false
         },
         {
+            "description": "Whether KIE Container alias ids will be redirected to generated deployment ids.",
+            "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+            "value": "false",
+            "required": false
+        },
+        {
             "description": "The protocol to access the KIE Server REST interface.",
             "name": "KIE_SERVER_PROTOCOL",
             "value": "https",
@@ -450,6 +456,10 @@
                             {
                                 "name": "KIE_CONTAINER_DEPLOYMENT",
                                 "value": "${KIE_CONTAINER_DEPLOYMENT}"
+                            },
+                            {
+                                "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+                                "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
                             }
                         ],
                         "forcePull": true,
@@ -586,6 +596,10 @@
                                     {
                                         "name": "KIE_CONTAINER_DEPLOYMENT",
                                         "value": "${KIE_CONTAINER_DEPLOYMENT}"
+                                    },
+                                    {
+                                        "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+                                        "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
                                     },
                                     {
                                         "name": "KIE_SERVER_PROTOCOL",

--- a/processserver/processserver63-amq-mysql-s2i.json
+++ b/processserver/processserver63-amq-mysql-s2i.json
@@ -22,6 +22,12 @@
             "required": false
         },
         {
+            "description": "Whether KIE Container alias ids will be redirected to generated deployment ids.",
+            "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+            "value": "false",
+            "required": false
+        },
+        {
             "description": "The protocol to access the KIE Server REST interface.",
             "name": "KIE_SERVER_PROTOCOL",
             "value": "https",
@@ -444,6 +450,10 @@
                             {
                                 "name": "KIE_CONTAINER_DEPLOYMENT",
                                 "value": "${KIE_CONTAINER_DEPLOYMENT}"
+                            },
+                            {
+                                "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+                                "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
                             }
                         ],
                         "forcePull": true,
@@ -580,6 +590,10 @@
                                     {
                                         "name": "KIE_CONTAINER_DEPLOYMENT",
                                         "value": "${KIE_CONTAINER_DEPLOYMENT}"
+                                    },
+                                    {
+                                        "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+                                        "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
                                     },
                                     {
                                         "name": "KIE_SERVER_PROTOCOL",

--- a/processserver/processserver63-amq-postgresql-persistent-s2i.json
+++ b/processserver/processserver63-amq-postgresql-persistent-s2i.json
@@ -22,6 +22,12 @@
             "required": false
         },
         {
+            "description": "Whether KIE Container alias ids will be redirected to generated deployment ids.",
+            "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+            "value": "false",
+            "required": false
+        },
+        {
             "description": "The protocol to access the KIE Server REST interface.",
             "name": "KIE_SERVER_PROTOCOL",
             "value": "https",
@@ -435,6 +441,10 @@
                             {
                                 "name": "KIE_CONTAINER_DEPLOYMENT",
                                 "value": "${KIE_CONTAINER_DEPLOYMENT}"
+                            },
+                            {
+                                "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+                                "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
                             }
                         ],
                         "forcePull": true,
@@ -571,6 +581,10 @@
                                     {
                                         "name": "KIE_CONTAINER_DEPLOYMENT",
                                         "value": "${KIE_CONTAINER_DEPLOYMENT}"
+                                    },
+                                    {
+                                        "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+                                        "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
                                     },
                                     {
                                         "name": "KIE_SERVER_PROTOCOL",

--- a/processserver/processserver63-amq-postgresql-s2i.json
+++ b/processserver/processserver63-amq-postgresql-s2i.json
@@ -22,6 +22,12 @@
             "required": false
         },
         {
+            "description": "Whether KIE Container alias ids will be redirected to generated deployment ids.",
+            "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+            "value": "false",
+            "required": false
+        },
+        {
             "description": "The protocol to access the KIE Server REST interface.",
             "name": "KIE_SERVER_PROTOCOL",
             "value": "https",
@@ -429,6 +435,10 @@
                             {
                                 "name": "KIE_CONTAINER_DEPLOYMENT",
                                 "value": "${KIE_CONTAINER_DEPLOYMENT}"
+                            },
+                            {
+                                "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+                                "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
                             }
                         ],
                         "forcePull": true,
@@ -565,6 +575,10 @@
                                     {
                                         "name": "KIE_CONTAINER_DEPLOYMENT",
                                         "value": "${KIE_CONTAINER_DEPLOYMENT}"
+                                    },
+                                    {
+                                        "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+                                        "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
                                     },
                                     {
                                         "name": "KIE_SERVER_PROTOCOL",

--- a/processserver/processserver63-basic-s2i.json
+++ b/processserver/processserver63-basic-s2i.json
@@ -22,6 +22,12 @@
             "required": false
         },
         {
+            "description": "Whether KIE Container alias ids will be redirected to generated deployment ids.",
+            "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+            "value": "false",
+            "required": false
+        },
+        {
             "description": "The user name to access the KIE Server REST or JMS interface.",
             "name": "KIE_SERVER_USER",
             "value": "kieserver",
@@ -190,6 +196,10 @@
                             {
                                 "name": "KIE_CONTAINER_DEPLOYMENT",
                                 "value": "${KIE_CONTAINER_DEPLOYMENT}"
+                            },
+                            {
+                                "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+                                "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
                             }
                         ],
                         "forcePull": true,
@@ -313,6 +323,10 @@
                                     {
                                         "name": "KIE_CONTAINER_DEPLOYMENT",
                                         "value": "${KIE_CONTAINER_DEPLOYMENT}"
+                                    },
+                                    {
+                                        "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+                                        "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
                                     },
                                     {
                                         "name": "KIE_SERVER_USER",

--- a/processserver/processserver63-mysql-persistent-s2i.json
+++ b/processserver/processserver63-mysql-persistent-s2i.json
@@ -22,6 +22,12 @@
             "required": false
         },
         {
+            "description": "Whether KIE Container alias ids will be redirected to generated deployment ids.",
+            "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+            "value": "false",
+            "required": false
+        },
+        {
             "description": "The protocol to access the KIE Server REST interface.",
             "name": "KIE_SERVER_PROTOCOL",
             "value": "https",
@@ -387,6 +393,10 @@
                             {
                                 "name": "KIE_CONTAINER_DEPLOYMENT",
                                 "value": "${KIE_CONTAINER_DEPLOYMENT}"
+                            },
+                            {
+                                "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+                                "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
                             }
                         ],
                         "forcePull": true,
@@ -523,6 +533,10 @@
                                     {
                                         "name": "KIE_CONTAINER_DEPLOYMENT",
                                         "value": "${KIE_CONTAINER_DEPLOYMENT}"
+                                    },
+                                    {
+                                        "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+                                        "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
                                     },
                                     {
                                         "name": "KIE_SERVER_PROTOCOL",

--- a/processserver/processserver63-mysql-s2i.json
+++ b/processserver/processserver63-mysql-s2i.json
@@ -22,6 +22,12 @@
             "required": false
         },
         {
+            "description": "Whether KIE Container alias ids will be redirected to generated deployment ids.",
+            "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+            "value": "false",
+            "required": false
+        },
+        {
             "description": "The protocol to access the KIE Server REST interface.",
             "name": "KIE_SERVER_PROTOCOL",
             "value": "https",
@@ -381,6 +387,10 @@
                             {
                                 "name": "KIE_CONTAINER_DEPLOYMENT",
                                 "value": "${KIE_CONTAINER_DEPLOYMENT}"
+                            },
+                            {
+                                "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+                                "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
                             }
                         ],
                         "forcePull": true,
@@ -517,6 +527,10 @@
                                     {
                                         "name": "KIE_CONTAINER_DEPLOYMENT",
                                         "value": "${KIE_CONTAINER_DEPLOYMENT}"
+                                    },
+                                    {
+                                        "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+                                        "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
                                     },
                                     {
                                         "name": "KIE_SERVER_PROTOCOL",

--- a/processserver/processserver63-postgresql-persistent-s2i.json
+++ b/processserver/processserver63-postgresql-persistent-s2i.json
@@ -22,6 +22,12 @@
             "required": false
         },
         {
+            "description": "Whether KIE Container alias ids will be redirected to generated deployment ids.",
+            "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+            "value": "false",
+            "required": false
+        },
+        {
             "description": "The protocol to access the KIE Server REST interface.",
             "name": "KIE_SERVER_PROTOCOL",
             "value": "https",
@@ -372,6 +378,10 @@
                             {
                                 "name": "KIE_CONTAINER_DEPLOYMENT",
                                 "value": "${KIE_CONTAINER_DEPLOYMENT}"
+                            },
+                            {
+                                "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+                                "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
                             }
                         ],
                         "forcePull": true,
@@ -508,6 +518,10 @@
                                     {
                                         "name": "KIE_CONTAINER_DEPLOYMENT",
                                         "value": "${KIE_CONTAINER_DEPLOYMENT}"
+                                    },
+                                    {
+                                        "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+                                        "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
                                     },
                                     {
                                         "name": "KIE_SERVER_PROTOCOL",

--- a/processserver/processserver63-postgresql-s2i.json
+++ b/processserver/processserver63-postgresql-s2i.json
@@ -22,6 +22,12 @@
             "required": false
         },
         {
+            "description": "Whether KIE Container alias ids will be redirected to generated deployment ids.",
+            "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+            "value": "false",
+            "required": false
+        },
+        {
             "description": "The protocol to access the KIE Server REST interface.",
             "name": "KIE_SERVER_PROTOCOL",
             "value": "https",
@@ -366,6 +372,10 @@
                             {
                                 "name": "KIE_CONTAINER_DEPLOYMENT",
                                 "value": "${KIE_CONTAINER_DEPLOYMENT}"
+                            },
+                            {
+                                "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+                                "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
                             }
                         ],
                         "forcePull": true,
@@ -502,6 +512,10 @@
                                     {
                                         "name": "KIE_CONTAINER_DEPLOYMENT",
                                         "value": "${KIE_CONTAINER_DEPLOYMENT}"
+                                    },
+                                    {
+                                        "name": "KIE_CONTAINER_REDIRECT_ENABLED",
+                                        "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
                                     },
                                     {
                                         "name": "KIE_SERVER_PROTOCOL",


### PR DESCRIPTION
CLOUD-641: Add multi-version Container support to KIE Server
https://issues.jboss.org/browse/CLOUD-641