### PR TITLE
Cleaning up spacing and indentation

### DIFF
--- a/jboss-image-streams.json
+++ b/jboss-image-streams.json
@@ -23,7 +23,7 @@
                             "description": "JBoss Web Server 3.0 Tomcat 7 S2I images.",
                             "iconClass": "icon-jboss",
                             "tags": "builder,tomcat,tomcat7,java,jboss,xpaas",
-                            "supports":"tomcat7:3.0,tomcat:7,java:8,xpaas:1.1",
+                            "supports": "tomcat7:3.0,tomcat:7,java:8,xpaas:1.1",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
                             "sampleContextDir": "tomcat-websocket-chat",
                             "version": "1.1"
@@ -35,7 +35,7 @@
                             "description": "JBoss Web Server 3.0 Tomcat 7 S2I images.",
                             "iconClass": "icon-jboss",
                             "tags": "builder,tomcat,tomcat7,java,jboss,xpaas",
-                            "supports":"tomcat7:3.0,tomcat:7,java:8,xpaas:1.2",
+                            "supports": "tomcat7:3.0,tomcat:7,java:8,xpaas:1.2",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
                             "sampleContextDir": "tomcat-websocket-chat",
                             "version": "1.2"
@@ -59,7 +59,7 @@
                             "description": "JBoss Web Server 3.0 Tomcat 8 S2I images.",
                             "iconClass": "icon-jboss",
                             "tags": "builder,tomcat,tomcat8,java,jboss,xpaas",
-                            "supports":"tomcat8:3.0,tomcat:8,java:8,xpaas:1.1",
+                            "supports": "tomcat8:3.0,tomcat:8,java:8,xpaas:1.1",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
                             "sampleContextDir": "tomcat-websocket-chat",
                             "version": "1.1"
@@ -71,7 +71,7 @@
                             "description": "JBoss Web Server 3.0 Tomcat 8 S2I images.",
                             "iconClass": "icon-jboss",
                             "tags": "builder,tomcat,tomcat8,java,jboss,xpaas",
-                            "supports":"tomcat8:3.0,tomcat:8,java:8,xpaas:1.2",
+                            "supports": "tomcat8:3.0,tomcat:8,java:8,xpaas:1.2",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
                             "sampleContextDir": "tomcat-websocket-chat",
                             "version": "1.2"
@@ -95,7 +95,7 @@
                             "description": "JBoss EAP 6.4 S2I images.",
                             "iconClass": "icon-jboss",
                             "tags": "builder,eap,javaee,java,jboss,xpaas",
-                            "supports":"eap:6.4,javaee:6,java:8,xpaas:1.1",
+                            "supports": "eap:6.4,javaee:6,java:8,xpaas:1.1",
                             "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
                             "sampleContextDir": "kitchensink",
                             "sampleRef": "6.4.x",
@@ -108,7 +108,7 @@
                             "description": "JBoss EAP 6.4 S2I images.",
                             "iconClass": "icon-jboss",
                             "tags": "builder,eap,javaee,java,jboss,xpaas",
-                            "supports":"eap:6.4,javaee:6,java:8,xpaas:1.2",
+                            "supports": "eap:6.4,javaee:6,java:8,xpaas:1.2",
                             "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
                             "sampleContextDir": "kitchensink",
                             "sampleRef": "6.4.x",
@@ -121,7 +121,7 @@
                             "description": "JBoss EAP 6.4 S2I images.",
                             "iconClass": "icon-jboss",
                             "tags": "builder,eap,javaee,java,jboss,xpaas",
-                            "supports":"eap:6.4,javaee:6,java:8,xpaas:1.3",
+                            "supports": "eap:6.4,javaee:6,java:8,xpaas:1.3",
                             "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
                             "sampleContextDir": "kitchensink",
                             "sampleRef": "6.4.x",
@@ -134,7 +134,7 @@
                             "description": "JBoss EAP 6.4 S2I images.",
                             "iconClass": "icon-jboss",
                             "tags": "builder,eap,javaee,java,jboss,xpaas",
-                            "supports":"eap:6.4,javaee:6,java:8,xpaas:1.4",
+                            "supports": "eap:6.4,javaee:6,java:8,xpaas:1.4",
                             "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
                             "sampleContextDir": "kitchensink",
                             "sampleRef": "6.4.x",
@@ -159,7 +159,7 @@
                             "description": "JBoss EAP 7.0 S2I images.",
                             "iconClass": "icon-jboss",
                             "tags": "builder,eap,javaee,java,jboss,xpaas",
