### PR TITLE
CLOUD-584, CLOUD-589, CLOUD-590, CLOUD-605

### DIFF
--- a/decisionserver/decisionserver62-amq-s2i.json
+++ b/decisionserver/decisionserver62-amq-s2i.json
@@ -41,6 +41,12 @@
             "required": false
         },
         {
+            "description": "JNDI name of request queue for JMS.",
+            "name": "KIE_SERVER_JMS_QUEUES_REQUEST",
+            "value": "queue/KIE.SERVER.REQUEST",
+            "required": false
+        },
+        {
             "description": "JNDI name of response queue for JMS.",
             "name": "KIE_SERVER_JMS_QUEUES_RESPONSE",
             "value": "queue/KIE.SERVER.RESPONSE",
@@ -480,6 +486,10 @@
                                         "value": "${KIE_SERVER_DOMAIN}"
                                     },
                                     {
+                                        "name": "KIE_SERVER_JMS_QUEUES_REQUEST",
+                                        "value": "${KIE_SERVER_JMS_QUEUES_REQUEST}"
+                                    },
+                                    {
                                         "name": "KIE_SERVER_JMS_QUEUES_RESPONSE",
                                         "value": "${KIE_SERVER_JMS_QUEUES_RESPONSE}"
                                     },
@@ -656,14 +666,6 @@
                                     {
                                         "name": "AMQ_TRANSPORTS",
                                         "value": "${MQ_PROTOCOL}"
-                                    },
-                                    {
-                                        "name": "AMQ_QUEUES",
-                                        "value": "${MQ_QUEUES}"
-                                    },
-                                    {
-                                        "name": "AMQ_TOPICS",
-                                        "value": "${MQ_TOPICS}"
                                     },
                                     {
                                         "name": "AMQ_ADMIN_USERNAME",

--- a/decisionserver/decisionserver63-amq-s2i.json
+++ b/decisionserver/decisionserver63-amq-s2i.json
@@ -47,6 +47,12 @@
             "required": false
         },
         {
+            "description": "JNDI name of request queue for JMS.",
+            "name": "KIE_SERVER_JMS_QUEUES_REQUEST",
+            "value": "queue/KIE.SERVER.REQUEST",
+            "required": false
+        },
+        {
             "description": "JNDI name of response queue for JMS.",
             "name": "KIE_SERVER_JMS_QUEUES_RESPONSE",
             "value": "queue/KIE.SERVER.RESPONSE",
@@ -494,6 +500,10 @@
                                         "value": "${KIE_SERVER_DOMAIN}"
                                     },
                                     {
+                                        "name": "KIE_SERVER_JMS_QUEUES_REQUEST",
+                                        "value": "${KIE_SERVER_JMS_QUEUES_REQUEST}"
+                                    },
+                                    {
                                         "name": "KIE_SERVER_JMS_QUEUES_RESPONSE",
                                         "value": "${KIE_SERVER_JMS_QUEUES_RESPONSE}"
                                     },
@@ -580,7 +590,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "jboss-amq-62:1.2"
+                                "name": "jboss-amq-62:1.3"
                             }
                         }
                     },
