### PR TITLE
Updating description for GITHUB_WEBHOOK_SECRET

### DIFF
--- a/decisionserver/decisionserver62-amq-s2i.json
+++ b/decisionserver/decisionserver62-amq-s2i.json
@@ -183,7 +183,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -191,7 +191,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/decisionserver/decisionserver62-basic-s2i.json
+++ b/decisionserver/decisionserver62-basic-s2i.json
@@ -98,7 +98,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -106,7 +106,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/decisionserver/decisionserver62-https-s2i.json
+++ b/decisionserver/decisionserver62-https-s2i.json
@@ -147,7 +147,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -155,7 +155,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/decisionserver/decisionserver63-amq-s2i.json
+++ b/decisionserver/decisionserver63-amq-s2i.json
@@ -190,7 +190,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -198,7 +198,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/decisionserver/decisionserver63-basic-s2i.json
+++ b/decisionserver/decisionserver63-basic-s2i.json
@@ -98,7 +98,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -106,7 +106,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/decisionserver/decisionserver63-https-s2i.json
+++ b/decisionserver/decisionserver63-https-s2i.json
@@ -147,7 +147,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -155,7 +155,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/docs/decisionserver/decisionserver62-amq-s2i.adoc
+++ b/docs/decisionserver/decisionserver62-amq-s2i.adoc
@@ -46,8 +46,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`MQ_PASSWORD` | `MQ_PASSWORD` | Password for standard broker user. It is required for connecting to the broker. If left empty, it will be generated. | `${MQ_PASSWORD}` | False
 |`AMQ_MESH_DISCOVERY_TYPE` | `AMQ_MESH_DISCOVERY_TYPE` | The discovery agent type to use for discovering mesh endpoints.  'dns' will use OpenShift's DNS service to resolve endpoints.  'kube' will use Kubernetes REST API to resolve service endpoints.  If using 'kube' the service account for the pod must have the 'view' role, which can be added via 'oc policy add-role-to-user view system:serviceaccount:<namespace>:default' where <namespace> is the project namespace. | kube | False
 |`AMQ_STORAGE_USAGE_LIMIT` | `AMQ_STORAGE_USAGE_LIMIT` | The A-MQ storage usage limit | 100 gb | False
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |=======================================================================
 

