### PR TITLE
fix markdown syntax for headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-#Application Templates
+# Application Templates
 This project contains OpenShift v3 application templates which support
 applications based on JBoss Middleware products.
 
-##Structure
+## Structure
 The templates in this folder are organized by JBoss Middleware product.  Each
 template is configured with the following basic parameters:
  * APPLICATION_NAME: the name of the application.  This is also used as the
@@ -20,12 +20,12 @@ the following:
  * DB_DATABASE: The database/tablespace to connect to.
  * DB_JNDI: The JNDI name to use for datasource definitions (e.g. eap: java:jdbc/mydb or jws: jdbc/mydb)
 
-##Common Image Repositories
+## Common Image Repositories
 The `jboss-image-streams.json` file contains __ImageStream__ definitions for all
 JBoss Middleware products.  This will need to be
 installed in the common `openshift` namespace (`oc create -f jboss-images-streams.json -n openshift`) before using any of the templates in these folders.  You will also need to install (into the `openshift` namespace) the database image streams supplied by OpenShift to use any of the templates that integrate with MySQL, PostgreSQL or MongoDB.
 
-##HTTPS configuration
+## HTTPS configuration
 The majority of templates contain configuration that requires the creation of resources within your project to support HTTPS, specifically a service account and a secret that can be included into the pod as a volume.  The secrets directory contains a number of examples that can be installed into your project to allow you to test the A-MQ, EAP and JWS templates, you should replace the contents of these with data that is more appropriate for your deployments.
 
 To install the service accounts and secrets into your project:
@@ -35,7 +35,7 @@ $ oc create -n myproject -f secrets
 
 The following templates can be used without creating a service account or a secret: eap/eap6-basic-s2i.json, webserver/jws-tomcat7-basic-s2i.json and webserver/jws-tomcat8-basic-s2i.json.
 
-##Example
+## Example
 The easiest way to use the templates is to install them in your project, then use the _Create+_ button in the OpenShift console to create your application.  The console will prompt you for the values for all of the parameters used by the template.  To set this up for a particular template:
 ```
 $ oc create -n openshift -f jboss-image-streams.json


### PR DESCRIPTION
They were not being rendered properly by (at least) GitHub.