@@ -670,14 +680,6 @@
                                     {
                                         "name": "AMQ_TRANSPORTS",
                                         "value": "${MQ_PROTOCOL}"
-                                    },
-                                    {
-                                        "name": "AMQ_QUEUES",
-                                        "value": "${MQ_QUEUES}"
-                                    },
-                                    {
-                                        "name": "AMQ_TOPICS",
-                                        "value": "${MQ_TOPICS}"
                                     },
                                     {
                                         "name": "AMQ_ADMIN_USERNAME",

--- a/processserver/processserver63-amq-mysql-persistent-s2i.json
+++ b/processserver/processserver63-amq-mysql-persistent-s2i.json
@@ -59,15 +59,21 @@
             "required": false
         },
         {
-            "description": "JNDI name of executor queue for JMS.",
-            "name": "KIE_SERVER_EXECUTOR_JMS_QUEUE",
-            "value": "queue/KIE.EXECUTOR",
+            "description": "JNDI name of request queue for JMS.",
+            "name": "KIE_SERVER_JMS_QUEUES_REQUEST",
+            "value": "queue/KIE.SERVER.REQUEST",
             "required": false
         },
         {
             "description": "JNDI name of response queue for JMS.",
             "name": "KIE_SERVER_JMS_QUEUES_RESPONSE",
             "value": "queue/KIE.SERVER.RESPONSE",
+            "required": false
+        },
+        {
+            "description": "JNDI name of executor queue for JMS.",
+            "name": "KIE_SERVER_EXECUTOR_JMS_QUEUE",
+            "value": "queue/KIE.SERVER.EXECUTOR",
             "required": false
         },
         {
@@ -145,7 +151,7 @@
         {
             "description": "Queue names, separated by commas. These queues will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP.",
             "name": "MQ_QUEUES",
-            "value": "KIE.SERVER.REQUEST,KIE.SERVER.RESPONSE,KIE.EXECUTOR",
+            "value": "KIE.SERVER.REQUEST,KIE.SERVER.RESPONSE,KIE.SERVER.EXECUTOR",
             "required": false
         },
         {
@@ -622,12 +628,16 @@
                                         "value": "${KIE_SERVER_DOMAIN}"
                                     },
                                     {
-                                        "name": "KIE_SERVER_EXECUTOR_JMS_QUEUE",
-                                        "value": "${KIE_SERVER_EXECUTOR_JMS_QUEUE}"
+                                        "name": "KIE_SERVER_JMS_QUEUES_REQUEST",
+                                        "value": "${KIE_SERVER_JMS_QUEUES_REQUEST}"
                                     },
                                     {
                                         "name": "KIE_SERVER_JMS_QUEUES_RESPONSE",
                                         "value": "${KIE_SERVER_JMS_QUEUES_RESPONSE}"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_EXECUTOR_JMS_QUEUE",
+                                        "value": "${KIE_SERVER_EXECUTOR_JMS_QUEUE}"
                                     },
                                     {
                                         "name": "MQ_SERVICE_PREFIX_MAPPING",
@@ -883,7 +893,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "jboss-amq-62:1.2"
+                                "name": "jboss-amq-62:1.3"
                             }
                         }
                     },
@@ -973,14 +983,6 @@
                                     {
                                         "name": "AMQ_TRANSPORTS",
                                         "value": "${MQ_PROTOCOL}"
-                                    },
-                                    {
-                                        "name": "AMQ_QUEUES",
-                                        "value": "${MQ_QUEUES}"
-                                    },
-                                    {
-                                        "name": "AMQ_TOPICS",
-                                        "value": "${MQ_TOPICS}"
                                     },
                                     {
                                         "name": "AMQ_ADMIN_USERNAME",

--- a/processserver/processserver63-amq-mysql-s2i.json
+++ b/processserver/processserver63-amq-mysql-s2i.json
@@ -59,15 +59,21 @@
             "required": false
         },
         {
-            "description": "JNDI name of executor queue for JMS.",
-            "name": "KIE_SERVER_EXECUTOR_JMS_QUEUE",
-            "value": "queue/KIE.EXECUTOR",
+            "description": "JNDI name of request queue for JMS.",
+            "name": "KIE_SERVER_JMS_QUEUES_REQUEST",
+            "value": "queue/KIE.SERVER.REQUEST",
             "required": false
         },
         {
             "description": "JNDI name of response queue for JMS.",
             "name": "KIE_SERVER_JMS_QUEUES_RESPONSE",
             "value": "queue/KIE.SERVER.RESPONSE",
+            "required": false
+        },
+        {
+            "description": "JNDI name of executor queue for JMS.",
+            "name": "KIE_SERVER_EXECUTOR_JMS_QUEUE",
+            "value": "queue/KIE.SERVER.EXECUTOR",
             "required": false
         },
         {
@@ -139,7 +145,7 @@
         {
             "description": "Queue names, separated by commas. These queues will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP.",
             "name": "MQ_QUEUES",
-            "value": "KIE.SERVER.REQUEST,KIE.SERVER.RESPONSE,KIE.EXECUTOR",
+            "value": "KIE.SERVER.REQUEST,KIE.SERVER.RESPONSE,KIE.SERVER.EXECUTOR",
             "required": false
         },
         {
@@ -616,12 +622,16 @@
                                         "value": "${KIE_SERVER_DOMAIN}"
                                     },
                                     {
-                                        "name": "KIE_SERVER_EXECUTOR_JMS_QUEUE",
-                                        "value": "${KIE_SERVER_EXECUTOR_JMS_QUEUE}"
+                                        "name": "KIE_SERVER_JMS_QUEUES_REQUEST",
+                                        "value": "${KIE_SERVER_JMS_QUEUES_REQUEST}"
                                     },
                                     {
                                         "name": "KIE_SERVER_JMS_QUEUES_RESPONSE",
                                         "value": "${KIE_SERVER_JMS_QUEUES_RESPONSE}"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_EXECUTOR_JMS_QUEUE",
+                                        "value": "${KIE_SERVER_EXECUTOR_JMS_QUEUE}"
                                     },
                                     {
                                         "name": "MQ_SERVICE_PREFIX_MAPPING",
@@ -843,7 +853,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "jboss-amq-62:1.2"
+                                "name": "jboss-amq-62:1.3"
                             }
                         }
                     },