-                            "supports":"eap:7.0,javaee:7,java:8,xpaas:1.3",
+                            "supports": "eap:7.0,javaee:7,java:8,xpaas:1.3",
                             "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
                             "sampleContextDir": "kitchensink",
                             "sampleRef": "7.0.0.GA",
@@ -172,7 +172,7 @@
                             "description": "JBoss EAP 7.0 S2I images.",
                             "iconClass": "icon-jboss",
                             "tags": "builder,eap,javaee,java,jboss,xpaas",
-                            "supports":"eap:7.0,javaee:7,java:8,xpaas:1.4",
+                            "supports": "eap:7.0,javaee:7,java:8,xpaas:1.4",
                             "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
                             "sampleContextDir": "kitchensink",
                             "sampleRef": "7.0.0.GA",
@@ -197,7 +197,7 @@
                             "description": "Red Hat JBoss BRMS 6.2 decision server S2I images.",
                             "iconClass": "icon-jboss",
                             "tags": "builder,decisionserver,java,xpaas",
-                            "supports":"decisionserver:6.2,java:8,xpaas:1.2",
+                            "supports": "decisionserver:6.2,java:8,xpaas:1.2",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
                             "sampleContextDir": "decisionserver/hellorules",
                             "sampleRef": "1.2",
@@ -222,7 +222,7 @@
                             "description": "Red Hat JBoss BRMS 6.3 decision server S2I images.",
                             "iconClass": "icon-jboss",
                             "tags": "builder,decisionserver,java,xpaas",
-                            "supports":"decisionserver:6.3,java:8,xpaas:1.3",
+                            "supports": "decisionserver:6.3,java:8,xpaas:1.3",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
                             "sampleContextDir": "decisionserver/hellorules",
                             "sampleRef": "1.3",
@@ -247,7 +247,7 @@
                             "description": "Red Hat JBoss BPM Suite 6.3 intelligent process server S2I images.",
                             "iconClass": "icon-jboss",
                             "tags": "builder,processserver,java,xpaas",
-                            "supports":"processserver:6.3,java:8,xpaas:1.3",
+                            "supports": "processserver:6.3,java:8,xpaas:1.3",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
                             "sampleContextDir": "processserver/library",
                             "sampleRef": "1.3",
@@ -272,7 +272,7 @@
                             "description": "JBoss Data Grid 6.5 S2I images.",
                             "iconClass": "icon-jboss",
                             "tags": "datagrid,java,jboss,xpaas",
-                            "supports":"datagrid:6.5,java:8,xpaas:1.2",
+                            "supports": "datagrid:6.5,java:8,xpaas:1.2",
                             "version": "1.2"
                         }
                     },
@@ -282,7 +282,7 @@
                             "description": "JBoss Data Grid 6.5 S2I images.",
                             "iconClass": "icon-jboss",
                             "tags": "datagrid,java,jboss,xpaas",
-                            "supports":"datagrid:6.5,java:8,xpaas:1.4",
+                            "supports": "datagrid:6.5,java:8,xpaas:1.4",
                             "version": "1.3"
                         }
                     }
@@ -304,7 +304,7 @@
                             "description": "JBoss Data Grid 6.5 Client Modules for EAP.",
                             "iconClass": "icon-jboss",
                             "tags": "datagrid,jboss,xpaas",
-                            "supports":"datagrid:6.5,eap:6.4,eap:7.0",
+                            "supports": "datagrid:6.5,eap:6.4,eap:7.0",
                             "version": "1.0"
                         }
                     }
@@ -326,7 +326,7 @@
                             "description": "Red Hat JBoss Data Virtualization 6.3 S2I images.",
                             "iconClass": "icon-jboss",
                             "tags": "datavirt,java,jboss,xpaas",
-                            "supports":"datavirt:6.3,java:8,xpaas:1.4",
+                            "supports": "datavirt:6.3,java:8,xpaas:1.4",
                             "version": "1.0"
                         }
                     },
@@ -336,7 +336,7 @@
                             "description": "Red Hat JBoss Data Virtualization 6.3 S2I images.",
                             "iconClass": "icon-jboss",
                             "tags": "datavirt,java,jboss,xpaas",
-                            "supports":"datavirt:6.3,java:8,xpaas:1.4",
+                            "supports": "datavirt:6.3,java:8,xpaas:1.4",
                             "version": "1.1"
                         }
                     }
