### PR TITLE
[CLOUD-1382] [CLOUD-1383] Add openshift.io/display-name to all image stream tag definitions

### DIFF
--- a/jboss-image-streams.json
+++ b/jboss-image-streams.json
@@ -23,7 +23,7 @@
                             "description": "JBoss Web Server 3.0 Tomcat 7 S2I images.",
                             "iconClass": "icon-jboss",
                             "tags": "builder,tomcat,tomcat7,java,jboss,xpaas",
-                            "supports":"tomcat7:3.0,tomcat:7,java:8,xpaas:1.1",
+                            "supports": "tomcat7:3.0,tomcat:7,java:8,xpaas:1.1",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
                             "sampleContextDir": "tomcat-websocket-chat",
                             "version": "1.1"
@@ -35,7 +35,7 @@
                             "description": "JBoss Web Server 3.0 Tomcat 7 S2I images.",
                             "iconClass": "icon-jboss",
                             "tags": "builder,tomcat,tomcat7,java,jboss,xpaas",
-                            "supports":"tomcat7:3.0,tomcat:7,java:8,xpaas:1.2",
+                            "supports": "tomcat7:3.0,tomcat:7,java:8,xpaas:1.2",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
                             "sampleContextDir": "tomcat-websocket-chat",
                             "version": "1.2"
@@ -59,7 +59,7 @@
                             "description": "JBoss Web Server 3.0 Tomcat 8 S2I images.",
                             "iconClass": "icon-jboss",
                             "tags": "builder,tomcat,tomcat8,java,jboss,xpaas",
-                            "supports":"tomcat8:3.0,tomcat:8,java:8,xpaas:1.1",
+                            "supports": "tomcat8:3.0,tomcat:8,java:8,xpaas:1.1",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
                             "sampleContextDir": "tomcat-websocket-chat",
                             "version": "1.1"
@@ -71,7 +71,7 @@
                             "description": "JBoss Web Server 3.0 Tomcat 8 S2I images.",
                             "iconClass": "icon-jboss",
                             "tags": "builder,tomcat,tomcat8,java,jboss,xpaas",
-                            "supports":"tomcat8:3.0,tomcat:8,java:8,xpaas:1.2",
+                            "supports": "tomcat8:3.0,tomcat:8,java:8,xpaas:1.2",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
                             "sampleContextDir": "tomcat-websocket-chat",
                             "version": "1.2"
@@ -95,7 +95,7 @@
                             "description": "JBoss EAP 6.4 S2I images.",
                             "iconClass": "icon-jboss",
                             "tags": "builder,eap,javaee,java,jboss,xpaas",
-                            "supports":"eap:6.4,javaee:6,java:8,xpaas:1.1",
+                            "supports": "eap:6.4,javaee:6,java:8,xpaas:1.1",
                             "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
                             "sampleContextDir": "kitchensink",
                             "sampleRef": "6.4.x",
@@ -108,7 +108,7 @@
                             "description": "JBoss EAP 6.4 S2I images.",
                             "iconClass": "icon-jboss",
                             "tags": "builder,eap,javaee,java,jboss,xpaas",
-                            "supports":"eap:6.4,javaee:6,java:8,xpaas:1.2",
+                            "supports": "eap:6.4,javaee:6,java:8,xpaas:1.2",
                             "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
                             "sampleContextDir": "kitchensink",
                             "sampleRef": "6.4.x",
@@ -121,7 +121,7 @@
                             "description": "JBoss EAP 6.4 S2I images.",
                             "iconClass": "icon-jboss",
                             "tags": "builder,eap,javaee,java,jboss,xpaas",
-                            "supports":"eap:6.4,javaee:6,java:8,xpaas:1.3",
+                            "supports": "eap:6.4,javaee:6,java:8,xpaas:1.3",
                             "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
                             "sampleContextDir": "kitchensink",
                             "sampleRef": "6.4.x",