@@ -933,14 +943,6 @@
                                     {
                                         "name": "AMQ_TRANSPORTS",
                                         "value": "${MQ_PROTOCOL}"
-                                    },
-                                    {
-                                        "name": "AMQ_QUEUES",
-                                        "value": "${MQ_QUEUES}"
-                                    },
-                                    {
-                                        "name": "AMQ_TOPICS",
-                                        "value": "${MQ_TOPICS}"
                                     },
                                     {
                                         "name": "AMQ_ADMIN_USERNAME",

--- a/processserver/processserver63-amq-postgresql-persistent-s2i.json
+++ b/processserver/processserver63-amq-postgresql-persistent-s2i.json
@@ -59,15 +59,21 @@
             "required": false
         },
         {
-            "description": "JNDI name of executor queue for JMS.",
-            "name": "KIE_SERVER_EXECUTOR_JMS_QUEUE",
-            "value": "queue/KIE.EXECUTOR",
+            "description": "JNDI name of request queue for JMS.",
+            "name": "KIE_SERVER_JMS_QUEUES_REQUEST",
+            "value": "queue/KIE.SERVER.REQUEST",
             "required": false
         },
         {
             "description": "JNDI name of response queue for JMS.",
             "name": "KIE_SERVER_JMS_QUEUES_RESPONSE",
             "value": "queue/KIE.SERVER.RESPONSE",
+            "required": false
+        },
+        {
+            "description": "JNDI name of executor queue for JMS.",
+            "name": "KIE_SERVER_EXECUTOR_JMS_QUEUE",
+            "value": "queue/KIE.SERVER.EXECUTOR",
             "required": false
         },
         {
@@ -145,7 +151,7 @@
         {
             "description": "Queue names, separated by commas. These queues will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP.",
             "name": "MQ_QUEUES",
-            "value": "KIE.SERVER.REQUEST,KIE.SERVER.RESPONSE,KIE.EXECUTOR",
+            "value": "KIE.SERVER.REQUEST,KIE.SERVER.RESPONSE,KIE.SERVER.EXECUTOR",
             "required": false
         },
         {
@@ -607,12 +613,16 @@
                                         "value": "${KIE_SERVER_DOMAIN}"
                                     },
                                     {
-                                        "name": "KIE_SERVER_EXECUTOR_JMS_QUEUE",
-                                        "value": "${KIE_SERVER_EXECUTOR_JMS_QUEUE}"
+                                        "name": "KIE_SERVER_JMS_QUEUES_REQUEST",
+                                        "value": "${KIE_SERVER_JMS_QUEUES_REQUEST}"
                                     },
                                     {
                                         "name": "KIE_SERVER_JMS_QUEUES_RESPONSE",
                                         "value": "${KIE_SERVER_JMS_QUEUES_RESPONSE}"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_EXECUTOR_JMS_QUEUE",
+                                        "value": "${KIE_SERVER_EXECUTOR_JMS_QUEUE}"
                                     },
                                     {
                                         "name": "MQ_SERVICE_PREFIX_MAPPING",
@@ -856,7 +866,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "jboss-amq-62:1.2"
+                                "name": "jboss-amq-62:1.3"
                             }
                         }
                     },
