### PR TITLE
CLOUD-673: [IPS] Allow workflow for using multiple container versions with KIE_CONTAINER_REDIRCT_ENABLED in the default template

### DIFF
--- a/decisionserver/decisionserver63-amq-s2i.json
+++ b/decisionserver/decisionserver63-amq-s2i.json
@@ -16,18 +16,6 @@
     },
     "parameters": [
         {
-            "description": "The KIE Container deployment configuration in format: containerId=groupId:artifactId:version|c2=g2:a2:v2",
-            "name": "KIE_CONTAINER_DEPLOYMENT",
-            "value": "HelloRulesContainer=org.openshift.quickstarts:decisionserver-hellorules:1.3.0.Final",
-            "required": false
-        },
-        {
-            "description": "Whether KIE Container alias ids will be redirected to generated deployment ids.",
-            "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-            "value": "false",
-            "required": false
-        },
-        {
             "description": "The user name to access the KIE Server REST or JMS interface.",
             "name": "KIE_SERVER_USER",
             "value": "kieserver",
@@ -339,14 +327,6 @@
                     "type": "Source",
                     "sourceStrategy": {
                         "env": [
-                            {
-                                "name": "KIE_CONTAINER_DEPLOYMENT",
-                                "value": "${KIE_CONTAINER_DEPLOYMENT}"
-                            },
-                            {
-                                "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-                                "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
-                            }
                         ],
                         "forcePull": true,
                         "from": {
@@ -479,14 +459,6 @@
                                     }
                                 ],
                                 "env": [
-                                    {
-                                        "name": "KIE_CONTAINER_DEPLOYMENT",
-                                        "value": "${KIE_CONTAINER_DEPLOYMENT}"
-                                    },
-                                    {
-                                        "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-                                        "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
-                                    },
                                     {
                                         "name": "KIE_SERVER_USER",
                                         "value": "${KIE_SERVER_USER}"

--- a/decisionserver/decisionserver63-basic-s2i.json
+++ b/decisionserver/decisionserver63-basic-s2i.json
@@ -16,18 +16,6 @@
     },
     "parameters": [
         {
-            "description": "The KIE Container deployment configuration in format: containerId=groupId:artifactId:version|c2=g2:a2:v2",
-            "name": "KIE_CONTAINER_DEPLOYMENT",
-            "value": "HelloRulesContainer=org.openshift.quickstarts:decisionserver-hellorules:1.3.0.Final",
-            "required": false
-        },
-        {
-            "description": "Whether KIE Container alias ids will be redirected to generated deployment ids.",
-            "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-            "value": "false",
-            "required": false
-        },
-        {
             "description": "The user name to access the KIE Server REST or JMS interface.",
             "name": "KIE_SERVER_USER",
             "value": "kieserver",
@@ -187,14 +175,6 @@
                     "type": "Source",
                     "sourceStrategy": {
                         "env": [
-                            {
-                                "name": "KIE_CONTAINER_DEPLOYMENT",
-                                "value": "${KIE_CONTAINER_DEPLOYMENT}"
-                            },
-                            {
-                                "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-                                "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
-                            }
                         ],
                         "forcePull": true,
                         "from": {
@@ -314,14 +294,6 @@
                                     }
                                 ],
                                 "env": [
-                                    {
-                                        "name": "KIE_CONTAINER_DEPLOYMENT",
-                                        "value": "${KIE_CONTAINER_DEPLOYMENT}"
-                                    },
-                                    {
-                                        "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-                                        "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
-                                    },
                                     {
                                         "name": "KIE_SERVER_USER",
                                         "value": "${KIE_SERVER_USER}"

--- a/decisionserver/decisionserver63-https-s2i.json
+++ b/decisionserver/decisionserver63-https-s2i.json
@@ -16,18 +16,6 @@
     },
     "parameters": [
         {
-            "description": "The KIE Container deployment configuration in format: containerId=groupId:artifactId:version|c2=g2:a2:v2",
-            "name": "KIE_CONTAINER_DEPLOYMENT",
-            "value": "HelloRulesContainer=org.openshift.quickstarts:decisionserver-hellorules:1.3.0.Final",
-            "required": false
-        },
-        {
-            "description": "Whether KIE Container alias ids will be redirected to generated deployment ids.",
-            "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-            "value": "false",
-            "required": false
-        },
-        {
             "description": "The protocol to access the KIE Server REST interface.",
             "name": "KIE_SERVER_PROTOCOL",
             "value": "https",
@@ -276,14 +264,6 @@
                     "type": "Source",
                     "sourceStrategy": {
                         "env": [
-                            {
-                                "name": "KIE_CONTAINER_DEPLOYMENT",
-                                "value": "${KIE_CONTAINER_DEPLOYMENT}"
-                            },
-                            {
-                                "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-                                "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
-                            }
                         ],
                         "forcePull": true,
                         "from": {
@@ -416,14 +396,6 @@
                                     }
                                 ],
                                 "env": [
-                                    {
-                                        "name": "KIE_CONTAINER_DEPLOYMENT",
-                                        "value": "${KIE_CONTAINER_DEPLOYMENT}"
-                                    },
-                                    {
-                                        "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-                                        "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
-                                    },
                                     {
                                         "name": "KIE_SERVER_PROTOCOL",
                                         "value": "${KIE_SERVER_PROTOCOL}"

--- a/processserver/processserver63-amq-mysql-persistent-s2i.json
+++ b/processserver/processserver63-amq-mysql-persistent-s2i.json
@@ -16,18 +16,6 @@
     },
     "parameters": [
         {
-            "description": "The KIE Container deployment configuration in format: containerId=groupId:artifactId:version|c2=g2:a2:v2",
-            "name": "KIE_CONTAINER_DEPLOYMENT",
-            "value": "LibraryContainer=org.openshift.quickstarts:processserver-library:1.3.0.Final",
-            "required": false
-        },
-        {
-            "description": "Whether KIE Container alias ids will be redirected to generated deployment ids.",
-            "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-            "value": "false",
-            "required": false
-        },
-        {
             "description": "The protocol to access the KIE Server REST interface.",
             "name": "KIE_SERVER_PROTOCOL",
             "value": "https",
@@ -459,14 +447,6 @@
                     "type": "Source",
                     "sourceStrategy": {
                         "env": [
-                            {
-                                "name": "KIE_CONTAINER_DEPLOYMENT",
-                                "value": "${KIE_CONTAINER_DEPLOYMENT}"
-                            },
-                            {
-                                "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-                                "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
-                            }
                         ],
                         "forcePull": true,
                         "from": {
@@ -599,14 +579,6 @@
                                     }
                                 ],
                                 "env": [
-                                    {
-                                        "name": "KIE_CONTAINER_DEPLOYMENT",
-                                        "value": "${KIE_CONTAINER_DEPLOYMENT}"
-                                    },
-                                    {
-                                        "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-                                        "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
-                                    },
                                     {
                                         "name": "KIE_SERVER_PROTOCOL",
                                         "value": "${KIE_SERVER_PROTOCOL}"

--- a/processserver/processserver63-amq-mysql-s2i.json
+++ b/processserver/processserver63-amq-mysql-s2i.json
@@ -16,18 +16,6 @@
     },
     "parameters": [
         {
-            "description": "The KIE Container deployment configuration in format: containerId=groupId:artifactId:version|c2=g2:a2:v2",
-            "name": "KIE_CONTAINER_DEPLOYMENT",
-            "value": "LibraryContainer=org.openshift.quickstarts:processserver-library:1.3.0.Final",
-            "required": false
-        },
-        {
-            "description": "Whether KIE Container alias ids will be redirected to generated deployment ids.",
-            "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-            "value": "false",
-            "required": false
-        },
-        {
             "description": "The protocol to access the KIE Server REST interface.",
             "name": "KIE_SERVER_PROTOCOL",
             "value": "https",
@@ -453,14 +441,6 @@
                     "type": "Source",
                     "sourceStrategy": {
                         "env": [
-                            {
-                                "name": "KIE_CONTAINER_DEPLOYMENT",
-                                "value": "${KIE_CONTAINER_DEPLOYMENT}"
-                            },
-                            {
-                                "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-                                "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
-                            }
                         ],
                         "forcePull": true,
                         "from": {
@@ -593,14 +573,6 @@
                                     }
                                 ],
                                 "env": [
-                                    {
-                                        "name": "KIE_CONTAINER_DEPLOYMENT",
-                                        "value": "${KIE_CONTAINER_DEPLOYMENT}"
-                                    },
-                                    {
-                                        "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-                                        "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
-                                    },
                                     {
                                         "name": "KIE_SERVER_PROTOCOL",
                                         "value": "${KIE_SERVER_PROTOCOL}"

--- a/processserver/processserver63-amq-postgresql-persistent-s2i.json
+++ b/processserver/processserver63-amq-postgresql-persistent-s2i.json
@@ -16,18 +16,6 @@
     },
     "parameters": [
         {
-            "description": "The KIE Container deployment configuration in format: containerId=groupId:artifactId:version|c2=g2:a2:v2",
-            "name": "KIE_CONTAINER_DEPLOYMENT",
-            "value": "LibraryContainer=org.openshift.quickstarts:processserver-library:1.3.0.Final",
-            "required": false
-        },
-        {
-            "description": "Whether KIE Container alias ids will be redirected to generated deployment ids.",
-            "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-            "value": "false",
-            "required": false
-        },
-        {
             "description": "The protocol to access the KIE Server REST interface.",
             "name": "KIE_SERVER_PROTOCOL",
             "value": "https",
@@ -444,14 +432,6 @@
                     "type": "Source",
                     "sourceStrategy": {
                         "env": [
-                            {
-                                "name": "KIE_CONTAINER_DEPLOYMENT",
-                                "value": "${KIE_CONTAINER_DEPLOYMENT}"
-                            },
-                            {
-                                "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-                                "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
-                            }
                         ],
                         "forcePull": true,
                         "from": {
@@ -584,14 +564,6 @@
                                     }
                                 ],
                                 "env": [
-                                    {
-                                        "name": "KIE_CONTAINER_DEPLOYMENT",
-                                        "value": "${KIE_CONTAINER_DEPLOYMENT}"
-                                    },
-                                    {
-                                        "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-                                        "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
-                                    },
                                     {
                                         "name": "KIE_SERVER_PROTOCOL",
                                         "value": "${KIE_SERVER_PROTOCOL}"

--- a/processserver/processserver63-amq-postgresql-s2i.json
+++ b/processserver/processserver63-amq-postgresql-s2i.json
@@ -16,18 +16,6 @@
     },
     "parameters": [
         {
-            "description": "The KIE Container deployment configuration in format: containerId=groupId:artifactId:version|c2=g2:a2:v2",
-            "name": "KIE_CONTAINER_DEPLOYMENT",
-            "value": "LibraryContainer=org.openshift.quickstarts:processserver-library:1.3.0.Final",
-            "required": false
-        },
-        {
-            "description": "Whether KIE Container alias ids will be redirected to generated deployment ids.",
-            "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-            "value": "false",
-            "required": false
-        },
-        {
             "description": "The protocol to access the KIE Server REST interface.",
             "name": "KIE_SERVER_PROTOCOL",
             "value": "https",
@@ -438,14 +426,6 @@
                     "type": "Source",
                     "sourceStrategy": {
                         "env": [
-                            {
-                                "name": "KIE_CONTAINER_DEPLOYMENT",
-                                "value": "${KIE_CONTAINER_DEPLOYMENT}"
-                            },
-                            {
-                                "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-                                "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
-                            }
                         ],
                         "forcePull": true,
                         "from": {
@@ -578,14 +558,6 @@
                                     }
                                 ],
                                 "env": [
-                                    {
-                                        "name": "KIE_CONTAINER_DEPLOYMENT",
-                                        "value": "${KIE_CONTAINER_DEPLOYMENT}"
-                                    },
-                                    {
-                                        "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-                                        "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
-                                    },
                                     {
                                         "name": "KIE_SERVER_PROTOCOL",
                                         "value": "${KIE_SERVER_PROTOCOL}"

--- a/processserver/processserver63-basic-s2i.json
+++ b/processserver/processserver63-basic-s2i.json
@@ -16,18 +16,6 @@
     },
     "parameters": [
         {
-            "description": "The KIE Container deployment configuration in format: containerId=groupId:artifactId:version|c2=g2:a2:v2",
-            "name": "KIE_CONTAINER_DEPLOYMENT",
-            "value": "LibraryContainer=org.openshift.quickstarts:processserver-library:1.3.0.Final",
-            "required": false
-        },
-        {
-            "description": "Whether KIE Container alias ids will be redirected to generated deployment ids.",
-            "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-            "value": "false",
-            "required": false
-        },
-        {
             "description": "The user name to access the KIE Server REST or JMS interface.",
             "name": "KIE_SERVER_USER",
             "value": "kieserver",
@@ -193,14 +181,6 @@
                     "type": "Source",
                     "sourceStrategy": {
                         "env": [
-                            {
-                                "name": "KIE_CONTAINER_DEPLOYMENT",
-                                "value": "${KIE_CONTAINER_DEPLOYMENT}"
-                            },
-                            {
-                                "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-                                "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
-                            }
                         ],
                         "forcePull": true,
                         "from": {
@@ -320,14 +300,6 @@
                                     }
                                 ],
                                 "env": [
-                                    {
-                                        "name": "KIE_CONTAINER_DEPLOYMENT",
-                                        "value": "${KIE_CONTAINER_DEPLOYMENT}"
-                                    },
-                                    {
-                                        "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-                                        "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
-                                    },
                                     {
                                         "name": "KIE_SERVER_USER",
                                         "value": "${KIE_SERVER_USER}"

--- a/processserver/processserver63-mysql-persistent-s2i.json
+++ b/processserver/processserver63-mysql-persistent-s2i.json
@@ -16,18 +16,6 @@
     },
     "parameters": [
         {
-            "description": "The KIE Container deployment configuration in format: containerId=groupId:artifactId:version|c2=g2:a2:v2",
-            "name": "KIE_CONTAINER_DEPLOYMENT",
-            "value": "LibraryContainer=org.openshift.quickstarts:processserver-library:1.3.0.Final",
-            "required": false
-        },
-        {
-            "description": "Whether KIE Container alias ids will be redirected to generated deployment ids.",
-            "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-            "value": "false",
-            "required": false
-        },
-        {
             "description": "The protocol to access the KIE Server REST interface.",
             "name": "KIE_SERVER_PROTOCOL",
             "value": "https",
@@ -384,14 +372,6 @@
                     "type": "Source",
                     "sourceStrategy": {
                         "env": [
-                            {
-                                "name": "KIE_CONTAINER_DEPLOYMENT",
-                                "value": "${KIE_CONTAINER_DEPLOYMENT}"
-                            },
-                            {
-                                "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-                                "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
-                            }
                         ],
                         "forcePull": true,
                         "from": {
@@ -524,14 +504,6 @@
                                     }
                                 ],
                                 "env": [
-                                    {
-                                        "name": "KIE_CONTAINER_DEPLOYMENT",
-                                        "value": "${KIE_CONTAINER_DEPLOYMENT}"
-                                    },
-                                    {
-                                        "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-                                        "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
-                                    },
                                     {
                                         "name": "KIE_SERVER_PROTOCOL",
                                         "value": "${KIE_SERVER_PROTOCOL}"

--- a/processserver/processserver63-mysql-s2i.json
+++ b/processserver/processserver63-mysql-s2i.json
@@ -16,18 +16,6 @@
     },
     "parameters": [
         {
-            "description": "The KIE Container deployment configuration in format: containerId=groupId:artifactId:version|c2=g2:a2:v2",
-            "name": "KIE_CONTAINER_DEPLOYMENT",
-            "value": "LibraryContainer=org.openshift.quickstarts:processserver-library:1.3.0.Final",
-            "required": false
-        },
-        {
-            "description": "Whether KIE Container alias ids will be redirected to generated deployment ids.",
-            "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-            "value": "false",
-            "required": false
-        },
-        {
             "description": "The protocol to access the KIE Server REST interface.",
             "name": "KIE_SERVER_PROTOCOL",
             "value": "https",
@@ -378,14 +366,6 @@
                     "type": "Source",
                     "sourceStrategy": {
                         "env": [
-                            {
-                                "name": "KIE_CONTAINER_DEPLOYMENT",
-                                "value": "${KIE_CONTAINER_DEPLOYMENT}"
-                            },
-                            {
-                                "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-                                "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
-                            }
                         ],
                         "forcePull": true,
                         "from": {
@@ -518,14 +498,6 @@
                                     }
                                 ],
                                 "env": [
-                                    {
-                                        "name": "KIE_CONTAINER_DEPLOYMENT",
-                                        "value": "${KIE_CONTAINER_DEPLOYMENT}"
-                                    },
-                                    {
-                                        "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-                                        "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
-                                    },
                                     {
                                         "name": "KIE_SERVER_PROTOCOL",
                                         "value": "${KIE_SERVER_PROTOCOL}"

--- a/processserver/processserver63-postgresql-persistent-s2i.json
+++ b/processserver/processserver63-postgresql-persistent-s2i.json
@@ -16,18 +16,6 @@
     },
     "parameters": [
         {
-            "description": "The KIE Container deployment configuration in format: containerId=groupId:artifactId:version|c2=g2:a2:v2",
-            "name": "KIE_CONTAINER_DEPLOYMENT",
-            "value": "LibraryContainer=org.openshift.quickstarts:processserver-library:1.3.0.Final",
-            "required": false
-        },
-        {
-            "description": "Whether KIE Container alias ids will be redirected to generated deployment ids.",
-            "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-            "value": "false",
-            "required": false
-        },
-        {
             "description": "The protocol to access the KIE Server REST interface.",
             "name": "KIE_SERVER_PROTOCOL",
             "value": "https",
@@ -369,14 +357,6 @@
                     "type": "Source",
                     "sourceStrategy": {
                         "env": [
-                            {
-                                "name": "KIE_CONTAINER_DEPLOYMENT",
-                                "value": "${KIE_CONTAINER_DEPLOYMENT}"
-                            },
-                            {
-                                "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-                                "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
-                            }
                         ],
                         "forcePull": true,
                         "from": {
@@ -509,14 +489,6 @@
                                     }
                                 ],
                                 "env": [
-                                    {
-                                        "name": "KIE_CONTAINER_DEPLOYMENT",
-                                        "value": "${KIE_CONTAINER_DEPLOYMENT}"
-                                    },
-                                    {
-                                        "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-                                        "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
-                                    },
                                     {
                                         "name": "KIE_SERVER_PROTOCOL",
                                         "value": "${KIE_SERVER_PROTOCOL}"

--- a/processserver/processserver63-postgresql-s2i.json
+++ b/processserver/processserver63-postgresql-s2i.json
@@ -16,18 +16,6 @@
     },
     "parameters": [
         {
-            "description": "The KIE Container deployment configuration in format: containerId=groupId:artifactId:version|c2=g2:a2:v2",
-            "name": "KIE_CONTAINER_DEPLOYMENT",
-            "value": "LibraryContainer=org.openshift.quickstarts:processserver-library:1.3.0.Final",
-            "required": false
-        },
-        {
-            "description": "Whether KIE Container alias ids will be redirected to generated deployment ids.",
-            "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-            "value": "false",
-            "required": false
-        },
-        {
             "description": "The protocol to access the KIE Server REST interface.",
             "name": "KIE_SERVER_PROTOCOL",
             "value": "https",
@@ -363,14 +351,6 @@
                     "type": "Source",
                     "sourceStrategy": {
                         "env": [
-                            {
-                                "name": "KIE_CONTAINER_DEPLOYMENT",
-                                "value": "${KIE_CONTAINER_DEPLOYMENT}"
-                            },
-                            {
-                                "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-                                "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
-                            }
                         ],
                         "forcePull": true,
                         "from": {
@@ -503,14 +483,6 @@
                                     }
                                 ],
                                 "env": [
-                                    {
-                                        "name": "KIE_CONTAINER_DEPLOYMENT",
-                                        "value": "${KIE_CONTAINER_DEPLOYMENT}"
-                                    },
-                                    {
-                                        "name": "KIE_CONTAINER_REDIRECT_ENABLED",
-                                        "value": "${KIE_CONTAINER_REDIRECT_ENABLED}"
-                                    },
                                     {
                                         "name": "KIE_SERVER_PROTOCOL",
                                         "value": "${KIE_SERVER_PROTOCOL}"


### PR DESCRIPTION
CLOUD-673: [IPS] Allow workflow for using multiple container versions with KIE_CONTAINER_REDIRCT_ENABLED in the default template
https://issues.jboss.org/browse/CLOUD-673