@@ -134,7 +134,7 @@
                             "description": "JBoss EAP 6.4 S2I images.",
                             "iconClass": "icon-jboss",
                             "tags": "builder,eap,javaee,java,jboss,xpaas",
-                            "supports":"eap:6.4,javaee:6,java:8,xpaas:1.4",
+                            "supports": "eap:6.4,javaee:6,java:8,xpaas:1.4",
                             "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
                             "sampleContextDir": "kitchensink",
                             "sampleRef": "6.4.x",
@@ -159,7 +159,7 @@
                             "description": "JBoss EAP 7.0 S2I images.",
                             "iconClass": "icon-jboss",
                             "tags": "builder,eap,javaee,java,jboss,xpaas",
-                            "supports":"eap:7.0,javaee:7,java:8,xpaas:1.3",
+                            "supports": "eap:7.0,javaee:7,java:8,xpaas:1.3",
                             "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
                             "sampleContextDir": "kitchensink",
                             "sampleRef": "7.0.0.GA",
@@ -172,7 +172,7 @@
                             "description": "JBoss EAP 7.0 S2I images.",
                             "iconClass": "icon-jboss",
                             "tags": "builder,eap,javaee,java,jboss,xpaas",
-                            "supports":"eap:7.0,javaee:7,java:8,xpaas:1.4",
+                            "supports": "eap:7.0,javaee:7,java:8,xpaas:1.4",
                             "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
                             "sampleContextDir": "kitchensink",
                             "sampleRef": "7.0.0.GA",
@@ -197,7 +197,7 @@
                             "description": "Red Hat JBoss BRMS 6.2 decision server S2I images.",
                             "iconClass": "icon-jboss",
                             "tags": "builder,decisionserver,xpaas",
-                            "supports":"decisionserver:6.2,xpaas:1.2",
+                            "supports": "decisionserver:6.2,xpaas:1.2",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
                             "sampleContextDir": "decisionserver/hellorules",
                             "sampleRef": "1.2",
@@ -222,7 +222,7 @@
                             "description": "Red Hat JBoss BRMS 6.3 decision server S2I images.",
                             "iconClass": "icon-jboss",
                             "tags": "builder,decisionserver,xpaas",
-                            "supports":"decisionserver:6.3,xpaas:1.3",
+                            "supports": "decisionserver:6.3,xpaas:1.3",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
                             "sampleContextDir": "decisionserver/hellorules",
                             "sampleRef": "1.3",
@@ -247,7 +247,7 @@
                             "description": "Red Hat JBoss BPM Suite 6.3 intelligent process server S2I images.",
                             "iconClass": "icon-jboss",
                             "tags": "builder,processserver,xpaas",
-                            "supports":"processserver:6.3,xpaas:1.3",
+                            "supports": "processserver:6.3,xpaas:1.3",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
                             "sampleContextDir": "processserver/library",
                             "sampleRef": "1.3",
@@ -272,7 +272,7 @@
                             "description": "JBoss Data Grid 6.5 S2I images.",
                             "iconClass": "icon-jboss",
                             "tags": "datagrid,jboss,xpaas",
-                            "supports":"datagrid:6.5,xpaas:1.2",
+                            "supports": "datagrid:6.5,xpaas:1.2",
                             "version": "1.2"
                         }
                     },
@@ -282,7 +282,7 @@
                             "description": "JBoss Data Grid 6.5 S2I images.",
                             "iconClass": "icon-jboss",
                             "tags": "datagrid,jboss,xpaas",
-                            "supports":"datagrid:6.5,xpaas:1.4",
+                            "supports": "datagrid:6.5,xpaas:1.4",
                             "version": "1.3"
                         }
                     }
@@ -325,7 +325,7 @@
                             "description": "Red Hat JBoss Data Virtualization 6.3 S2I images.",
                             "iconClass": "icon-jboss",
                             "tags": "datavirt,jboss,xpaas",
-                            "supports":"datavirt:6.3,xpaas:1.4",
+                            "supports": "datavirt:6.3,xpaas:1.4",
                             "version": "1.0"
                         }
                     },
