### PR TITLE
CLOUD-1068: Create "amq-service-account" as part of A-MQ application templates

### DIFF
--- a/amq/amq62-basic.json
+++ b/amq/amq62-basic.json
@@ -176,6 +176,13 @@
             }
         },
         {
+            "kind": "ServiceAccount",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "amq-service-account"
+            }
+        },
+        {
             "kind": "DeploymentConfig",
             "apiVersion": "v1",
             "metadata": {

--- a/amq/amq62-persistent-ssl.json
+++ b/amq/amq62-persistent-ssl.json
@@ -314,6 +314,13 @@
             }
         },
         {
+            "kind": "ServiceAccount",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "amq-service-account"
+            }
+        },
+        {
             "kind": "DeploymentConfig",
             "apiVersion": "v1",
             "metadata": {

--- a/amq/amq62-persistent.json
+++ b/amq/amq62-persistent.json
@@ -188,6 +188,13 @@
             }
         },
         {
+            "kind": "ServiceAccount",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "amq-service-account"
+            }
+        },
+        {
             "kind": "DeploymentConfig",
             "apiVersion": "v1",
             "metadata": {

--- a/amq/amq62-ssl.json
+++ b/amq/amq62-ssl.json
@@ -302,6 +302,13 @@
             }
         },
         {
+            "kind": "ServiceAccount",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "amq-service-account"
+            }
+        },
+        {
             "kind": "DeploymentConfig",
             "apiVersion": "v1",
             "metadata": {


### PR DESCRIPTION

Let's standardize the "amq-service-account" as the SA which is expected subsequently to be granted
'view' privilege in order to 'kube' mesh discovery agent to work properly.

This PR ensures 'amq-service-account' will be created when some of the A-MQ templates is deployed (the add-on of 'serviceAccountName' parameter with 'amq-service-account' value will be done as part of different PR -- since there's different JIRA for it already).

Please review.

Thank you, Jan.