@@ -946,14 +956,6 @@
                                     {
                                         "name": "AMQ_TRANSPORTS",
                                         "value": "${MQ_PROTOCOL}"
-                                    },
-                                    {
-                                        "name": "AMQ_QUEUES",
-                                        "value": "${MQ_QUEUES}"
-                                    },
-                                    {
-                                        "name": "AMQ_TOPICS",
-                                        "value": "${MQ_TOPICS}"
                                     },
                                     {
                                         "name": "AMQ_ADMIN_USERNAME",

--- a/processserver/processserver63-amq-postgresql-s2i.json
+++ b/processserver/processserver63-amq-postgresql-s2i.json
@@ -59,15 +59,21 @@
             "required": false
         },
         {
-            "description": "JNDI name of executor queue for JMS.",
-            "name": "KIE_SERVER_EXECUTOR_JMS_QUEUE",
-            "value": "queue/KIE.EXECUTOR",
+            "description": "JNDI name of request queue for JMS.",
+            "name": "KIE_SERVER_JMS_QUEUES_REQUEST",
+            "value": "queue/KIE.SERVER.REQUEST",
             "required": false
         },
         {
             "description": "JNDI name of response queue for JMS.",
             "name": "KIE_SERVER_JMS_QUEUES_RESPONSE",
             "value": "queue/KIE.SERVER.RESPONSE",
+            "required": false
+        },
+        {
+            "description": "JNDI name of executor queue for JMS.",
+            "name": "KIE_SERVER_EXECUTOR_JMS_QUEUE",
+            "value": "queue/KIE.SERVER.EXECUTOR",
             "required": false
         },
         {
@@ -139,7 +145,7 @@
         {
             "description": "Queue names, separated by commas. These queues will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP.",
             "name": "MQ_QUEUES",
-            "value": "KIE.SERVER.REQUEST,KIE.SERVER.RESPONSE,KIE.EXECUTOR",
+            "value": "KIE.SERVER.REQUEST,KIE.SERVER.RESPONSE,KIE.SERVER.EXECUTOR",
             "required": false
         },
         {
@@ -601,12 +607,16 @@
                                         "value": "${KIE_SERVER_DOMAIN}"
                                     },
                                     {
-                                        "name": "KIE_SERVER_EXECUTOR_JMS_QUEUE",
-                                        "value": "${KIE_SERVER_EXECUTOR_JMS_QUEUE}"
+                                        "name": "KIE_SERVER_JMS_QUEUES_REQUEST",
+                                        "value": "${KIE_SERVER_JMS_QUEUES_REQUEST}"
                                     },
                                     {
                                         "name": "KIE_SERVER_JMS_QUEUES_RESPONSE",
                                         "value": "${KIE_SERVER_JMS_QUEUES_RESPONSE}"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_EXECUTOR_JMS_QUEUE",
+                                        "value": "${KIE_SERVER_EXECUTOR_JMS_QUEUE}"
                                     },
                                     {
                                         "name": "MQ_SERVICE_PREFIX_MAPPING",
@@ -816,7 +826,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "jboss-amq-62:1.2"
+                                "name": "jboss-amq-62:1.3"
                             }
                         }
                     },