@@ -335,7 +335,7 @@
                             "description": "Red Hat JBoss Data Virtualization 6.3 S2I images.",
                             "iconClass": "icon-jboss",
                             "tags": "datavirt,jboss,xpaas",
-                            "supports":"datavirt:6.3,xpaas:1.4",
+                            "supports": "datavirt:6.3,xpaas:1.4",
                             "version": "1.1"
                         }
                     }
@@ -378,7 +378,7 @@
                             "description": "JBoss A-MQ 6.2 broker image.",
                             "iconClass": "icon-jboss",
                             "tags": "messaging,amq,jboss,xpaas",
-                            "supports":"amq:6.2,messaging,xpaas:1.1",
+                            "supports": "amq:6.2,messaging,xpaas:1.1",
                             "version": "1.1"
                         }
                     },
@@ -388,7 +388,7 @@
                             "description": "JBoss A-MQ 6.2 broker image.",
                             "iconClass": "icon-jboss",
                             "tags": "messaging,amq,jboss,xpaas",
-                            "supports":"amq:6.2,messaging,xpaas:1.2",
+                            "supports": "amq:6.2,messaging,xpaas:1.2",
                             "version": "1.2"
                         }
                     },
@@ -398,7 +398,7 @@
                             "description": "JBoss A-MQ 6.2 broker image.",
                             "iconClass": "icon-jboss",
                             "tags": "messaging,amq,jboss,xpaas",
-                            "supports":"amq:6.2,messaging,xpaas:1.3",
+                            "supports": "amq:6.2,messaging,xpaas:1.3",
                             "version": "1.3"
                         }
                     }
@@ -410,7 +410,7 @@
             "apiVersion": "v1",
             "metadata": {
                 "name": "redhat-sso70-openshift",
-                 "annotations": {
+                "annotations": {
                     "description": "Red Hat SSO 7.0"
                 }
             },
@@ -423,7 +423,7 @@
                             "description": "Red Hat SSO 7.0",
                             "iconClass": "icon-jboss",
                             "tags": "sso,keycloak,redhat",
-                            "supports":"sso:7.0,xpaas:1.3",
+                            "supports": "sso:7.0,xpaas:1.3",
                             "version": "1.3"
                         }
                     },
@@ -433,7 +433,7 @@
                             "description": "Red Hat SSO 7.0",
                             "iconClass": "icon-jboss",
                             "tags": "sso,keycloak,redhat",
-                            "supports":"sso:7.0,xpaas:1.4",
+                            "supports": "sso:7.0,xpaas:1.4",
                             "version": "1.4"
                         }
                     }
@@ -445,7 +445,7 @@
             "apiVersion": "v1",
             "metadata": {
                 "name": "redhat-sso71-openshift",
-                 "annotations": {
+                "annotations": {
                     "description": "Red Hat SSO 7.1"
                 }
             },
@@ -458,7 +458,7 @@
                             "description": "Red Hat SSO 7.1",
                             "iconClass": "icon-jboss",
                             "tags": "sso,keycloak,redhat",
-                            "supports":"sso:7.1,xpaas:1.4",
+                            "supports": "sso:7.1,xpaas:1.4",
                             "version": "1.0"
                         }
                     }
@@ -481,7 +481,7 @@
                             "description": "Build and run Java applications using Maven and OpenJDK 8.",
                             "iconClass": "icon-jboss",
                             "tags": "builder,java,xpaas,openjdk",
-                            "supports":"java:8,xpaas:1.0",
+                            "supports": "java:8,xpaas:1.0",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
                             "sampleContextDir": "undertow-servlet",
                             "version": "1.0"

--- a/jboss-image-streams.json
+++ b/jboss-image-streams.json
@@ -29,7 +29,8 @@
                             "supports": "tomcat7:3.0,tomcat:7,java:8,xpaas:1.1",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
                             "sampleContextDir": "tomcat-websocket-chat",
