### PR TITLE
CLOUD-813 add missing SERVICE_ACCOUNT_NAME parameter to eap70-sso-s2i

### DIFF
--- a/eap/eap70-sso-s2i.json
+++ b/eap/eap70-sso-s2i.json
@@ -64,6 +64,12 @@
             "required": false
         },
         {
+            "description": "The name of the service account to use for the deployment.  The service account should be configured to allow useage of the secret(s) specified by HTTPS_SECRET and JGROUPS_ENCRYPT_SECRET.",
+            "name": "SERVICE_ACCOUNT_NAME",
+            "value": "eap7-service-account",
+            "required": true
+        },
+        {
             "description": "The name of the secret containing the keystore file",
             "name": "HTTPS_SECRET",
             "value": "eap7-app-secret",

--- a/jboss-image-streams.json
+++ b/jboss-image-streams.json
@@ -260,7 +260,7 @@
                     {
                         "name": "1.3",
                         "annotations": {
-                            "description": "Red Hat SSO 7.0 Tech Preview",
+                            "description": "Red Hat SSO 7.0",
                             "iconClass": "icon-jboss",
                             "tags": "sso,keycloak,redhat",
                             "supports":"sso:7.0,xpaas:1.3",


### PR DESCRIPTION
Also removed "Tech Preview" from sso image stream description.