### PR TITLE
[CLOUD-449] Expose ARTIFACT_DIR as parameter in s2i templates (EAP)

### DIFF
--- a/eap/eap64-amq-persistent-s2i.json
+++ b/eap/eap64-amq-persistent-s2i.json
@@ -252,6 +252,12 @@
             "name": "MAVEN_MIRROR_URL",
             "value": "",
             "required": false
+        },
+        {
+            "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
+            "name": "ARTIFACT_DIR",
+            "value": "",
+            "required": false
         }
     ],
     "objects": [
@@ -405,6 +411,10 @@
                             {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "ARTIFACT_DIR",
+                                "value": "${ARTIFACT_DIR}"
                             }
                         ],
                         "forcePull": true,

--- a/eap/eap64-amq-s2i.json
+++ b/eap/eap64-amq-s2i.json
@@ -238,6 +238,12 @@
             "name": "MAVEN_MIRROR_URL",
             "value": "",
             "required": false
+        },
+        {
+            "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
+            "name": "ARTIFACT_DIR",
+            "value": "",
+            "required": false
         }
     ],
     "objects": [
@@ -391,6 +397,10 @@
                             {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "ARTIFACT_DIR",
+                                "value": "${ARTIFACT_DIR}"
                             }
                         ],
                         "forcePull": true,

--- a/eap/eap64-basic-s2i.json
+++ b/eap/eap64-basic-s2i.json
@@ -118,6 +118,12 @@
             "name": "MAVEN_MIRROR_URL",
             "value": "",
             "required": false
+        },
+        {
+            "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
+            "name": "ARTIFACT_DIR",
+            "value": "",
+            "required": false
         }
     ],
     "objects": [
@@ -200,6 +206,10 @@
                             {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "ARTIFACT_DIR",
+                                "value": "${ARTIFACT_DIR}"
                             }
                         ],
                         "forcePull": true,

--- a/eap/eap64-https-s2i.json
+++ b/eap/eap64-https-s2i.json
@@ -195,6 +195,12 @@
             "name": "MAVEN_MIRROR_URL",
             "value": "",
             "required": false
+        },
+        {
+            "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
+            "name": "ARTIFACT_DIR",
+            "value": "",
+            "required": false
         }
     ],
     "objects": [
@@ -324,6 +330,10 @@
                             {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "ARTIFACT_DIR",
+                                "value": "${ARTIFACT_DIR}"
                             }
                         ],
                         "forcePull": true,

--- a/eap/eap64-mongodb-persistent-s2i.json
+++ b/eap/eap64-mongodb-persistent-s2i.json
@@ -276,6 +276,12 @@
             "name": "MAVEN_MIRROR_URL",
             "value": "",
             "required": false
+        },
+        {
+            "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
+            "name": "ARTIFACT_DIR",
+            "value": "",
+            "required": false
         }
     ],
     "objects": [
@@ -429,6 +435,10 @@
                             {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "ARTIFACT_DIR",
+                                "value": "${ARTIFACT_DIR}"
                             }
                         ],
                         "forcePull": true,

--- a/eap/eap64-mongodb-s2i.json
+++ b/eap/eap64-mongodb-s2i.json
@@ -269,6 +269,12 @@
             "name": "MAVEN_MIRROR_URL",
             "value": "",
             "required": false
+        },
+        {
+            "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
+            "name": "ARTIFACT_DIR",
+            "value": "",
+            "required": false
         }
     ],
     "objects": [
@@ -422,6 +428,10 @@
                             {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "ARTIFACT_DIR",
+                                "value": "${ARTIFACT_DIR}"
                             }
                         ],
                         "forcePull": true,

--- a/eap/eap64-mysql-persistent-s2i.json
+++ b/eap/eap64-mysql-persistent-s2i.json
@@ -280,6 +280,12 @@
             "name": "MAVEN_MIRROR_URL",
             "value": "",
             "required": false
+        },
+        {
+            "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
+            "name": "ARTIFACT_DIR",
+            "value": "",
+            "required": false
         }
     ],
     "objects": [
@@ -433,6 +439,10 @@
                             {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "ARTIFACT_DIR",
+                                "value": "${ARTIFACT_DIR}"
                             }
                         ],
                         "forcePull": true,

--- a/eap/eap64-mysql-s2i.json
+++ b/eap/eap64-mysql-s2i.json
@@ -273,6 +273,12 @@
             "name": "MAVEN_MIRROR_URL",
             "value": "",
             "required": false