--- a/docs/decisionserver/decisionserver62-basic-s2i.adoc
+++ b/docs/decisionserver/decisionserver62-basic-s2i.adoc
@@ -34,8 +34,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`HORNETQ_QUEUES` | `HORNETQ_QUEUES` | Queue names | `${HORNETQ_QUEUES}` | False
 |`HORNETQ_TOPICS` | `HORNETQ_TOPICS` | Topic names | `${HORNETQ_TOPICS}` | False
 |`HORNETQ_CLUSTER_PASSWORD` | `HORNETQ_CLUSTER_PASSWORD` | HornetQ cluster admin password | `${HORNETQ_CLUSTER_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |=======================================================================
 

--- a/docs/decisionserver/decisionserver62-https-s2i.adoc
+++ b/docs/decisionserver/decisionserver62-https-s2i.adoc
@@ -41,8 +41,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`HTTPS_NAME` | `HTTPS_NAME` | The name associated with the server certificate | jboss | False
 |`HTTPS_PASSWORD` | `HTTPS_PASSWORD` | The password for the keystore and certificate | mykeystorepass | False
 |`HORNETQ_CLUSTER_PASSWORD` | `HORNETQ_CLUSTER_PASSWORD` | HornetQ cluster admin password | `${HORNETQ_CLUSTER_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |=======================================================================
 

--- a/docs/decisionserver/decisionserver63-amq-s2i.adoc
+++ b/docs/decisionserver/decisionserver63-amq-s2i.adoc
@@ -47,8 +47,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`MQ_PASSWORD` | `MQ_PASSWORD` | Password for standard broker user. It is required for connecting to the broker. If left empty, it will be generated. | `${MQ_PASSWORD}` | False
 |`AMQ_MESH_DISCOVERY_TYPE` | `AMQ_MESH_DISCOVERY_TYPE` | The discovery agent type to use for discovering mesh endpoints.  'dns' will use OpenShift's DNS service to resolve endpoints.  'kube' will use Kubernetes REST API to resolve service endpoints.  If using 'kube' the service account for the pod must have the 'view' role, which can be added via 'oc policy add-role-to-user view system:serviceaccount:<namespace>:default' where <namespace> is the project namespace. | kube | False
 |`AMQ_STORAGE_USAGE_LIMIT` | `AMQ_STORAGE_USAGE_LIMIT` | The A-MQ storage usage limit | 100 gb | False
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`MAVEN_MIRROR_URL` | -- | Maven mirror to use for S2I builds | -- | False
 |`ARTIFACT_DIR` | -- | List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied. | -- | False

--- a/docs/decisionserver/decisionserver63-basic-s2i.adoc
+++ b/docs/decisionserver/decisionserver63-basic-s2i.adoc
@@ -34,8 +34,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`HORNETQ_QUEUES` | `HORNETQ_QUEUES` | Queue names | `${HORNETQ_QUEUES}` | False
 |`HORNETQ_TOPICS` | `HORNETQ_TOPICS` | Topic names | `${HORNETQ_TOPICS}` | False
 |`HORNETQ_CLUSTER_PASSWORD` | `HORNETQ_CLUSTER_PASSWORD` | HornetQ cluster admin password | `${HORNETQ_CLUSTER_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`MAVEN_MIRROR_URL` | -- | Maven mirror to use for S2I builds | -- | False
 |`ARTIFACT_DIR` | -- | List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied. | -- | False

--- a/docs/decisionserver/decisionserver63-https-s2i.adoc
+++ b/docs/decisionserver/decisionserver63-https-s2i.adoc
@@ -41,8 +41,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`HTTPS_NAME` | `HTTPS_NAME` | The name associated with the server certificate | jboss | False
 |`HTTPS_PASSWORD` | `HTTPS_PASSWORD` | The password for the keystore and certificate | mykeystorepass | False
 |`HORNETQ_CLUSTER_PASSWORD` | `HORNETQ_CLUSTER_PASSWORD` | HornetQ cluster admin password | `${HORNETQ_CLUSTER_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`MAVEN_MIRROR_URL` | -- | Maven mirror to use for S2I builds | -- | False
 |`ARTIFACT_DIR` | -- | List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied. | -- | False

--- a/docs/eap/eap64-amq-persistent-s2i.adoc
+++ b/docs/eap/eap64-amq-persistent-s2i.adoc
@@ -46,8 +46,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`MQ_PASSWORD` | `MQ_PASSWORD` | Password for standard broker user. It is required for connecting to the broker. If left empty, it will be generated. | `${MQ_PASSWORD}` | False
 |`AMQ_MESH_DISCOVERY_TYPE` | `AMQ_MESH_DISCOVERY_TYPE` | The discovery agent type to use for discovering mesh endpoints.  'dns' will use OpenShift's DNS service to resolve endpoints.  'kube' will use Kubernetes REST API to resolve service endpoints.  If using 'kube' the service account for the pod must have the 'view' role, which can be added via 'oc policy add-role-to-user view system:serviceaccount:<namespace>:default' where <namespace> is the project namespace. | kube | False
 |`AMQ_STORAGE_USAGE_LIMIT` | `AMQ_STORAGE_USAGE_LIMIT` | The A-MQ storage usage limit | 100 gb | False
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`JGROUPS_ENCRYPT_SECRET` | `JGROUPS_ENCRYPT_SECRET` | The name of the secret containing the keystore file | eap-app-secret | False
 |`JGROUPS_ENCRYPT_KEYSTORE` | `JGROUPS_ENCRYPT_KEYSTORE_DIR` | The name of the keystore file within the secret | jgroups.jceks | False

--- a/docs/eap/eap64-amq-s2i.adoc
+++ b/docs/eap/eap64-amq-s2i.adoc
@@ -44,8 +44,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`MQ_PASSWORD` | `MQ_PASSWORD` | Password for standard broker user. It is required for connecting to the broker. If left empty, it will be generated. | `${MQ_PASSWORD}` | False
 |`AMQ_MESH_DISCOVERY_TYPE` | `AMQ_MESH_DISCOVERY_TYPE` | The discovery agent type to use for discovering mesh endpoints.  'dns' will use OpenShift's DNS service to resolve endpoints.  'kube' will use Kubernetes REST API to resolve service endpoints.  If using 'kube' the service account for the pod must have the 'view' role, which can be added via 'oc policy add-role-to-user view system:serviceaccount:<namespace>:default' where <namespace> is the project namespace. | kube | False
 |`AMQ_STORAGE_USAGE_LIMIT` | `AMQ_STORAGE_USAGE_LIMIT` | The A-MQ storage usage limit | 100 gb | False
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`JGROUPS_ENCRYPT_SECRET` | `JGROUPS_ENCRYPT_SECRET` | The name of the secret containing the keystore file | eap-app-secret | False
 |`JGROUPS_ENCRYPT_KEYSTORE` | `JGROUPS_ENCRYPT_KEYSTORE_DIR` | The name of the keystore file within the secret | jgroups.jceks | False

--- a/docs/eap/eap64-basic-s2i.adoc
+++ b/docs/eap/eap64-basic-s2i.adoc
@@ -31,8 +31,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`HORNETQ_QUEUES` | `HORNETQ_QUEUES` | Queue names | `${HORNETQ_QUEUES}` | False
 |`HORNETQ_TOPICS` | `HORNETQ_TOPICS` | Topic names | `${HORNETQ_TOPICS}` | False
 |`HORNETQ_CLUSTER_PASSWORD` | `HORNETQ_CLUSTER_PASSWORD` | HornetQ cluster admin password | `${HORNETQ_CLUSTER_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`JGROUPS_CLUSTER_PASSWORD` | `JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}` | True
 |`AUTO_DEPLOY_EXPLODED` | `AUTO_DEPLOY_EXPLODED` | Controls whether exploded deployment content should be automatically deployed | false | False

--- a/docs/eap/eap64-https-s2i.adoc
+++ b/docs/eap/eap64-https-s2i.adoc
@@ -38,8 +38,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`HTTPS_NAME` | `HTTPS_NAME` | The name associated with the server certificate | `${HTTPS_NAME}` | False
 |`HTTPS_PASSWORD` | `HTTPS_PASSWORD` | The password for the keystore and certificate | `${HTTPS_PASSWORD}` | False
 |`HORNETQ_CLUSTER_PASSWORD` | `HORNETQ_CLUSTER_PASSWORD` | HornetQ cluster admin password | `${HORNETQ_CLUSTER_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`JGROUPS_ENCRYPT_SECRET` | `JGROUPS_ENCRYPT_SECRET` | The name of the secret containing the keystore file | eap-app-secret | False
 |`JGROUPS_ENCRYPT_KEYSTORE` | `JGROUPS_ENCRYPT_KEYSTORE_DIR` | The name of the keystore file within the secret | jgroups.jceks | False

--- a/docs/eap/eap64-mongodb-persistent-s2i.adoc
+++ b/docs/eap/eap64-mongodb-persistent-s2i.adoc
@@ -50,8 +50,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`DB_USERNAME` | `DB_USERNAME` | Database user name | `${DB_USERNAME}` | True
 |`DB_PASSWORD` | `DB_PASSWORD` | Database user password | `${DB_PASSWORD}` | True
 |`DB_ADMIN_PASSWORD` | `DB_ADMIN_PASSWORD` | Database admin password | `${DB_ADMIN_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`JGROUPS_ENCRYPT_SECRET` | `JGROUPS_ENCRYPT_SECRET` | The name of the secret containing the keystore file | eap-app-secret | False
 |`JGROUPS_ENCRYPT_KEYSTORE` | `JGROUPS_ENCRYPT_KEYSTORE_DIR` | The name of the keystore file within the secret | jgroups.jceks | False

--- a/docs/eap/eap64-mongodb-s2i.adoc
+++ b/docs/eap/eap64-mongodb-s2i.adoc
@@ -49,8 +49,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`DB_USERNAME` | `DB_USERNAME` | Database user name | `${DB_USERNAME}` | True
 |`DB_PASSWORD` | `DB_PASSWORD` | Database user password | `${DB_PASSWORD}` | True
 |`DB_ADMIN_PASSWORD` | `DB_ADMIN_PASSWORD` | Database admin password | `${DB_ADMIN_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`JGROUPS_ENCRYPT_SECRET` | `JGROUPS_ENCRYPT_SECRET` | The name of the secret containing the keystore file | eap-app-secret | False
 |`JGROUPS_ENCRYPT_KEYSTORE` | `JGROUPS_ENCRYPT_KEYSTORE_DIR` | The name of the keystore file within the secret | jgroups.jceks | False

--- a/docs/eap/eap64-mysql-persistent-s2i.adoc
+++ b/docs/eap/eap64-mysql-persistent-s2i.adoc
@@ -51,8 +51,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`HORNETQ_CLUSTER_PASSWORD` | `HORNETQ_CLUSTER_PASSWORD` | HornetQ cluster admin password | `${HORNETQ_CLUSTER_PASSWORD}` | True
 |`DB_USERNAME` | `DB_USERNAME` | Database user name | `${DB_USERNAME}` | True
 |`DB_PASSWORD` | `DB_PASSWORD` | Database user password | `${DB_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`JGROUPS_ENCRYPT_SECRET` | `JGROUPS_ENCRYPT_SECRET` | The name of the secret containing the keystore file | eap-app-secret | False
 |`JGROUPS_ENCRYPT_KEYSTORE` | `JGROUPS_ENCRYPT_KEYSTORE_DIR` | The name of the keystore file within the secret | jgroups.jceks | False

--- a/docs/eap/eap64-mysql-s2i.adoc
+++ b/docs/eap/eap64-mysql-s2i.adoc
@@ -50,8 +50,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`HORNETQ_CLUSTER_PASSWORD` | `HORNETQ_CLUSTER_PASSWORD` | HornetQ cluster admin password | `${HORNETQ_CLUSTER_PASSWORD}` | True
 |`DB_USERNAME` | `DB_USERNAME` | Database user name | `${DB_USERNAME}` | True
 |`DB_PASSWORD` | `DB_PASSWORD` | Database user password | `${DB_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`JGROUPS_ENCRYPT_SECRET` | `JGROUPS_ENCRYPT_SECRET` | The name of the secret containing the keystore file | eap-app-secret | False
 |`JGROUPS_ENCRYPT_KEYSTORE` | `JGROUPS_ENCRYPT_KEYSTORE_DIR` | The name of the keystore file within the secret | jgroups.jceks | False

--- a/docs/eap/eap64-postgresql-persistent-s2i.adoc
+++ b/docs/eap/eap64-postgresql-persistent-s2i.adoc
@@ -48,8 +48,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`HORNETQ_CLUSTER_PASSWORD` | `HORNETQ_CLUSTER_PASSWORD` | HornetQ cluster admin password | `${HORNETQ_CLUSTER_PASSWORD}` | True
 |`DB_USERNAME` | `DB_USERNAME` | Database user name | `${DB_USERNAME}` | True
 |`DB_PASSWORD` | `DB_PASSWORD` | Database user password | `${DB_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`JGROUPS_ENCRYPT_SECRET` | `JGROUPS_ENCRYPT_SECRET` | The name of the secret containing the keystore file | eap-app-secret | False
 |`JGROUPS_ENCRYPT_KEYSTORE` | `JGROUPS_ENCRYPT_KEYSTORE_DIR` | The name of the keystore file within the secret | jgroups.jceks | False

--- a/docs/eap/eap64-postgresql-s2i.adoc
+++ b/docs/eap/eap64-postgresql-s2i.adoc
@@ -47,8 +47,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`HORNETQ_CLUSTER_PASSWORD` | `HORNETQ_CLUSTER_PASSWORD` | HornetQ cluster admin password | `${HORNETQ_CLUSTER_PASSWORD}` | True
 |`DB_USERNAME` | `DB_USERNAME` | Database user name | `${DB_USERNAME}` | True
 |`DB_PASSWORD` | `DB_PASSWORD` | Database user password | `${DB_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`JGROUPS_ENCRYPT_SECRET` | `JGROUPS_ENCRYPT_SECRET` | The name of the secret containing the keystore file | eap-app-secret | False
 |`JGROUPS_ENCRYPT_KEYSTORE` | `JGROUPS_ENCRYPT_KEYSTORE_DIR` | The name of the keystore file within the secret | jgroups.jceks | False

--- a/docs/eap/eap64-sso-s2i.adoc
+++ b/docs/eap/eap64-sso-s2i.adoc
@@ -38,8 +38,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`HTTPS_NAME` | `HTTPS_NAME` | The name associated with the server certificate (e.g. jboss) | `${HTTPS_NAME}` | False
 |`HTTPS_PASSWORD` | `HTTPS_PASSWORD` | The password for the keystore and certificate (e.g. mykeystorepass) | `${HTTPS_PASSWORD}` | False
 |`HORNETQ_CLUSTER_PASSWORD` | `HORNETQ_CLUSTER_PASSWORD` | HornetQ cluster admin password | `${HORNETQ_CLUSTER_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`JGROUPS_ENCRYPT_SECRET` | `JGROUPS_ENCRYPT_SECRET` | The name of the secret containing the keystore file | eap-app-secret | False
 |`JGROUPS_ENCRYPT_KEYSTORE` | `JGROUPS_ENCRYPT_KEYSTORE_DIR` | The name of the keystore file within the secret | jgroups.jceks | False

--- a/docs/eap/eap70-amq-persistent-s2i.adoc
+++ b/docs/eap/eap70-amq-persistent-s2i.adoc
@@ -46,8 +46,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`MQ_PASSWORD` | `MQ_PASSWORD` | Password for standard broker user. It is required for connecting to the broker. If left empty, it will be generated. | `${MQ_PASSWORD}` | False
 |`AMQ_MESH_DISCOVERY_TYPE` | `AMQ_MESH_DISCOVERY_TYPE` | The discovery agent type to use for discovering mesh endpoints.  'dns' will use OpenShift's DNS service to resolve endpoints.  'kube' will use Kubernetes REST API to resolve service endpoints.  If using 'kube' the service account for the pod must have the 'view' role, which can be added via 'oc policy add-role-to-user view system:serviceaccount:<namespace>:default' where <namespace> is the project namespace. | kube | False
 |`AMQ_STORAGE_USAGE_LIMIT` | `AMQ_STORAGE_USAGE_LIMIT` | The A-MQ storage usage limit | 100 gb | False
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`JGROUPS_ENCRYPT_SECRET` | `JGROUPS_ENCRYPT_SECRET` | The name of the secret containing the keystore file | eap7-app-secret | False
 |`JGROUPS_ENCRYPT_KEYSTORE` | `JGROUPS_ENCRYPT_KEYSTORE_DIR` | The name of the keystore file within the secret | jgroups.jceks | False

--- a/docs/eap/eap70-amq-s2i.adoc
+++ b/docs/eap/eap70-amq-s2i.adoc
@@ -44,8 +44,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`MQ_PASSWORD` | `MQ_PASSWORD` | Password for standard broker user. It is required for connecting to the broker. If left empty, it will be generated. | `${MQ_PASSWORD}` | False
 |`AMQ_MESH_DISCOVERY_TYPE` | `AMQ_MESH_DISCOVERY_TYPE` | The discovery agent type to use for discovering mesh endpoints.  'dns' will use OpenShift's DNS service to resolve endpoints.  'kube' will use Kubernetes REST API to resolve service endpoints.  If using 'kube' the service account for the pod must have the 'view' role, which can be added via 'oc policy add-role-to-user view system:serviceaccount:<namespace>:default' where <namespace> is the project namespace. | kube | False
 |`AMQ_STORAGE_USAGE_LIMIT` | `AMQ_STORAGE_USAGE_LIMIT` | The A-MQ storage usage limit | 100 gb | False
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`JGROUPS_ENCRYPT_SECRET` | `JGROUPS_ENCRYPT_SECRET` | The name of the secret containing the keystore file | eap7-app-secret | False
 |`JGROUPS_ENCRYPT_KEYSTORE` | `JGROUPS_ENCRYPT_KEYSTORE_DIR` | The name of the keystore file within the secret | jgroups.jceks | False

--- a/docs/eap/eap70-basic-s2i.adoc
+++ b/docs/eap/eap70-basic-s2i.adoc
@@ -31,8 +31,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`MQ_QUEUES` | `MQ_QUEUES` | Queue names | `${MQ_QUEUES}` | False
 |`MQ_TOPICS` | `MQ_TOPICS` | Topic names | `${MQ_TOPICS}` | False
 |`MQ_CLUSTER_PASSWORD` | `MQ_CLUSTER_PASSWORD` | A-MQ cluster admin password | `${MQ_CLUSTER_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`JGROUPS_CLUSTER_PASSWORD` | `JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}` | True
 |`AUTO_DEPLOY_EXPLODED` | `AUTO_DEPLOY_EXPLODED` | Controls whether exploded deployment content should be automatically deployed | false | False

--- a/docs/eap/eap70-https-s2i.adoc
+++ b/docs/eap/eap70-https-s2i.adoc
@@ -38,8 +38,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`HTTPS_NAME` | `HTTPS_NAME` | The name associated with the server certificate | `${HTTPS_NAME}` | False
 |`HTTPS_PASSWORD` | `HTTPS_PASSWORD` | The password for the keystore and certificate | `${HTTPS_PASSWORD}` | False
 |`MQ_CLUSTER_PASSWORD` | `MQ_CLUSTER_PASSWORD` | A-MQ cluster admin password | `${MQ_CLUSTER_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`JGROUPS_ENCRYPT_SECRET` | `JGROUPS_ENCRYPT_SECRET` | The name of the secret containing the keystore file | eap7-app-secret | False
 |`JGROUPS_ENCRYPT_KEYSTORE` | `JGROUPS_ENCRYPT_KEYSTORE_DIR` | The name of the keystore file within the secret | jgroups.jceks | False

--- a/docs/eap/eap70-mongodb-persistent-s2i.adoc
+++ b/docs/eap/eap70-mongodb-persistent-s2i.adoc
@@ -50,8 +50,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`DB_USERNAME` | `DB_USERNAME` | Database user name | `${DB_USERNAME}` | True
 |`DB_PASSWORD` | `DB_PASSWORD` | Database user password | `${DB_PASSWORD}` | True
 |`DB_ADMIN_PASSWORD` | `DB_ADMIN_PASSWORD` | Database admin password | `${DB_ADMIN_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`JGROUPS_ENCRYPT_SECRET` | `JGROUPS_ENCRYPT_SECRET` | The name of the secret containing the keystore file | eap7-app-secret | False
 |`JGROUPS_ENCRYPT_KEYSTORE` | `JGROUPS_ENCRYPT_KEYSTORE_DIR` | The name of the keystore file within the secret | jgroups.jceks | False

--- a/docs/eap/eap70-mongodb-s2i.adoc
+++ b/docs/eap/eap70-mongodb-s2i.adoc
@@ -49,8 +49,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`DB_USERNAME` | `DB_USERNAME` | Database user name | `${DB_USERNAME}` | True
 |`DB_PASSWORD` | `DB_PASSWORD` | Database user password | `${DB_PASSWORD}` | True
 |`DB_ADMIN_PASSWORD` | `DB_ADMIN_PASSWORD` | Database admin password | `${DB_ADMIN_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`JGROUPS_ENCRYPT_SECRET` | `JGROUPS_ENCRYPT_SECRET` | The name of the secret containing the keystore file | eap7-app-secret | False
 |`JGROUPS_ENCRYPT_KEYSTORE` | `JGROUPS_ENCRYPT_KEYSTORE_DIR` | The name of the keystore file within the secret | jgroups.jceks | False

--- a/docs/eap/eap70-mysql-persistent-s2i.adoc
+++ b/docs/eap/eap70-mysql-persistent-s2i.adoc
@@ -51,8 +51,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`MQ_CLUSTER_PASSWORD` | `MQ_CLUSTER_PASSWORD` | A-MQ cluster admin password | `${MQ_CLUSTER_PASSWORD}` | True
 |`DB_USERNAME` | `DB_USERNAME` | Database user name | `${DB_USERNAME}` | True
 |`DB_PASSWORD` | `DB_PASSWORD` | Database user password | `${DB_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`JGROUPS_ENCRYPT_SECRET` | `JGROUPS_ENCRYPT_SECRET` | The name of the secret containing the keystore file | eap7-app-secret | False
 |`JGROUPS_ENCRYPT_KEYSTORE` | `JGROUPS_ENCRYPT_KEYSTORE_DIR` | The name of the keystore file within the secret | jgroups.jceks | False

--- a/docs/eap/eap70-mysql-s2i.adoc
+++ b/docs/eap/eap70-mysql-s2i.adoc
@@ -50,8 +50,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`MQ_CLUSTER_PASSWORD` | `MQ_CLUSTER_PASSWORD` | A-MQ cluster admin password | `${MQ_CLUSTER_PASSWORD}` | True
 |`DB_USERNAME` | `DB_USERNAME` | Database user name | `${DB_USERNAME}` | True
 |`DB_PASSWORD` | `DB_PASSWORD` | Database user password | `${DB_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`JGROUPS_ENCRYPT_SECRET` | `JGROUPS_ENCRYPT_SECRET` | The name of the secret containing the keystore file | eap7-app-secret | False
 |`JGROUPS_ENCRYPT_KEYSTORE` | `JGROUPS_ENCRYPT_KEYSTORE_DIR` | The name of the keystore file within the secret | jgroups.jceks | False

--- a/docs/eap/eap70-postgresql-persistent-s2i.adoc
+++ b/docs/eap/eap70-postgresql-persistent-s2i.adoc
@@ -48,8 +48,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`MQ_CLUSTER_PASSWORD` | `MQ_CLUSTER_PASSWORD` | A-MQ cluster admin password | `${MQ_CLUSTER_PASSWORD}` | True
 |`DB_USERNAME` | `DB_USERNAME` | Database user name | `${DB_USERNAME}` | True
 |`DB_PASSWORD` | `DB_PASSWORD` | Database user password | `${DB_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`JGROUPS_ENCRYPT_SECRET` | `JGROUPS_ENCRYPT_SECRET` | The name of the secret containing the keystore file | eap7-app-secret | False
 |`JGROUPS_ENCRYPT_KEYSTORE` | `JGROUPS_ENCRYPT_KEYSTORE_DIR` | The name of the keystore file within the secret | jgroups.jceks | False

--- a/docs/eap/eap70-postgresql-s2i.adoc
+++ b/docs/eap/eap70-postgresql-s2i.adoc
@@ -47,8 +47,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`MQ_CLUSTER_PASSWORD` | `MQ_CLUSTER_PASSWORD` | A-MQ cluster admin password | `${MQ_CLUSTER_PASSWORD}` | True
 |`DB_USERNAME` | `DB_USERNAME` | Database user name | `${DB_USERNAME}` | True
 |`DB_PASSWORD` | `DB_PASSWORD` | Database user password | `${DB_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`JGROUPS_ENCRYPT_SECRET` | `JGROUPS_ENCRYPT_SECRET` | The name of the secret containing the keystore file | eap7-app-secret | False
 |`JGROUPS_ENCRYPT_KEYSTORE` | `JGROUPS_ENCRYPT_KEYSTORE_DIR` | The name of the keystore file within the secret | jgroups.jceks | False

--- a/docs/eap/eap70-sso-s2i.adoc
+++ b/docs/eap/eap70-sso-s2i.adoc
@@ -38,8 +38,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`HTTPS_NAME` | `HTTPS_NAME` | The name associated with the server certificate (e.g. jboss) | `${HTTPS_NAME}` | False
 |`HTTPS_PASSWORD` | `HTTPS_PASSWORD` | The password for the keystore and certificate (e.g. mykeystorepass) | `${HTTPS_PASSWORD}` | False
 |`HORNETQ_CLUSTER_PASSWORD` | `HORNETQ_CLUSTER_PASSWORD` | HornetQ cluster admin password | `${HORNETQ_CLUSTER_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`JGROUPS_ENCRYPT_SECRET` | `JGROUPS_ENCRYPT_SECRET` | The name of the secret containing the keystore file | eap7-app-secret | False
 |`JGROUPS_ENCRYPT_KEYSTORE` | `JGROUPS_ENCRYPT_KEYSTORE_DIR` | The name of the keystore file within the secret | jgroups.jceks | False

--- a/docs/processserver/processserver63-amq-mysql-persistent-s2i.adoc
+++ b/docs/processserver/processserver63-amq-mysql-persistent-s2i.adoc
@@ -65,8 +65,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`MQ_PASSWORD` | `MQ_PASSWORD` | Password for standard broker user. It is required for connecting to the broker. If left empty, it will be generated. | `${MQ_PASSWORD}` | False
 |`AMQ_MESH_DISCOVERY_TYPE` | `AMQ_MESH_DISCOVERY_TYPE` | The discovery agent type to use for discovering mesh endpoints.  'dns' will use OpenShift's DNS service to resolve endpoints.  'kube' will use Kubernetes REST API to resolve service endpoints.  If using 'kube' the service account for the pod must have the 'view' role, which can be added via 'oc policy add-role-to-user view system:serviceaccount:<namespace>:default' where <namespace> is the project namespace. | kube | False
 |`AMQ_STORAGE_USAGE_LIMIT` | `AMQ_STORAGE_USAGE_LIMIT` | The A-MQ storage usage limit | 100 gb | False
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`MAVEN_MIRROR_URL` | -- | Maven mirror to use for S2I builds | -- | False
 |`ARTIFACT_DIR` | -- | List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied. | -- | False

--- a/docs/processserver/processserver63-amq-mysql-s2i.adoc
+++ b/docs/processserver/processserver63-amq-mysql-s2i.adoc
@@ -63,8 +63,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`MQ_PASSWORD` | `MQ_PASSWORD` | Password for standard broker user. It is required for connecting to the broker. If left empty, it will be generated. | `${MQ_PASSWORD}` | False
 |`AMQ_MESH_DISCOVERY_TYPE` | `AMQ_MESH_DISCOVERY_TYPE` | The discovery agent type to use for discovering mesh endpoints.  'dns' will use OpenShift's DNS service to resolve endpoints.  'kube' will use Kubernetes REST API to resolve service endpoints.  If using 'kube' the service account for the pod must have the 'view' role, which can be added via 'oc policy add-role-to-user view system:serviceaccount:<namespace>:default' where <namespace> is the project namespace. | kube | False
 |`AMQ_STORAGE_USAGE_LIMIT` | `AMQ_STORAGE_USAGE_LIMIT` | The A-MQ storage usage limit | 100 gb | False
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`MAVEN_MIRROR_URL` | -- | Maven mirror to use for S2I builds | -- | False
 |`ARTIFACT_DIR` | -- | List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied. | -- | False

--- a/docs/processserver/processserver63-amq-postgresql-persistent-s2i.adoc
+++ b/docs/processserver/processserver63-amq-postgresql-persistent-s2i.adoc
@@ -62,8 +62,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`MQ_PASSWORD` | `MQ_PASSWORD` | Password for standard broker user. It is required for connecting to the broker. If left empty, it will be generated. | `${MQ_PASSWORD}` | False
 |`AMQ_MESH_DISCOVERY_TYPE` | `AMQ_MESH_DISCOVERY_TYPE` | The discovery agent type to use for discovering mesh endpoints.  'dns' will use OpenShift's DNS service to resolve endpoints.  'kube' will use Kubernetes REST API to resolve service endpoints.  If using 'kube' the service account for the pod must have the 'view' role, which can be added via 'oc policy add-role-to-user view system:serviceaccount:<namespace>:default' where <namespace> is the project namespace. | kube | False
 |`AMQ_STORAGE_USAGE_LIMIT` | `AMQ_STORAGE_USAGE_LIMIT` | The A-MQ storage usage limit | 100 gb | False
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`MAVEN_MIRROR_URL` | -- | Maven mirror to use for S2I builds | -- | False
 |`ARTIFACT_DIR` | -- | List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied. | -- | False

--- a/docs/processserver/processserver63-amq-postgresql-s2i.adoc
+++ b/docs/processserver/processserver63-amq-postgresql-s2i.adoc
@@ -60,8 +60,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`MQ_PASSWORD` | `MQ_PASSWORD` | Password for standard broker user. It is required for connecting to the broker. If left empty, it will be generated. | `${MQ_PASSWORD}` | False
 |`AMQ_MESH_DISCOVERY_TYPE` | `AMQ_MESH_DISCOVERY_TYPE` | The discovery agent type to use for discovering mesh endpoints.  'dns' will use OpenShift's DNS service to resolve endpoints.  'kube' will use Kubernetes REST API to resolve service endpoints.  If using 'kube' the service account for the pod must have the 'view' role, which can be added via 'oc policy add-role-to-user view system:serviceaccount:<namespace>:default' where <namespace> is the project namespace. | kube | False
 |`AMQ_STORAGE_USAGE_LIMIT` | `AMQ_STORAGE_USAGE_LIMIT` | The A-MQ storage usage limit | 100 gb | False
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`MAVEN_MIRROR_URL` | -- | Maven mirror to use for S2I builds | -- | False
 |`ARTIFACT_DIR` | -- | List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied. | -- | False

--- a/docs/processserver/processserver63-basic-s2i.adoc
+++ b/docs/processserver/processserver63-basic-s2i.adoc
@@ -35,8 +35,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`HORNETQ_QUEUES` | `HORNETQ_QUEUES` | Queue names | `${HORNETQ_QUEUES}` | False
 |`HORNETQ_TOPICS` | `HORNETQ_TOPICS` | Topic names | `${HORNETQ_TOPICS}` | False
 |`HORNETQ_CLUSTER_PASSWORD` | `HORNETQ_CLUSTER_PASSWORD` | HornetQ cluster admin password | `${HORNETQ_CLUSTER_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`MAVEN_MIRROR_URL` | -- | Maven mirror to use for S2I builds | -- | False
 |`ARTIFACT_DIR` | -- | List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied. | -- | False

--- a/docs/processserver/processserver63-mysql-persistent-s2i.adoc
+++ b/docs/processserver/processserver63-mysql-persistent-s2i.adoc
@@ -56,8 +56,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`MYSQL_FT_MAX_WORD_LEN` | `MYSQL_FT_MAX_WORD_LEN` | The maximum length of the word to be included in a FULLTEXT index. | `${MYSQL_FT_MAX_WORD_LEN}` | False
 |`MYSQL_AIO` | `MYSQL_AIO` | Controls the innodb_use_native_aio setting value if the native AIO is broken. | `${MYSQL_AIO}` | False
 |`HORNETQ_CLUSTER_PASSWORD` | `HORNETQ_CLUSTER_PASSWORD` | HornetQ cluster admin password | `${HORNETQ_CLUSTER_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`MAVEN_MIRROR_URL` | -- | Maven mirror to use for S2I builds | -- | False
 |`ARTIFACT_DIR` | -- | List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied. | -- | False

--- a/docs/processserver/processserver63-mysql-s2i.adoc
+++ b/docs/processserver/processserver63-mysql-s2i.adoc
@@ -55,8 +55,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`MYSQL_FT_MAX_WORD_LEN` | `MYSQL_FT_MAX_WORD_LEN` | The maximum length of the word to be included in a FULLTEXT index. | `${MYSQL_FT_MAX_WORD_LEN}` | False
 |`MYSQL_AIO` | `MYSQL_AIO` | Controls the innodb_use_native_aio setting value if the native AIO is broken. | `${MYSQL_AIO}` | False
 |`HORNETQ_CLUSTER_PASSWORD` | `HORNETQ_CLUSTER_PASSWORD` | HornetQ cluster admin password | `${HORNETQ_CLUSTER_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`MAVEN_MIRROR_URL` | -- | Maven mirror to use for S2I builds | -- | False
 |`ARTIFACT_DIR` | -- | List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied. | -- | False

--- a/docs/processserver/processserver63-postgresql-persistent-s2i.adoc
+++ b/docs/processserver/processserver63-postgresql-persistent-s2i.adoc
@@ -53,8 +53,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`POSTGRESQL_MAX_CONNECTIONS` | `POSTGRESQL_MAX_CONNECTIONS` | The maximum number of client connections allowed. This also sets the maximum number of prepared transactions. | `${POSTGRESQL_MAX_CONNECTIONS}` | False
 |`POSTGRESQL_SHARED_BUFFERS` | `POSTGRESQL_SHARED_BUFFERS` | Configures how much memory is dedicated to PostgreSQL for caching data. | `${POSTGRESQL_SHARED_BUFFERS}` | False
 |`HORNETQ_CLUSTER_PASSWORD` | `HORNETQ_CLUSTER_PASSWORD` | HornetQ cluster admin password | `${HORNETQ_CLUSTER_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`MAVEN_MIRROR_URL` | -- | Maven mirror to use for S2I builds | -- | False
 |`ARTIFACT_DIR` | -- | List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied. | -- | False

--- a/docs/processserver/processserver63-postgresql-s2i.adoc
+++ b/docs/processserver/processserver63-postgresql-s2i.adoc
@@ -52,8 +52,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`POSTGRESQL_MAX_CONNECTIONS` | `POSTGRESQL_MAX_CONNECTIONS` | The maximum number of client connections allowed. This also sets the maximum number of prepared transactions. | `${POSTGRESQL_MAX_CONNECTIONS}` | False
 |`POSTGRESQL_SHARED_BUFFERS` | `POSTGRESQL_SHARED_BUFFERS` | Configures how much memory is dedicated to PostgreSQL for caching data. | `${POSTGRESQL_SHARED_BUFFERS}` | False
 |`HORNETQ_CLUSTER_PASSWORD` | `HORNETQ_CLUSTER_PASSWORD` | HornetQ cluster admin password | `${HORNETQ_CLUSTER_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`MAVEN_MIRROR_URL` | -- | Maven mirror to use for S2I builds | -- | False
 |`ARTIFACT_DIR` | -- | List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied. | -- | False

--- a/docs/webserver/jws30-tomcat7-basic-s2i.adoc
+++ b/docs/webserver/jws30-tomcat7-basic-s2i.adoc
@@ -30,8 +30,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`CONTEXT_DIR` | -- | Path within Git project to build; empty for root project directory. | tomcat-websocket-chat | False
 |`JWS_ADMIN_USERNAME` | `JWS_ADMIN_USERNAME` | JWS Admin User | `${JWS_ADMIN_USERNAME}` | True
 |`JWS_ADMIN_PASSWORD` | `JWS_ADMIN_PASSWORD` | JWS Admin Password | `${JWS_ADMIN_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`MAVEN_MIRROR_URL` | -- | Maven mirror to use for S2I builds | -- | False
 |`ARTIFACT_DIR` | -- | List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied. | -- | False

--- a/docs/webserver/jws30-tomcat7-https-s2i.adoc
+++ b/docs/webserver/jws30-tomcat7-https-s2i.adoc
@@ -35,8 +35,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`JWS_HTTPS_CERTIFICATE_PASSWORD` | `JWS_HTTPS_CERTIFICATE` | The certificate password | `${JWS_HTTPS_CERTIFICATE}` | False
 |`JWS_ADMIN_USERNAME` | `JWS_ADMIN_USERNAME` | JWS Admin User | `${JWS_ADMIN_USERNAME}` | True
 |`JWS_ADMIN_PASSWORD` | `JWS_ADMIN_PASSWORD` | JWS Admin Password | `${JWS_ADMIN_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`MAVEN_MIRROR_URL` | -- | Maven mirror to use for S2I builds | -- | False
 |`ARTIFACT_DIR` | -- | List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied. | -- | False

--- a/docs/webserver/jws30-tomcat7-mongodb-persistent-s2i.adoc
+++ b/docs/webserver/jws30-tomcat7-mongodb-persistent-s2i.adoc
@@ -47,8 +47,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`DB_ADMIN_PASSWORD` | `DB_ADMIN_PASSWORD` | Database admin password | `${DB_ADMIN_PASSWORD}` | True
 |`JWS_ADMIN_USERNAME` | `JWS_ADMIN_USERNAME` | JWS Admin User | `${JWS_ADMIN_USERNAME}` | True
 |`JWS_ADMIN_PASSWORD` | `JWS_ADMIN_PASSWORD` | JWS Admin Password | `${JWS_ADMIN_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`MAVEN_MIRROR_URL` | -- | Maven mirror to use for S2I builds | -- | False
 |`ARTIFACT_DIR` | -- | List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied. | -- | False

--- a/docs/webserver/jws30-tomcat7-mongodb-s2i.adoc
+++ b/docs/webserver/jws30-tomcat7-mongodb-s2i.adoc
@@ -46,8 +46,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`DB_ADMIN_PASSWORD` | `DB_ADMIN_PASSWORD` | Database admin password | `${DB_ADMIN_PASSWORD}` | True
 |`JWS_ADMIN_USERNAME` | `JWS_ADMIN_USERNAME` | JWS Admin User | `${JWS_ADMIN_USERNAME}` | True
 |`JWS_ADMIN_PASSWORD` | `JWS_ADMIN_PASSWORD` | JWS Admin Password | `${JWS_ADMIN_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`MAVEN_MIRROR_URL` | -- | Maven mirror to use for S2I builds | -- | False
 |`ARTIFACT_DIR` | -- | List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied. | -- | False

--- a/docs/webserver/jws30-tomcat7-mysql-persistent-s2i.adoc
+++ b/docs/webserver/jws30-tomcat7-mysql-persistent-s2i.adoc
@@ -48,8 +48,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`DB_PASSWORD` | `DB_PASSWORD` | Database user password | `${DB_PASSWORD}` | True
 |`JWS_ADMIN_USERNAME` | `JWS_ADMIN_USERNAME` | JWS Admin User | `${JWS_ADMIN_USERNAME}` | True
 |`JWS_ADMIN_PASSWORD` | `JWS_ADMIN_PASSWORD` | JWS Admin Password | `${JWS_ADMIN_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`MAVEN_MIRROR_URL` | -- | Maven mirror to use for S2I builds | -- | False
 |`ARTIFACT_DIR` | -- | List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied. | -- | False

--- a/docs/webserver/jws30-tomcat7-mysql-s2i.adoc
+++ b/docs/webserver/jws30-tomcat7-mysql-s2i.adoc
@@ -47,8 +47,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`DB_PASSWORD` | `DB_PASSWORD` | Database user password | `${DB_PASSWORD}` | True
 |`JWS_ADMIN_USERNAME` | `JWS_ADMIN_USERNAME` | JWS Admin User | `${JWS_ADMIN_USERNAME}` | True
 |`JWS_ADMIN_PASSWORD` | `JWS_ADMIN_PASSWORD` | JWS Admin Password | `${JWS_ADMIN_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`MAVEN_MIRROR_URL` | -- | Maven mirror to use for S2I builds | -- | False
 |`ARTIFACT_DIR` | -- | List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied. | -- | False

--- a/docs/webserver/jws30-tomcat7-postgresql-persistent-s2i.adoc
+++ b/docs/webserver/jws30-tomcat7-postgresql-persistent-s2i.adoc
@@ -45,8 +45,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`DB_PASSWORD` | `DB_PASSWORD` | Database user password | `${DB_PASSWORD}` | True
 |`JWS_ADMIN_USERNAME` | `JWS_ADMIN_USERNAME` | JWS Admin User | `${JWS_ADMIN_USERNAME}` | True
 |`JWS_ADMIN_PASSWORD` | `JWS_ADMIN_PASSWORD` | JWS Admin Password | `${JWS_ADMIN_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`MAVEN_MIRROR_URL` | -- | Maven mirror to use for S2I builds | -- | False
 |`ARTIFACT_DIR` | -- | List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied. | -- | False

--- a/docs/webserver/jws30-tomcat7-postgresql-s2i.adoc
+++ b/docs/webserver/jws30-tomcat7-postgresql-s2i.adoc
@@ -44,8 +44,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`DB_PASSWORD` | `DB_PASSWORD` | Database user password | `${DB_PASSWORD}` | True
 |`JWS_ADMIN_USERNAME` | `JWS_ADMIN_USERNAME` | JWS Admin User | `${JWS_ADMIN_USERNAME}` | True
 |`JWS_ADMIN_PASSWORD` | `JWS_ADMIN_PASSWORD` | JWS Admin Password | `${JWS_ADMIN_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`MAVEN_MIRROR_URL` | -- | Maven mirror to use for S2I builds | -- | False
 |`ARTIFACT_DIR` | -- | List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied. | -- | False

--- a/docs/webserver/jws30-tomcat8-basic-s2i.adoc
+++ b/docs/webserver/jws30-tomcat8-basic-s2i.adoc
@@ -30,8 +30,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`CONTEXT_DIR` | -- | Path within Git project to build; empty for root project directory. | tomcat-websocket-chat | False
 |`JWS_ADMIN_USERNAME` | `JWS_ADMIN_USERNAME` | JWS Admin User | `${JWS_ADMIN_USERNAME}` | True
 |`JWS_ADMIN_PASSWORD` | `JWS_ADMIN_PASSWORD` | JWS Admin Password | `${JWS_ADMIN_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`MAVEN_MIRROR_URL` | -- | Maven mirror to use for S2I builds | -- | False
 |`ARTIFACT_DIR` | -- | List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied. | -- | False

--- a/docs/webserver/jws30-tomcat8-https-s2i.adoc
+++ b/docs/webserver/jws30-tomcat8-https-s2i.adoc
@@ -35,8 +35,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`JWS_HTTPS_CERTIFICATE_PASSWORD` | `JWS_HTTPS_CERTIFICATE` | The certificate password | `${JWS_HTTPS_CERTIFICATE}` | False
 |`JWS_ADMIN_USERNAME` | `JWS_ADMIN_USERNAME` | JWS Admin User | `${JWS_ADMIN_USERNAME}` | True
 |`JWS_ADMIN_PASSWORD` | `JWS_ADMIN_PASSWORD` | JWS Admin Password | `${JWS_ADMIN_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`MAVEN_MIRROR_URL` | -- | Maven mirror to use for S2I builds | -- | False
 |`ARTIFACT_DIR` | -- | List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied. | -- | False

--- a/docs/webserver/jws30-tomcat8-mongodb-persistent-s2i.adoc
+++ b/docs/webserver/jws30-tomcat8-mongodb-persistent-s2i.adoc
@@ -47,8 +47,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`DB_ADMIN_PASSWORD` | `DB_ADMIN_PASSWORD` | Database admin password | `${DB_ADMIN_PASSWORD}` | True
 |`JWS_ADMIN_USERNAME` | `JWS_ADMIN_USERNAME` | JWS Admin User | `${JWS_ADMIN_USERNAME}` | True
 |`JWS_ADMIN_PASSWORD` | `JWS_ADMIN_PASSWORD` | JWS Admin Password | `${JWS_ADMIN_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`MAVEN_MIRROR_URL` | -- | Maven mirror to use for S2I builds | -- | False
 |`ARTIFACT_DIR` | -- | List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied. | -- | False

--- a/docs/webserver/jws30-tomcat8-mongodb-s2i.adoc
+++ b/docs/webserver/jws30-tomcat8-mongodb-s2i.adoc
@@ -46,8 +46,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`DB_ADMIN_PASSWORD` | `DB_ADMIN_PASSWORD` | Database admin password | `${DB_ADMIN_PASSWORD}` | True
 |`JWS_ADMIN_USERNAME` | `JWS_ADMIN_USERNAME` | JWS Admin User | `${JWS_ADMIN_USERNAME}` | True
 |`JWS_ADMIN_PASSWORD` | `JWS_ADMIN_PASSWORD` | JWS Admin Password | `${JWS_ADMIN_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`MAVEN_MIRROR_URL` | -- | Maven mirror to use for S2I builds | -- | False
 |`ARTIFACT_DIR` | -- | List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied. | -- | False

--- a/docs/webserver/jws30-tomcat8-mysql-persistent-s2i.adoc
+++ b/docs/webserver/jws30-tomcat8-mysql-persistent-s2i.adoc
@@ -48,8 +48,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`DB_PASSWORD` | `DB_PASSWORD` | Database user password | `${DB_PASSWORD}` | True
 |`JWS_ADMIN_USERNAME` | `JWS_ADMIN_USERNAME` | JWS Admin User | `${JWS_ADMIN_USERNAME}` | True
 |`JWS_ADMIN_PASSWORD` | `JWS_ADMIN_PASSWORD` | JWS Admin Password | `${JWS_ADMIN_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`MAVEN_MIRROR_URL` | -- | Maven mirror to use for S2I builds | -- | False
 |`ARTIFACT_DIR` | -- | List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied. | -- | False

--- a/docs/webserver/jws30-tomcat8-mysql-s2i.adoc
+++ b/docs/webserver/jws30-tomcat8-mysql-s2i.adoc
@@ -47,8 +47,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`DB_PASSWORD` | `DB_PASSWORD` | Database user password | `${DB_PASSWORD}` | True
 |`JWS_ADMIN_USERNAME` | `JWS_ADMIN_USERNAME` | JWS Admin User | `${JWS_ADMIN_USERNAME}` | True
 |`JWS_ADMIN_PASSWORD` | `JWS_ADMIN_PASSWORD` | JWS Admin Password | `${JWS_ADMIN_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`MAVEN_MIRROR_URL` | -- | Maven mirror to use for S2I builds | -- | False
 |`ARTIFACT_DIR` | -- | List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied. | -- | False

--- a/docs/webserver/jws30-tomcat8-postgresql-persistent-s2i.adoc
+++ b/docs/webserver/jws30-tomcat8-postgresql-persistent-s2i.adoc
@@ -45,8 +45,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`DB_PASSWORD` | `DB_PASSWORD` | Database user password | `${DB_PASSWORD}` | True
 |`JWS_ADMIN_USERNAME` | `JWS_ADMIN_USERNAME` | JWS Admin User | `${JWS_ADMIN_USERNAME}` | True
 |`JWS_ADMIN_PASSWORD` | `JWS_ADMIN_PASSWORD` | JWS Admin Password | `${JWS_ADMIN_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`MAVEN_MIRROR_URL` | -- | Maven mirror to use for S2I builds | -- | False
 |`ARTIFACT_DIR` | -- | List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied. | -- | False

--- a/docs/webserver/jws30-tomcat8-postgresql-s2i.adoc
+++ b/docs/webserver/jws30-tomcat8-postgresql-s2i.adoc
@@ -44,8 +44,8 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`DB_PASSWORD` | `DB_PASSWORD` | Database user password | `${DB_PASSWORD}` | True
 |`JWS_ADMIN_USERNAME` | `JWS_ADMIN_USERNAME` | JWS Admin User | `${JWS_ADMIN_USERNAME}` | True
 |`JWS_ADMIN_PASSWORD` | `JWS_ADMIN_PASSWORD` | JWS Admin Password | `${JWS_ADMIN_PASSWORD}` | True
-|`GITHUB_WEBHOOK_SECRET` | -- | GitHub trigger secret | secret101 | True
-|`GENERIC_WEBHOOK_SECRET` | -- | Generic build trigger secret | secret101 | True
+|`GITHUB_WEBHOOK_SECRET` | -- | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
+|`GENERIC_WEBHOOK_SECRET` | -- | Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted. | secret101 | True
 |`IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project. | openshift | True
 |`MAVEN_MIRROR_URL` | -- | Maven mirror to use for S2I builds | -- | False
 |`ARTIFACT_DIR` | -- | List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied. | -- | False

--- a/eap/eap64-amq-persistent-s2i.json
+++ b/eap/eap64-amq-persistent-s2i.json
@@ -182,7 +182,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -190,7 +190,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/eap/eap64-amq-s2i.json
+++ b/eap/eap64-amq-s2i.json
@@ -168,7 +168,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -176,7 +176,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/eap/eap64-basic-s2i.json
+++ b/eap/eap64-basic-s2i.json
@@ -76,7 +76,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -84,7 +84,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/eap/eap64-https-s2i.json
+++ b/eap/eap64-https-s2i.json
@@ -125,7 +125,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -133,7 +133,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/eap/eap64-mongodb-persistent-s2i.json
+++ b/eap/eap64-mongodb-persistent-s2i.json
@@ -206,7 +206,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -214,7 +214,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/eap/eap64-mongodb-s2i.json
+++ b/eap/eap64-mongodb-s2i.json
@@ -199,7 +199,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -207,7 +207,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/eap/eap64-mysql-persistent-s2i.json
+++ b/eap/eap64-mysql-persistent-s2i.json
@@ -210,7 +210,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -218,7 +218,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/eap/eap64-mysql-s2i.json
+++ b/eap/eap64-mysql-s2i.json
@@ -203,7 +203,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -211,7 +211,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/eap/eap64-postgresql-persistent-s2i.json
+++ b/eap/eap64-postgresql-persistent-s2i.json
@@ -192,7 +192,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -200,7 +200,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/eap/eap64-postgresql-s2i.json
+++ b/eap/eap64-postgresql-s2i.json
@@ -185,7 +185,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -193,7 +193,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/eap/eap64-sso-s2i.json
+++ b/eap/eap64-sso-s2i.json
@@ -125,7 +125,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -133,7 +133,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/eap/eap70-amq-persistent-s2i.json
+++ b/eap/eap70-amq-persistent-s2i.json
@@ -182,7 +182,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -190,7 +190,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/eap/eap70-amq-s2i.json
+++ b/eap/eap70-amq-s2i.json
@@ -168,7 +168,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -176,7 +176,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/eap/eap70-basic-s2i.json
+++ b/eap/eap70-basic-s2i.json
@@ -76,7 +76,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -84,7 +84,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/eap/eap70-https-s2i.json
+++ b/eap/eap70-https-s2i.json
@@ -125,7 +125,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -133,7 +133,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/eap/eap70-mongodb-persistent-s2i.json
+++ b/eap/eap70-mongodb-persistent-s2i.json
@@ -206,7 +206,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -214,7 +214,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/eap/eap70-mongodb-s2i.json
+++ b/eap/eap70-mongodb-s2i.json
@@ -199,7 +199,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -207,7 +207,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/eap/eap70-mysql-persistent-s2i.json
+++ b/eap/eap70-mysql-persistent-s2i.json
@@ -210,7 +210,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -218,7 +218,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/eap/eap70-mysql-s2i.json
+++ b/eap/eap70-mysql-s2i.json
@@ -203,7 +203,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -211,7 +211,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/eap/eap70-postgresql-persistent-s2i.json
+++ b/eap/eap70-postgresql-persistent-s2i.json
@@ -192,7 +192,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -200,7 +200,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/eap/eap70-postgresql-s2i.json
+++ b/eap/eap70-postgresql-s2i.json
@@ -185,7 +185,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -193,7 +193,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/eap/eap70-sso-s2i.json
+++ b/eap/eap70-sso-s2i.json
@@ -125,7 +125,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -133,7 +133,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/openjdk/openjdk18-web-basic-s2i.json
+++ b/openjdk/openjdk18-web-basic-s2i.json
@@ -53,7 +53,7 @@
             "required": false
         },
         {
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "displayName": "Github Webhook Secret",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
@@ -61,7 +61,7 @@
             "required": true
         },
         {
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "displayName": "Generic Webhook Secret",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",

--- a/processserver/processserver63-amq-mysql-persistent-s2i.json
+++ b/processserver/processserver63-amq-mysql-persistent-s2i.json
@@ -310,7 +310,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -318,7 +318,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/processserver/processserver63-amq-mysql-s2i.json
+++ b/processserver/processserver63-amq-mysql-s2i.json
@@ -296,7 +296,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -304,7 +304,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/processserver/processserver63-amq-postgresql-persistent-s2i.json
+++ b/processserver/processserver63-amq-postgresql-persistent-s2i.json
@@ -292,7 +292,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -300,7 +300,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/processserver/processserver63-amq-postgresql-s2i.json
+++ b/processserver/processserver63-amq-postgresql-s2i.json
@@ -278,7 +278,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -286,7 +286,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/processserver/processserver63-basic-s2i.json
+++ b/processserver/processserver63-basic-s2i.json
@@ -105,7 +105,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -113,7 +113,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/processserver/processserver63-mysql-persistent-s2i.json
+++ b/processserver/processserver63-mysql-persistent-s2i.json
@@ -246,7 +246,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -254,7 +254,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/processserver/processserver63-mysql-s2i.json
+++ b/processserver/processserver63-mysql-s2i.json
@@ -239,7 +239,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -247,7 +247,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/processserver/processserver63-postgresql-persistent-s2i.json
+++ b/processserver/processserver63-postgresql-persistent-s2i.json
@@ -228,7 +228,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -236,7 +236,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/processserver/processserver63-postgresql-s2i.json
+++ b/processserver/processserver63-postgresql-s2i.json
@@ -221,7 +221,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -229,7 +229,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/webserver/jws30-tomcat7-basic-s2i.json
+++ b/webserver/jws30-tomcat7-basic-s2i.json
@@ -70,7 +70,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -78,7 +78,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/webserver/jws30-tomcat7-https-s2i.json
+++ b/webserver/jws30-tomcat7-https-s2i.json
@@ -105,7 +105,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -113,7 +113,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/webserver/jws30-tomcat7-mongodb-persistent-s2i.json
+++ b/webserver/jws30-tomcat7-mongodb-persistent-s2i.json
@@ -186,7 +186,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted..  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -194,7 +194,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted..  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/webserver/jws30-tomcat7-mongodb-s2i.json
+++ b/webserver/jws30-tomcat7-mongodb-s2i.json
@@ -179,7 +179,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -187,7 +187,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/webserver/jws30-tomcat7-mysql-persistent-s2i.json
+++ b/webserver/jws30-tomcat7-mysql-persistent-s2i.json
@@ -190,7 +190,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -198,7 +198,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/webserver/jws30-tomcat7-mysql-s2i.json
+++ b/webserver/jws30-tomcat7-mysql-s2i.json
@@ -183,7 +183,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -191,7 +191,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/webserver/jws30-tomcat7-postgresql-persistent-s2i.json
+++ b/webserver/jws30-tomcat7-postgresql-persistent-s2i.json
@@ -172,7 +172,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -180,7 +180,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/webserver/jws30-tomcat7-postgresql-s2i.json
+++ b/webserver/jws30-tomcat7-postgresql-s2i.json
@@ -165,7 +165,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -173,7 +173,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/webserver/jws30-tomcat8-basic-s2i.json
+++ b/webserver/jws30-tomcat8-basic-s2i.json
@@ -70,7 +70,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -78,7 +78,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/webserver/jws30-tomcat8-https-s2i.json
+++ b/webserver/jws30-tomcat8-https-s2i.json
@@ -105,7 +105,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -113,7 +113,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/webserver/jws30-tomcat8-mongodb-persistent-s2i.json
+++ b/webserver/jws30-tomcat8-mongodb-persistent-s2i.json
@@ -186,7 +186,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -194,7 +194,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/webserver/jws30-tomcat8-mongodb-s2i.json
+++ b/webserver/jws30-tomcat8-mongodb-s2i.json
@@ -179,7 +179,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -187,7 +187,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/webserver/jws30-tomcat8-mysql-persistent-s2i.json
+++ b/webserver/jws30-tomcat8-mysql-persistent-s2i.json
@@ -190,7 +190,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -198,7 +198,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/webserver/jws30-tomcat8-mysql-s2i.json
+++ b/webserver/jws30-tomcat8-mysql-s2i.json
@@ -183,7 +183,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -191,7 +191,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/webserver/jws30-tomcat8-postgresql-persistent-s2i.json
+++ b/webserver/jws30-tomcat8-postgresql-persistent-s2i.json
@@ -172,7 +172,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -180,7 +180,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",

--- a/webserver/jws30-tomcat8-postgresql-s2i.json
+++ b/webserver/jws30-tomcat8-postgresql-s2i.json
@@ -165,7 +165,7 @@
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -173,7 +173,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "Generic trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",


### PR DESCRIPTION
Updating description for the GITHUB_WEBHOOK_SECRET field per
Bugzilla https://bugzilla.redhat.com/show_bug.cgi?id=1365656
to more clearly differentiate between OpenShift's Github webhook
secret, and actual Github webhook secrets.