-                            "version": "1.1"
+                            "version": "1.1",
+                            "openshift.io/display-name": "Red Hat JBoss Web Server 3.0 Tomcat 7"
                         }
                     },
                     {
@@ -41,7 +42,8 @@
                             "supports": "tomcat7:3.0,tomcat:7,java:8,xpaas:1.2",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
                             "sampleContextDir": "tomcat-websocket-chat",
-                            "version": "1.2"
+                            "version": "1.2",
+                            "openshift.io/display-name": "Red Hat JBoss Web Server 3.0 Tomcat 7"
                         }
                     }
                 ]
@@ -68,7 +70,8 @@
                             "supports": "tomcat8:3.0,tomcat:8,java:8,xpaas:1.1",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
                             "sampleContextDir": "tomcat-websocket-chat",
-                            "version": "1.1"
+                            "version": "1.1",
+                            "openshift.io/display-name": "Red Hat JBoss Web Server 3.0 Tomcat 8"
                         }
                     },
                     {
@@ -80,7 +83,8 @@
                             "supports": "tomcat8:3.0,tomcat:8,java:8,xpaas:1.2",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
                             "sampleContextDir": "tomcat-websocket-chat",
-                            "version": "1.2"
+                            "version": "1.2",
+                            "openshift.io/display-name": "Red Hat JBoss Web Server 3.0 Tomcat 8"
                         }
                     }
                 ]
@@ -108,7 +112,8 @@
                             "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
                             "sampleContextDir": "kitchensink",
                             "sampleRef": "6.4.x",
-                            "version": "1.1"
+                            "version": "1.1",
+                            "openshift.io/display-name": "Red Hat JBoss EAP 6.4"
                         }
                     },
                     {
@@ -121,7 +126,8 @@
                             "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
                             "sampleContextDir": "kitchensink",
                             "sampleRef": "6.4.x",
-                            "version": "1.2"
+                            "version": "1.2",
+                            "openshift.io/display-name": "Red Hat JBoss EAP 6.4"
                         }
                     },
                     {
@@ -134,7 +140,8 @@
                             "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
                             "sampleContextDir": "kitchensink",
                             "sampleRef": "6.4.x",
-                            "version": "1.3"
+                            "version": "1.3",
+                            "openshift.io/display-name": "Red Hat JBoss EAP 6.4"
                         }
                     },
                     {
@@ -147,7 +154,8 @@
                             "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
                             "sampleContextDir": "kitchensink",
                             "sampleRef": "6.4.x",
-                            "version": "1.4"
+                            "version": "1.4",
+                            "openshift.io/display-name": "Red Hat JBoss EAP 6.4"
                         }
                     }
                 ]
@@ -175,7 +183,8 @@
                             "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
                             "sampleContextDir": "kitchensink",
                             "sampleRef": "7.0.0.GA",
-                            "version": "1.3"
+                            "version": "1.3",
+                            "openshift.io/display-name": "Red Hat JBoss EAP 7.0"
                         }
                     },
                     {
@@ -188,7 +197,8 @@
                             "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
                             "sampleContextDir": "kitchensink",
                             "sampleRef": "7.0.0.GA",
-                            "version": "1.4"
+                            "version": "1.4",
+                            "openshift.io/display-name": "Red Hat JBoss EAP 7.0"
                         }
                     }
                 ]
@@ -216,7 +226,8 @@
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
                             "sampleContextDir": "decisionserver/hellorules",
                             "sampleRef": "1.2",
-                            "version": "1.2"
+                            "version": "1.2",
+                            "openshift.io/display-name": "Red Hat JBoss BRMS 6.2 decision server"
                         }
                     }
                 ]
@@ -244,7 +255,8 @@
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
                             "sampleContextDir": "decisionserver/hellorules",
                             "sampleRef": "1.3",
-                            "version": "1.3"
+                            "version": "1.3",
+                            "openshift.io/display-name": "Red Hat JBoss BRMS 6.3 decision server"
                         }
                     }
                 ]
@@ -272,7 +284,8 @@
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
                             "sampleContextDir": "processserver/library",
                             "sampleRef": "1.3",
