### PR TITLE
[CLOUD-940] Expose the MAVEN_MIRROR_URL variable for JDV

### DIFF
--- a/datavirt/datavirt63-basic-s2i.json
+++ b/datavirt/datavirt63-basic-s2i.json
@@ -140,6 +140,13 @@
             "name": "VDB_DIRS",
             "value": "",
             "required": false
+        },
+        {
+            "displayName": "Maven mirror URL",
+            "description": "Maven mirror to use for S2I builds",
+            "name": "MAVEN_MIRROR_URL",
+            "value": "",
+            "required": false
         }
     ],
     "objects": [
@@ -242,6 +249,12 @@
                 "strategy": {
                     "type": "Source",
                     "sourceStrategy": {
+                        "env": [
+                            {
+                                "name": "MAVEN_MIRROR_URL",
+                                "value": "${MAVEN_MIRROR_URL}"
+                            }
+                        ],
                         "forcePull": true,
                         "from": {
                             "kind": "ImageStreamTag",

--- a/datavirt/datavirt63-extensions-support-s2i.json
+++ b/datavirt/datavirt63-extensions-support-s2i.json
@@ -245,6 +245,13 @@
             "name": "VDB_DIRS",
             "value": "",
             "required": false
+        },
+        {
+            "displayName": "Maven mirror URL",
+            "description": "Maven mirror to use for S2I builds",
+            "name": "MAVEN_MIRROR_URL",
+            "value": "",
+            "required": false
         }
     ],
     "objects": [
@@ -494,6 +501,10 @@
                             {
                                 "name": "VDB_DIRS",
                                 "value": "${VDB_DIRS}"
+                            },
+                            {
+                                "name": "MAVEN_MIRROR_URL",
+                                "value": "${MAVEN_MIRROR_URL}"
                             }
                         ]
                     }

--- a/datavirt/datavirt63-secure-s2i.json
+++ b/datavirt/datavirt63-secure-s2i.json
@@ -358,6 +358,13 @@
             "displayName": "SSO SAML Deployments",
             "value": "",
             "required": false
+        },
+        {
+            "displayName": "Maven mirror URL",
+            "description": "Maven mirror to use for S2I builds",
+            "name": "MAVEN_MIRROR_URL",
+            "value": "",
+            "required": false
         }
     ],
     "objects": [
@@ -522,6 +529,12 @@
                 "strategy": {
                     "type": "Source",
                     "sourceStrategy": {
+                        "env": [
+                            {
+                                "name": "MAVEN_MIRROR_URL",
+                                "value": "${MAVEN_MIRROR_URL}"
+                            }
+                        ],
                         "forcePull": true,
                         "from": {
                             "kind": "ImageStreamTag",


### PR DESCRIPTION
If set, it will be used by s2i while building sources.
Replaces [#242](https://github.com/jboss-openshift/application-templates/pull/242)
