### PR TITLE
[CLOUD-1349] HTTPS_SECRET is required as the field can't be blank

### DIFF
--- a/eap/eap64-mongodb-persistent-s2i.json
+++ b/eap/eap64-mongodb-persistent-s2i.json
@@ -91,7 +91,7 @@
             "description": "The name of the secret containing the keystore file",
             "name": "HTTPS_SECRET",
             "value": "eap-app-secret",
-            "required": false
+            "required": true
         },
         {
             "description": "The name of the keystore file within the secret",

--- a/eap/eap64-mongodb-s2i.json
+++ b/eap/eap64-mongodb-s2i.json
@@ -85,7 +85,7 @@
             "description": "The name of the secret containing the keystore file",
             "name": "HTTPS_SECRET",
             "value": "eap-app-secret",
-            "required": false
+            "required": true
         },
         {
             "description": "The name of the keystore file within the secret",

--- a/eap/eap64-mysql-persistent-s2i.json
+++ b/eap/eap64-mysql-persistent-s2i.json
@@ -91,7 +91,7 @@
             "description": "The name of the secret containing the keystore file",
             "name": "HTTPS_SECRET",
             "value": "eap-app-secret",
-            "required": false
+            "required": true
         },
         {
             "description": "The name of the keystore file within the secret",

--- a/eap/eap64-mysql-s2i.json
+++ b/eap/eap64-mysql-s2i.json
@@ -85,7 +85,7 @@
             "description": "The name of the secret containing the keystore file",
             "name": "HTTPS_SECRET",
             "value": "eap-app-secret",
-            "required": false
+            "required": true
         },
         {
             "description": "The name of the keystore file within the secret",

--- a/eap/eap64-postgresql-persistent-s2i.json
+++ b/eap/eap64-postgresql-persistent-s2i.json
@@ -91,7 +91,7 @@
             "description": "The name of the secret containing the keystore file",
             "name": "HTTPS_SECRET",
             "value": "eap-app-secret",
-            "required": false
+            "required": true
         },
         {
             "description": "The name of the keystore file within the secret",

--- a/eap/eap64-postgresql-s2i.json
+++ b/eap/eap64-postgresql-s2i.json
@@ -85,7 +85,7 @@
             "description": "The name of the secret containing the keystore file",
             "name": "HTTPS_SECRET",
             "value": "eap-app-secret",
-            "required": false
+            "required": true
         },
         {
             "description": "The name of the keystore file within the secret",

--- a/eap/eap70-mongodb-persistent-s2i.json
+++ b/eap/eap70-mongodb-persistent-s2i.json
@@ -91,7 +91,7 @@
             "description": "The name of the secret containing the keystore file",
             "name": "HTTPS_SECRET",
             "value": "eap7-app-secret",
-            "required": false
+            "required": true
         },
         {
             "description": "The name of the keystore file within the secret",

--- a/eap/eap70-mongodb-s2i.json
+++ b/eap/eap70-mongodb-s2i.json
@@ -85,7 +85,7 @@
             "description": "The name of the secret containing the keystore file",
             "name": "HTTPS_SECRET",
             "value": "eap7-app-secret",
-            "required": false
+            "required": true
         },
         {
             "description": "The name of the keystore file within the secret",

--- a/eap/eap70-mysql-persistent-s2i.json
+++ b/eap/eap70-mysql-persistent-s2i.json
@@ -91,7 +91,7 @@
             "description": "The name of the secret containing the keystore file",
             "name": "HTTPS_SECRET",
             "value": "eap7-app-secret",
-            "required": false
+            "required": true
         },
         {
             "description": "The name of the keystore file within the secret",

--- a/eap/eap70-mysql-s2i.json
+++ b/eap/eap70-mysql-s2i.json
@@ -85,7 +85,7 @@
             "description": "The name of the secret containing the keystore file",
             "name": "HTTPS_SECRET",
             "value": "eap7-app-secret",
-            "required": false
+            "required": true
         },
         {
             "description": "The name of the keystore file within the secret",

--- a/eap/eap70-postgresql-persistent-s2i.json
+++ b/eap/eap70-postgresql-persistent-s2i.json
@@ -91,7 +91,7 @@
             "description": "The name of the secret containing the keystore file",
             "name": "HTTPS_SECRET",
             "value": "eap7-app-secret",
-            "required": false
+            "required": true
         },
         {
             "description": "The name of the keystore file within the secret",

--- a/eap/eap70-postgresql-s2i.json
+++ b/eap/eap70-postgresql-s2i.json
@@ -85,7 +85,7 @@
             "description": "The name of the secret containing the keystore file",
             "name": "HTTPS_SECRET",
             "value": "eap7-app-secret",
-            "required": false
+            "required": true
         },
         {
             "description": "The name of the keystore file within the secret",


### PR DESCRIPTION
Currently, HTTPS_SECRET parameter is not required but it has a default
value. If the default value is removed and the field is blank, the app
deployment will fail as it needs the value of the field. As a result,
the parameter should be marked as required to avoid users to remove
the default value.

The parameter is changed to required: "true" to enforce users to either
keep the default value or provide a new value and can't keep the field
blank to avoid failure.

JIRA: CLOUD-1349
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1418013

Signed-off-by: Vu Dinh <vdinh@redhat.com>