-                            "version": "1.3"
+                            "version": "1.3",
+                            "openshift.io/display-name": "Red Hat JBoss BPM Suite 6.3 intelligent process server"
                         }
                     }
                 ]
@@ -297,7 +310,8 @@
                             "iconClass": "icon-jboss",
                             "tags": "datagrid,jboss,xpaas",
                             "supports": "datagrid:6.5,xpaas:1.2",
-                            "version": "1.2"
+                            "version": "1.2",
+                            "openshift.io/display-name": "Red Hat JBoss Data Grid 6.5"
                         }
                     },
                     {
@@ -307,7 +321,8 @@
                             "iconClass": "icon-jboss",
                             "tags": "datagrid,jboss,xpaas",
                             "supports": "datagrid:6.5,xpaas:1.4",
-                            "version": "1.3"
+                            "version": "1.3",
+                            "openshift.io/display-name": "Red Hat JBoss Data Grid 6.5"
                         }
                     }
                 ]
@@ -331,7 +346,8 @@
                             "description": "JBoss Data Grid 6.5 Client Modules for EAP.",
                             "iconClass": "icon-jboss",
                             "tags": "client,jboss,xpaas",
-                            "version": "1.0"
+                            "version": "1.0",
+                            "openshift.io/display-name": "Red Hat JBoss Data Grid 6.5 Client Modules for EAP"
                         }
                     }
                 ]
@@ -356,7 +372,8 @@
                             "iconClass": "icon-jboss",
                             "tags": "datavirt,jboss,xpaas",
                             "supports": "datavirt:6.3,xpaas:1.4",
-                            "version": "1.0"
+                            "version": "1.0",
+                            "openshift.io/display-name": "Red Hat JBoss Data Virtualization 6.3"
                         }
                     },
                     {
@@ -366,7 +383,8 @@
                             "iconClass": "icon-jboss",
                             "tags": "datavirt,jboss,xpaas",
                             "supports": "datavirt:6.3,xpaas:1.4",
-                            "version": "1.1"
+                            "version": "1.1",
+                            "openshift.io/display-name": "Red Hat JBoss Data Virtualization 6.3"
                         }
                     }
                 ]
@@ -390,7 +408,8 @@
                             "description": "JBoss Data Virtualization 6.5 JDBC Driver Modules for EAP.",
                             "iconClass": "icon-jboss",
                             "tags": "client,jboss,xpaas",
-                            "version": "1.0"
+                            "version": "1.0",
+                            "openshift.io/display-name": "Red Hat JBoss Data Virtualization 6.5 JDBC Driver Modules for EAP"
                         }
                     }
                 ]
@@ -415,7 +434,8 @@
                             "iconClass": "icon-jboss",
                             "tags": "messaging,amq,jboss,xpaas",
                             "supports": "amq:6.2,messaging,xpaas:1.1",
-                            "version": "1.1"
+                            "version": "1.1",
+                            "openshift.io/display-name": "Red Hat JBoss A-MQ 6.2"
                         }
                     },
                     {
@@ -425,7 +445,8 @@
                             "iconClass": "icon-jboss",
                             "tags": "messaging,amq,jboss,xpaas",
                             "supports": "amq:6.2,messaging,xpaas:1.2",
-                            "version": "1.2"
+                            "version": "1.2",
+                            "openshift.io/display-name": "Red Hat JBoss A-MQ 6.2"
                         }
                     },
                     {
@@ -435,7 +456,8 @@
                             "iconClass": "icon-jboss",
                             "tags": "messaging,amq,jboss,xpaas",
                             "supports": "amq:6.2,messaging,xpaas:1.3",
-                            "version": "1.3"
+                            "version": "1.3",
+                            "openshift.io/display-name": "Red Hat JBoss A-MQ 6.2"
                         }
                     }
                 ]
@@ -461,7 +483,8 @@
                             "iconClass": "icon-jboss",
                             "tags": "sso,keycloak,redhat",
                             "supports": "sso:7.0,xpaas:1.3",