@@ -906,14 +916,6 @@
                                     {
                                         "name": "AMQ_TRANSPORTS",
                                         "value": "${MQ_PROTOCOL}"
-                                    },
-                                    {
-                                        "name": "AMQ_QUEUES",
-                                        "value": "${MQ_QUEUES}"
-                                    },
-                                    {
-                                        "name": "AMQ_TOPICS",
-                                        "value": "${MQ_TOPICS}"
                                     },
                                     {
                                         "name": "AMQ_ADMIN_USERNAME",

--- a/processserver/processserver63-mysql-persistent-s2i.json
+++ b/processserver/processserver63-mysql-persistent-s2i.json
@@ -59,12 +59,6 @@
             "required": false
         },
         {
-            "description": "JNDI name of executor queue for JMS.",
-            "name": "KIE_SERVER_EXECUTOR_JMS_QUEUE",
-            "value": "queue/KIE.EXECUTOR",
-            "required": false
-        },
-        {
             "description": "Hibernate persistence dialect.",
             "name": "KIE_SERVER_PERSISTENCE_DIALECT",
             "value": "org.hibernate.dialect.MySQL5Dialect",
@@ -557,10 +551,6 @@
                                     {
                                         "name": "KIE_SERVER_DOMAIN",
                                         "value": "${KIE_SERVER_DOMAIN}"
-                                    },
-                                    {
-                                        "name": "KIE_SERVER_EXECUTOR_JMS_QUEUE",
-                                        "value": "${KIE_SERVER_EXECUTOR_JMS_QUEUE}"
                                     },
                                     {
                                         "name": "KIE_SERVER_PERSISTENCE_DIALECT",

--- a/processserver/processserver63-mysql-s2i.json
+++ b/processserver/processserver63-mysql-s2i.json
@@ -59,12 +59,6 @@
             "required": false
         },
         {
-            "description": "JNDI name of executor queue for JMS.",
-            "name": "KIE_SERVER_EXECUTOR_JMS_QUEUE",
-            "value": "queue/KIE.EXECUTOR",
-            "required": false
-        },
-        {
             "description": "Hibernate persistence dialect.",
             "name": "KIE_SERVER_PERSISTENCE_DIALECT",
             "value": "org.hibernate.dialect.MySQL5Dialect",
@@ -551,10 +545,6 @@
                                     {
                                         "name": "KIE_SERVER_DOMAIN",
                                         "value": "${KIE_SERVER_DOMAIN}"
-                                    },
-                                    {
-                                        "name": "KIE_SERVER_EXECUTOR_JMS_QUEUE",
-                                        "value": "${KIE_SERVER_EXECUTOR_JMS_QUEUE}"
                                     },
                                     {
                                         "name": "KIE_SERVER_PERSISTENCE_DIALECT",

--- a/processserver/processserver63-postgresql-persistent-s2i.json
+++ b/processserver/processserver63-postgresql-persistent-s2i.json
@@ -59,12 +59,6 @@
             "required": false
         },
         {
-            "description": "JNDI name of executor queue for JMS.",
-            "name": "KIE_SERVER_EXECUTOR_JMS_QUEUE",
-            "value": "queue/KIE.EXECUTOR",
-            "required": false
-        },
-        {
             "description": "Hibernate persistence dialect.",
             "name": "KIE_SERVER_PERSISTENCE_DIALECT",
             "value": "org.hibernate.dialect.PostgreSQL82Dialect",
@@ -542,10 +536,6 @@
                                     {
                                         "name": "KIE_SERVER_DOMAIN",
                                         "value": "${KIE_SERVER_DOMAIN}"
-                                    },
-                                    {
-                                        "name": "KIE_SERVER_EXECUTOR_JMS_QUEUE",
-                                        "value": "${KIE_SERVER_EXECUTOR_JMS_QUEUE}"
                                     },
                                     {
                                         "name": "KIE_SERVER_PERSISTENCE_DIALECT",

--- a/processserver/processserver63-postgresql-s2i.json
+++ b/processserver/processserver63-postgresql-s2i.json
@@ -59,12 +59,6 @@
             "required": false
         },
         {
-            "description": "JNDI name of executor queue for JMS.",
-            "name": "KIE_SERVER_EXECUTOR_JMS_QUEUE",
-            "value": "queue/KIE.EXECUTOR",
-            "required": false
-        },
-        {
             "description": "Hibernate persistence dialect.",
             "name": "KIE_SERVER_PERSISTENCE_DIALECT",
             "value": "org.hibernate.dialect.PostgreSQL82Dialect",
@@ -536,10 +530,6 @@
                                     {
                                         "name": "KIE_SERVER_DOMAIN",
                                         "value": "${KIE_SERVER_DOMAIN}"
-                                    },
-                                    {
-                                        "name": "KIE_SERVER_EXECUTOR_JMS_QUEUE",
-                                        "value": "${KIE_SERVER_EXECUTOR_JMS_QUEUE}"
                                     },
                                     {
                                         "name": "KIE_SERVER_PERSISTENCE_DIALECT",


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-584
[IPS] [DecisionServer] AMQ templates queues mismatch

https://issues.jboss.org/browse/CLOUD-589
CLOUD-589: [kie-server] Ability to specify KIE.SERVER.REQUEST queue

https://issues.jboss.org/browse/CLOUD-590
[kie-server] executor consumer ignores KIE_SERVER_EXECUTOR_JMS_QUEUE

https://issues.jboss.org/browse/CLOUD-605
[kie-server] "Disabling JMS support in executor" with non-AMQ templates