+        },
+        {
+            "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
+            "name": "ARTIFACT_DIR",
+            "value": "",
+            "required": false
         }
     ],
     "objects": [
@@ -426,6 +432,10 @@
                             {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "ARTIFACT_DIR",
+                                "value": "${ARTIFACT_DIR}"
                             }
                         ],
                         "forcePull": true,

--- a/eap/eap64-postgresql-persistent-s2i.json
+++ b/eap/eap64-postgresql-persistent-s2i.json
@@ -262,6 +262,12 @@
             "name": "MAVEN_MIRROR_URL",
             "value": "",
             "required": false
+        },
+        {
+            "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
+            "name": "ARTIFACT_DIR",
+            "value": "",
+            "required": false
         }
     ],
     "objects": [
@@ -415,6 +421,10 @@
                             {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "ARTIFACT_DIR",
+                                "value": "${ARTIFACT_DIR}"
                             }
                         ],
                         "forcePull": true,

--- a/eap/eap64-postgresql-s2i.json
+++ b/eap/eap64-postgresql-s2i.json
@@ -255,6 +255,12 @@
             "name": "MAVEN_MIRROR_URL",
             "value": "",
             "required": false
+        },
+        {
+            "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
+            "name": "ARTIFACT_DIR",
+            "value": "",
+            "required": false
         }
     ],
     "objects": [
@@ -408,6 +414,10 @@
                             {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "ARTIFACT_DIR",
+                                "value": "${ARTIFACT_DIR}"
                             }
                         ],
                         "forcePull": true,

--- a/eap/eap64-third-party-db-s2i.json
+++ b/eap/eap64-third-party-db-s2i.json
@@ -223,6 +223,12 @@
             "name": "MAVEN_MIRROR_URL",
             "value": "",
             "required": false
+        },
+        {
+            "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
+            "name": "ARTIFACT_DIR",
+            "value": "",
+            "required": false
         }
     ],
     "objects": [
@@ -371,6 +377,10 @@
                             {
                                 "name": "CUSTOM_INSTALL_DIRECTORIES",
                                 "value": "extensions/*"
+                            },
+                            {
+                                "name": "ARTIFACT_DIR",
+                                "value": "${ARTIFACT_DIR}"
                             }
                         ],
                         "forcePull": true,

--- a/eap/eap70-amq-persistent-s2i.json
+++ b/eap/eap70-amq-persistent-s2i.json
@@ -252,6 +252,12 @@
             "name": "MAVEN_MIRROR_URL",
             "value": "",
             "required": false
+        },
+        {
+            "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
+            "name": "ARTIFACT_DIR",
+            "value": "",
+            "required": false
         }
     ],
     "objects": [
@@ -405,6 +411,10 @@
                             {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "ARTIFACT_DIR",
+                                "value": "${ARTIFACT_DIR}"
                             }
                         ],
                         "forcePull": true,

--- a/eap/eap70-amq-s2i.json
+++ b/eap/eap70-amq-s2i.json
@@ -238,6 +238,12 @@
             "name": "MAVEN_MIRROR_URL",
             "value": "",
             "required": false
+        },
+        {
+            "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
+            "name": "ARTIFACT_DIR",
+            "value": "",
+            "required": false
         }
     ],
     "objects": [
@@ -391,6 +397,10 @@
                             {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "ARTIFACT_DIR",
+                                "value": "${ARTIFACT_DIR}"
                             }
                         ],
                         "forcePull": true,

--- a/eap/eap70-basic-s2i.json
+++ b/eap/eap70-basic-s2i.json
@@ -118,6 +118,12 @@
             "name": "MAVEN_MIRROR_URL",
             "value": "",
             "required": false
+        },
+        {
+            "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
+            "name": "ARTIFACT_DIR",
+            "value": "",
+            "required": false
         }
     ],
     "objects": [
@@ -200,6 +206,10 @@
                             {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "ARTIFACT_DIR",
+                                "value": "${ARTIFACT_DIR}"
                             }
                         ],
                         "forcePull": true,

--- a/eap/eap70-https-s2i.json
+++ b/eap/eap70-https-s2i.json
@@ -195,6 +195,12 @@
             "name": "MAVEN_MIRROR_URL",
             "value": "",
             "required": false
+        },
+        {
+            "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
+            "name": "ARTIFACT_DIR",
+            "value": "",
+            "required": false
         }
     ],
     "objects": [
@@ -324,6 +330,10 @@
                             {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "ARTIFACT_DIR",
+                                "value": "${ARTIFACT_DIR}"
                             }
                         ],
                         "forcePull": true,