-                            "version": "1.3"
+                            "version": "1.3",
+                            "openshift.io/display-name": "Red Hat Single Sign-On 7.0"
                         }
                     },
                     {
@@ -471,7 +494,8 @@
                             "iconClass": "icon-jboss",
                             "tags": "sso,keycloak,redhat",
                             "supports": "sso:7.0,xpaas:1.4",
-                            "version": "1.4"
+                            "version": "1.4",
+                            "openshift.io/display-name": "Red Hat Single Sign-On 7.0"
                         }
                     }
                 ]
@@ -497,7 +521,8 @@
                             "iconClass": "icon-jboss",
                             "tags": "sso,keycloak,redhat",
                             "supports": "sso:7.1,xpaas:1.4",
-                            "version": "1.0"
+                            "version": "1.0",
+                            "openshift.io/display-name": "Red Hat Single Sign-On 7.1"
                         }
                     }
                 ]

--- a/jboss-image-streams.json
+++ b/jboss-image-streams.json
@@ -12,7 +12,10 @@
             "kind": "ImageStream",
             "apiVersion": "v1",
             "metadata": {
-                "name": "jboss-webserver30-tomcat7-openshift"
+                "name": "jboss-webserver30-tomcat7-openshift",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat JBoss Web Server 3.0 Tomcat 7"
+                }
             },
             "spec": {
                 "dockerImageRepository": "registry.access.redhat.com/jboss-webserver-3/webserver30-tomcat7-openshift",
@@ -48,7 +51,10 @@
             "kind": "ImageStream",
             "apiVersion": "v1",
             "metadata": {
-                "name": "jboss-webserver30-tomcat8-openshift"
+                "name": "jboss-webserver30-tomcat8-openshift",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat JBoss Web Server 3.0 Tomcat 8"
+                }
             },
             "spec": {
                 "dockerImageRepository": "registry.access.redhat.com/jboss-webserver-3/webserver30-tomcat8-openshift",
@@ -84,7 +90,10 @@
             "kind": "ImageStream",
             "apiVersion": "v1",
             "metadata": {
-                "name": "jboss-eap64-openshift"
+                "name": "jboss-eap64-openshift",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat JBoss EAP 6.4"
+                }
             },
             "spec": {
                 "dockerImageRepository": "registry.access.redhat.com/jboss-eap-6/eap64-openshift",
@@ -148,7 +157,10 @@
             "kind": "ImageStream",
             "apiVersion": "v1",
             "metadata": {
-                "name": "jboss-eap70-openshift"
+                "name": "jboss-eap70-openshift",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat JBoss EAP 7.0"
+                }
             },
             "spec": {
                 "dockerImageRepository": "registry.access.redhat.com/jboss-eap-7/eap70-openshift",
@@ -186,7 +198,10 @@
             "kind": "ImageStream",
             "apiVersion": "v1",
             "metadata": {
-                "name": "jboss-decisionserver62-openshift"
+                "name": "jboss-decisionserver62-openshift",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat JBoss BRMS 6.2 decision server"
+                }
             },
             "spec": {
                 "dockerImageRepository": "registry.access.redhat.com/jboss-decisionserver-6/decisionserver62-openshift",
@@ -211,7 +226,10 @@
             "kind": "ImageStream",
             "apiVersion": "v1",
             "metadata": {
-                "name": "jboss-decisionserver63-openshift"
+                "name": "jboss-decisionserver63-openshift",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat JBoss BRMS 6.3 decision server"
+                }
             },
             "spec": {
                 "dockerImageRepository": "registry.access.redhat.com/jboss-decisionserver-6/decisionserver63-openshift",
@@ -236,7 +254,10 @@
             "kind": "ImageStream",
             "apiVersion": "v1",
             "metadata": {
-                "name": "jboss-processserver63-openshift"
+                "name": "jboss-processserver63-openshift",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat JBoss BPM Suite 6.3 intelligent process server"
+                }
             },
             "spec": {
                 "dockerImageRepository": "registry.access.redhat.com/jboss-processserver-6/processserver63-openshift",
@@ -261,7 +282,10 @@
             "kind": "ImageStream",
             "apiVersion": "v1",
             "metadata": {
-                "name": "jboss-datagrid65-openshift"
+                "name": "jboss-datagrid65-openshift",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat JBoss Data Grid 6.5"
+                }
             },
             "spec": {
                 "dockerImageRepository": "registry.access.redhat.com/jboss-datagrid-6/datagrid65-openshift",
@@ -293,7 +317,10 @@
             "kind": "ImageStream",
             "apiVersion": "v1",
             "metadata": {
-                "name": "jboss-datagrid65-client-openshift"
+                "name": "jboss-datagrid65-client-openshift",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat JBoss Data Grid 6.5 Client Modules for EAP"
+                }
             },
             "spec": {
                 "dockerImageRepository": "registry.access.redhat.com/jboss-datagrid-6/datagrid65-client-openshift",
@@ -314,7 +341,10 @@
             "kind": "ImageStream",
             "apiVersion": "v1",
             "metadata": {
-                "name": "jboss-datavirt63-openshift"
+                "name": "jboss-datavirt63-openshift",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat JBoss Data Virtualization 6.3"
+                }
             },
             "spec": {
                 "dockerImageRepository": "registry.access.redhat.com/jboss-datavirt-6/datavirt63-openshift",
@@ -346,7 +376,10 @@
             "kind": "ImageStream",
             "apiVersion": "v1",
             "metadata": {
-                "name": "jboss-datavirt63-driver-openshift"
+                "name": "jboss-datavirt63-driver-openshift",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat JBoss Data Virtualization 6.5 JDBC Driver Modules for EAP"
+                }
             },
             "spec": {
                 "dockerImageRepository": "registry.access.redhat.com/jboss-datavirt-6/datavirt63-driver-openshift",
@@ -367,7 +400,10 @@
             "kind": "ImageStream",
             "apiVersion": "v1",
             "metadata": {
-                "name": "jboss-amq-62"
+                "name": "jboss-amq-62",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat JBoss A-MQ 6.2"
+                }
             },
             "spec": {
                 "dockerImageRepository": "registry.access.redhat.com/jboss-amq-6/amq62-openshift",
@@ -411,7 +447,8 @@
             "metadata": {
                 "name": "redhat-sso70-openshift",
                 "annotations": {
-                    "description": "Red Hat SSO 7.0"
+                    "description": "Red Hat SSO 7.0",
+                    "openshift.io/display-name": "Red Hat Single Sign-On 7.0"
                 }
             },
             "spec": {
@@ -446,7 +483,8 @@
             "metadata": {
                 "name": "redhat-sso71-openshift",
                 "annotations": {
-                    "description": "Red Hat SSO 7.1"
+                    "description": "Red Hat SSO 7.1",
+                    "openshift.io/display-name": "Red Hat Single Sign-On 7.1"
                 }
             },
             "spec": {
@@ -469,7 +507,10 @@
             "kind": "ImageStream",
             "apiVersion": "v1",
             "metadata": {
-                "name": "redhat-openjdk18-openshift"
+                "name": "redhat-openjdk18-openshift",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat OpenJDK 8"
+                }
             },
             "spec": {
                 "dockerImageRepository": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift",


### PR DESCRIPTION
…s to all image stream tag definitions

Some files have multiple image Stream Tag definitions, I added the openshift/display-name var to the image stream tag definitions which refer to the application being built from the template. For example, for templates like eap64-amq-persistent-s2i.json, I added the openshift/display-name vars to the image stream tag definitions which were named ${APPLICATION_NAME}:latest but not to the ones named "jboss-eap64-openshift:1.4" or "jboss-amq-62:1.3". Is this the right way to do this? 

*NOTE: My script cleaned up some typos and indentation(a couple of the datavirt files had duplicate env lists). I can put this in a seperate commit/PR if you think that is better.