@@ -358,7 +358,7 @@
                             "description": "JBoss Data Virtualization 6.5 JDBC Driver Modules for EAP.",
                             "iconClass": "icon-jboss",
                             "tags": "datavirt,jboss,xpaas",
-                            "supports":"datavirt:6.3,eap:6.4,eap:7.0",
+                            "supports": "datavirt:6.3,eap:6.4,eap:7.0",
                             "version": "1.0"
                         }
                     }
@@ -380,7 +380,7 @@
                             "description": "JBoss A-MQ 6.2 broker image.",
                             "iconClass": "icon-jboss",
                             "tags": "messaging,amq,jboss,xpaas",
-                            "supports":"amq:6.2,messaging,xpaas:1.1",
+                            "supports": "amq:6.2,messaging,xpaas:1.1",
                             "version": "1.1"
                         }
                     },
@@ -390,7 +390,7 @@
                             "description": "JBoss A-MQ 6.2 broker image.",
                             "iconClass": "icon-jboss",
                             "tags": "messaging,amq,jboss,xpaas",
-                            "supports":"amq:6.2,messaging,xpaas:1.2",
+                            "supports": "amq:6.2,messaging,xpaas:1.2",
                             "version": "1.2"
                         }
                     },
@@ -400,7 +400,7 @@
                             "description": "JBoss A-MQ 6.2 broker image.",
                             "iconClass": "icon-jboss",
                             "tags": "messaging,amq,jboss,xpaas",
-                            "supports":"amq:6.2,messaging,xpaas:1.3",
+                            "supports": "amq:6.2,messaging,xpaas:1.3",
                             "version": "1.3"
                         }
                     }
@@ -412,7 +412,7 @@
             "apiVersion": "v1",
             "metadata": {
                 "name": "redhat-sso70-openshift",
-                 "annotations": {
+                "annotations": {
                     "description": "Red Hat SSO 7.0"
                 }
             },
@@ -425,7 +425,7 @@
                             "description": "Red Hat SSO 7.0",
                             "iconClass": "icon-jboss",
                             "tags": "sso,keycloak,redhat",
-                            "supports":"sso:7.0,xpaas:1.3",
+                            "supports": "sso:7.0,xpaas:1.3",
                             "version": "1.3"
                         }
                     },
@@ -435,7 +435,7 @@
                             "description": "Red Hat SSO 7.0",
                             "iconClass": "icon-jboss",
                             "tags": "sso,keycloak,redhat",
-                            "supports":"sso:7.0,xpaas:1.4",
+                            "supports": "sso:7.0,xpaas:1.4",
                             "version": "1.4"
                         }
                     }
@@ -447,7 +447,7 @@
             "apiVersion": "v1",
             "metadata": {
                 "name": "redhat-sso71-openshift",
-                 "annotations": {
+                "annotations": {
                     "description": "Red Hat SSO 7.1"
                 }
             },
@@ -460,7 +460,7 @@
                             "description": "Red Hat SSO 7.1",
                             "iconClass": "icon-jboss",
                             "tags": "sso,keycloak,redhat",
-                            "supports":"sso:7.1,xpaas:1.4",
+                            "supports": "sso:7.1,xpaas:1.4",
                             "version": "1.0"
                         }
                     }
@@ -483,7 +483,7 @@
                             "description": "Build and run Java applications using Maven and OpenJDK 8.",
                             "iconClass": "icon-jboss",
                             "tags": "builder,java,xpaas,openjdk",
-                            "supports":"java:8,xpaas:1.0",
+                            "supports": "java:8,xpaas:1.0",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
                             "sampleContextDir": "undertow-servlet",
                             "version": "1.0"


### PR DESCRIPTION
I have been using a Python script with the json library to make changes across the template files.

In order to keep the diffs clean I have been using the following arguments when parsing and writing to the template files.
`
data = OrderedDict()
...
json.dump(data, f, indent=4, separators=(',', ': '))
`

- The script corrects any inconsistencies among the files(indentations, spacing). It seems that my script occasionally come across these inconsistencies and auto corrects them. For the sake of keeping the templates clean, I was thinking we declare a format standard for the template json files. For instance, we could declare that a proper indentation is 4 spaces and that there be a single space after separators(such as colons). What do you think?

- If you think this is a good idea, I can add a cleaning script that people can run before they commit their changes. By doing this, we can reduce the formatting commits and keep the formatting of the files consistent.