--- a/eap/eap70-mongodb-persistent-s2i.json
+++ b/eap/eap70-mongodb-persistent-s2i.json
@@ -276,6 +276,12 @@
             "name": "MAVEN_MIRROR_URL",
             "value": "",
             "required": false
+        },
+        {
+            "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
+            "name": "ARTIFACT_DIR",
+            "value": "",
+            "required": false
         }
     ],
     "objects": [
@@ -429,6 +435,10 @@
                             {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "ARTIFACT_DIR",
+                                "value": "${ARTIFACT_DIR}"
                             }
                         ],
                         "forcePull": true,

--- a/eap/eap70-mongodb-s2i.json
+++ b/eap/eap70-mongodb-s2i.json
@@ -269,6 +269,12 @@
             "name": "MAVEN_MIRROR_URL",
             "value": "",
             "required": false
+        },
+        {
+            "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
+            "name": "ARTIFACT_DIR",
+            "value": "",
+            "required": false
         }
     ],
     "objects": [
@@ -422,6 +428,10 @@
                             {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "ARTIFACT_DIR",
+                                "value": "${ARTIFACT_DIR}"
                             }
                         ],
                         "forcePull": true,

--- a/eap/eap70-mysql-persistent-s2i.json
+++ b/eap/eap70-mysql-persistent-s2i.json
@@ -280,6 +280,12 @@
             "name": "MAVEN_MIRROR_URL",
             "value": "",
             "required": false
+        },
+        {
+            "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
+            "name": "ARTIFACT_DIR",
+            "value": "",
+            "required": false
         }
     ],
     "objects": [
@@ -433,6 +439,10 @@
                             {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "ARTIFACT_DIR",
+                                "value": "${ARTIFACT_DIR}"
                             }
                         ],
                         "forcePull": true,

--- a/eap/eap70-mysql-s2i.json
+++ b/eap/eap70-mysql-s2i.json
@@ -273,6 +273,12 @@
             "name": "MAVEN_MIRROR_URL",
             "value": "",
             "required": false
+        },
+        {
+            "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
+            "name": "ARTIFACT_DIR",
+            "value": "",
+            "required": false
         }
     ],
     "objects": [
@@ -426,6 +432,10 @@
                             {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "ARTIFACT_DIR",
+                                "value": "${ARTIFACT_DIR}"
                             }
                         ],
                         "forcePull": true,

--- a/eap/eap70-postgresql-persistent-s2i.json
+++ b/eap/eap70-postgresql-persistent-s2i.json
@@ -262,6 +262,12 @@
             "name": "MAVEN_MIRROR_URL",
             "value": "",
             "required": false
+        },
+        {
+            "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
+            "name": "ARTIFACT_DIR",
+            "value": "",
+            "required": false
         }
     ],
     "objects": [
@@ -415,6 +421,10 @@
                             {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "ARTIFACT_DIR",
+                                "value": "${ARTIFACT_DIR}"
                             }
                         ],
                         "forcePull": true,

--- a/eap/eap70-postgresql-s2i.json
+++ b/eap/eap70-postgresql-s2i.json
@@ -255,6 +255,12 @@
             "name": "MAVEN_MIRROR_URL",
             "value": "",
             "required": false
+        },
+        {
+            "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
+            "name": "ARTIFACT_DIR",
+            "value": "",
+            "required": false
         }
     ],
     "objects": [
@@ -408,6 +414,10 @@
                             {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "ARTIFACT_DIR",
+                                "value": "${ARTIFACT_DIR}"
                             }
                         ],
                         "forcePull": true,

--- a/eap/eap70-third-party-db-s2i.json
+++ b/eap/eap70-third-party-db-s2i.json
@@ -223,6 +223,12 @@
             "name": "MAVEN_MIRROR_URL",
             "value": "",
             "required": false
+        },
+        {
+            "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
+            "name": "ARTIFACT_DIR",
+            "value": "",
+            "required": false
         }
     ],
     "objects": [
@@ -371,6 +377,10 @@
                             {
                                 "name": "CUSTOM_INSTALL_DIRECTORIES",
                                 "value": "extensions/*"
+                            },
+                            {
+                                "name": "ARTIFACT_DIR",
+                                "value": "${ARTIFACT_DIR}"
                             }
                         ],
                         "forcePull": true,


### PR DESCRIPTION
The SSO templates already exposes this parameter, no need to change them.