### PR TITLE
CLOUD-730: added missing AMQ_SPLIT template parameter

### DIFF
--- a/processserver/processserver63-amq-mysql-persistent-s2i.json
+++ b/processserver/processserver63-amq-mysql-persistent-s2i.json
@@ -137,6 +137,12 @@
             "required": false
         },
         {
+            "description": "Split the data directory for each node in a mesh.",
+            "name": "AMQ_SPLIT",
+            "value": "false",
+            "required": false
+        },
+        {
             "description": "Broker protocols to configure, separated by commas. Allowed values are: `openwire`, `amqp`, `stomp` and `mqtt`. Only `openwire` is supported by EAP.",
             "name": "MQ_PROTOCOL",
             "value": "openwire",

--- a/processserver/processserver63-amq-postgresql-persistent-s2i.json
+++ b/processserver/processserver63-amq-postgresql-persistent-s2i.json
@@ -137,6 +137,12 @@
             "required": false
         },
         {
+            "description": "Split the data directory for each node in a mesh.",
+            "name": "AMQ_SPLIT",
+            "value": "false",
+            "required": false
+        },
+        {
             "description": "Broker protocols to configure, separated by commas. Allowed values are: `openwire`, `amqp`, `stomp` and `mqtt`. Only `openwire` is supported by EAP.",
             "name": "MQ_PROTOCOL",
             "value": "openwire",


### PR DESCRIPTION
CLOUD-730: added missing AMQ_SPLIT template parameter
https://issues.jboss.org/browse/CLOUD-730

Added missing template parameter to:
processserver/processserver63-amq-mysql-persistent-s2i.json
processserver/processserver63-amq-postgresql-persistent-s2i.json