### PR TITLE
CLOUD-1983: Initial implementation of BPMS templates

### DIFF
--- a/bpmsuite/bpmsuite70-businesscentral-monitoring-ephemeral.json
+++ b/bpmsuite/bpmsuite70-businesscentral-monitoring-ephemeral.json
@@ -1,0 +1,506 @@
+{
+    "kind": "Template",
+    "apiVersion": "v1",
+    "metadata": {
+        "annotations": {
+            "description": "Application template for Red Hat JBoss BPM Suite 7.0 which includes only a Business Central.",
+            "iconClass": "icon-jboss",
+            "tags": "bpmsuite,jboss,xpaas",
+            "version": "1.0.0",
+            "openshift.io/display-name": "Red Hat JBoss BPM Suite 7.0 Business Central",
+            "openshift.io/image.insecureRepository": "true"
+        },
+        "name": "bpmsuite70-businesscentral-monitoring-ephemeral"
+    },
+    "labels": {
+        "template": "bpmsuite70-businesscentral-monitoring-ephemeral",
+        "xpaas": "1.4.0"
+    },
+    "message": "A new BPM Suite Business Central Monitoring + Smart Router application has been created in your project. The username/password for accessing the BPMS Business Central interface is \"${KIE_ADMIN_USER}/${KIE_ADMIN_PWD}\".",
+    "parameters": [
+        {
+            "displayName": "Application Name",
+            "description": "The name for the application.",
+            "name": "APPLICATION_NAME",
+            "value": "myapp",
+            "required": true
+        },
+        {
+            "displayName": "ImageStream Namespace",
+            "description": "Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.",
+            "name": "IMAGE_STREAM_NAMESPACE",
+            "value": "openshift",
+            "required": true
+        },
+        {
+            "displayName": "EAP Admin User",
+            "description": "EAP administrator username",
+            "name": "ADMIN_USERNAME",
+            "value": "eapadmin",
+            "required": false
+        },
+        {
+            "displayName": "EAP Admin Password",
+            "description": "EAP administrator password",
+            "name": "ADMIN_PASSWORD",
+            "from": "[a-zA-Z]{6}[0-9]{1}!",
+            "generate": "expression",
+            "required": false
+        },
+        {
+            "displayName": "KIE Admin User",
+            "description": "KIE administrator username",
+            "name": "KIE_ADMIN_USER",
+            "value": "adminUser",
+            "required": false
+        },
+        {
+            "displayName": "KIE Admin Password",
+            "description": "KIE administrator password",
+            "name": "KIE_ADMIN_PWD",
+            "from": "[a-zA-Z]{6}[0-9]{1}!",
+            "generate": "expression",
+            "required": false
+        },
+        {
+            "displayName": "KIE Server Controller User",
+            "description": "KIE server controller username (adds the user)",
+            "name": "KIE_SERVER_CONTROLLER_USER",
+            "value": "controllerUser",
+            "required": false
+        },
+        {
+            "displayName": "KIE Server Controller Password",
+            "description": "KIE server controller password (adds the user)",
+            "name": "KIE_SERVER_CONTROLLER_PWD",
+            "value": "controllerPassword",
+            "required": false
+        },
+        {
+            "displayName": "KIE Server User",
+            "description": "KIE execution server username (Sets the org.kie.server.user system property, used by the embedded controller)",
+            "name": "KIE_SERVER_USER",
+            "value": "executionUser",
+            "required": false
+        },
+        {
+            "displayName": "KIE Server Password",
+            "description": "KIE execution server password (Sets the org.kie.server.pwd system property, used by the embedded controller)",
+            "name": "KIE_SERVER_PWD",
+            "value": "executionPassword",
+            "required": false
+        },
+        {
+            "displayName": "Smart Router listening port",
+            "description": "Port in which the smart router server listens (router property org.kie.server.router.port)",
+            "name": "KIE_ROUTER_PORT",
+            "value": "9000",
+            "required": false
+        },
+        {
+            "displayName": "Smart Router external URL",
+            "description": "Public URL where the router can be found. Format http://<host>:<port> (router property org.kie.server.router.url.external)",
+            "name": "KIE_ROUTER_URL_EXTERNAL",
+            "example": "http://my-app-smartrouter-projectName.osurl:9000",
+            "required": false
+        },
+        {
+            "displayName": "Smart Router ID",
+            "description": "Router ID used when connecting to the controller (router property org.kie.server.router.id)",
+            "name": "KIE_ROUTER_ID",
+            "value": "kie-server-router",
+            "required": false
+        },
+        {
+            "displayName": "Smart Router name",
+            "description": "Router name used when connecting to the controller (router property org.kie.server.router.name)",
+            "name": "KIE_ROUTER_NAME",
+            "value": "KIE Server Router",
+            "required": false
+        },
+        {
+            "displayName": "Smart Router controller URL",
+            "description": "URL to access the controller (standalone or embedded in the business central) (router property org.kie.server.controller)",
+            "name": "KIE_ROUTER_CONTROLLER_URL",
+            "example": "http://my-app-controller-ocpuser.os.example.com:8080/business-central/rest/controller",
+            "required": false
+        },
+        {
+            "displayName": "Smart Router controller user",
+            "description": "User name of the user to access the controller, when using basic authentication (router property org.kie.server.controller.user)",
+            "name": "KIE_ROUTER_CONTROLLER_USER",
+            "value": "controllerUser",
+            "example": "bpmsAdmin",
+            "required": false
+        },
+        {
+            "displayName": "Smart Router controller password",
+            "description": "Password of the user to access the controller, when using basic authentication (router property org.kie.server.controller.pwd)",
+            "name": "KIE_ROUTER_CONTROLLER_PASSWORD",
+            "value": "controllerPassword",
+            "example": "bpmsAdmin",
+            "required": false
+        },
+        {
+            "displayName": "Business Central Custom http Route Hostname",
+            "description": "Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-buscentr-<project>.<default-domain-suffix>",
+            "name": "BUSINESS_CENTRAL_HOSTNAME_HTTP",
+            "value": "",
+            "required": false
+        },
+        {
+            "displayName": "Smart Router Custom http Route Hostname",
+            "description": "Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-smartrouter-<project>.<default-domain-suffix>",
+            "name": "SMART_ROUTER_HOSTNAME_HTTP",
+            "value": "",
+            "required": false
+        },
+        {
+            "displayName": "Queues",
+            "description": "Queue names",
+            "name": "HORNETQ_QUEUES",
+            "value": "",
+            "required": false
+        },
+        {
+            "displayName": "Topics",
+            "description": "Topic names",
+            "name": "HORNETQ_TOPICS",
+            "value": "",
+            "required": false
+        },
+        {
+            "displayName": "HornetQ Password",
+            "description": "HornetQ cluster admin password",
+            "name": "HORNETQ_CLUSTER_PASSWORD",
+            "from": "[a-zA-Z0-9]{8}",
+            "generate": "expression",
+            "required": true
+        }
+    ],
+    "objects": [
+        {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "spec": {
+                "ports": [
+                    {
+                        "port": 8080,
+                        "targetPort": 8080
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}-buscentr"
+                }
+            },
+            "metadata": {
+                "name": "${APPLICATION_NAME}-buscentr",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "annotations": {
+                    "description": "The business central web server's http port."
+                }
+            }
+        },
+        {
+            "kind": "Route",
+            "apiVersion": "v1",
+            "id": "${APPLICATION_NAME}-buscentr-http",
+            "metadata": {
+                "name": "${APPLICATION_NAME}-buscentr",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "annotations": {
+                    "description": "Route for business central's http service."
+                }
+            },
+            "spec": {
+                "host": "${BUSINESS_CENTRAL_HOSTNAME_HTTP}",
+                "to": {
+                    "name": "${APPLICATION_NAME}-buscentr"
+                }
+            }
+        },
+        {
+            "kind": "DeploymentConfig",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "${APPLICATION_NAME}-buscentr",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                }
+            },
+            "spec": {
+                "strategy": {
+                    "type": "Recreate"
+                },
+                "triggers": [
+                    {
+                        "type": "ImageChange",
+                        "imageChangeParams": {
+                            "automatic": true,
+                            "containerNames": [
+                                "${APPLICATION_NAME}-buscentr"
+                            ],
+                            "from": {
+                                "kind": "ImageStreamTag",
+                                "namespace": "${IMAGE_STREAM_NAMESPACE}",
+                                "name": "jboss-bpmsuite70-businesscentral-monitoring-openshift:1.0"
+                            }
+                        }
+                    },
+                    {
+                        "type": "ConfigChange"
+                    }
+                ],
+                "replicas": 1,
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}-buscentr"
+                },
+                "template": {
+                    "metadata": {
+                        "name": "${APPLICATION_NAME}-buscentr",
+                        "labels": {
+                            "deploymentConfig": "${APPLICATION_NAME}-buscentr",
+                            "application": "${APPLICATION_NAME}"
+                        }
+                    },
+                    "spec": {
+                        "terminationGracePeriodSeconds": 60,
+                        "containers": [
+                            {
+                                "name": "${APPLICATION_NAME}-buscentr",
+                                "image": "jboss-bpmsuite70-businesscentral-monitoring-openshift",
+                                "imagePullPolicy": "Always",
+                                "livenessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "/bin/bash",
+                                            "-c",
+                                            "/opt/eap/bin/livenessProbe.sh"
+                                        ]
+                                    }
+                                },
+                                "readinessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "/bin/bash",
+                                            "-c",
+                                            "/opt/eap/bin/readinessProbe.sh"
+                                        ]
+                                    }
+                                },
+                                "ports": [
+                                    {
+                                        "name": "jolokia",
+                                        "containerPort": 8778,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "http",
+                                        "containerPort": 8080,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "env": [
+                                    {
+                                        "name": "KIE_ADMIN_PWD",
+                                        "value": "${KIE_ADMIN_PWD}"
+                                    },
+                                    {
+                                        "name": "KIE_ADMIN_USER",
+                                        "value": "${KIE_ADMIN_USER}"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_CONTROLLER_PWD",
+                                        "value": "${KIE_SERVER_CONTROLLER_PWD}"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_CONTROLLER_USER",
+                                        "value": "${KIE_SERVER_CONTROLLER_USER}"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_PWD",
+                                        "value": "${KIE_SERVER_PWD}"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_USER",
+                                        "value": "${KIE_SERVER_USER}"
+                                    },
+                                    {
+                                        "name": "HORNETQ_CLUSTER_PASSWORD",
+                                        "value": "${HORNETQ_CLUSTER_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "HORNETQ_QUEUES",
+                                        "value": "${HORNETQ_QUEUES}"
+                                    },
+                                    {
+                                        "name": "HORNETQ_TOPICS",
+                                        "value": "${HORNETQ_TOPICS}"
+                                    },
+                                    {
+                                        "name": "ADMIN_USERNAME",
+                                        "value": "${ADMIN_USERNAME}"
+                                    },
+                                    {
+                                        "name": "ADMIN_PASSWORD",
+                                        "value": "${ADMIN_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "PROBE_IMPL",
+                                        "value": "probe.eap.jolokia.EapProbe"
+                                    },
+                                    {
+                                        "name": "PROBE_DISABLE_BOOT_ERRORS_CHECK",
+                                        "value": "true"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "spec": {
+                "ports": [
+                    {
+                        "port": 9000,
+                        "targetPort": 9000
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}-smartrouter"
+                }
+            },
+            "metadata": {
+                "name": "${APPLICATION_NAME}-smartrouter",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "annotations": {
+                    "description": "The smart router server http port."
+                }
+            }
+        },
+        {
+            "kind": "Route",
+            "apiVersion": "v1",
+            "id": "${APPLICATION_NAME}-smartrouter-http",
+            "metadata": {
+                "name": "${APPLICATION_NAME}-smartrouter",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "annotations": {
+                    "description": "Route for the smart router's http service."
+                }
+            },
+            "spec": {
+                "host": "${SMART_ROUTER_HOSTNAME_HTTP}",
+                "to": {
+                    "name": "${APPLICATION_NAME}-smartrouter"
+                }
+            }
+        },
+        {
+            "kind": "DeploymentConfig",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "${APPLICATION_NAME}-smartrouter",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                }
+            },
+            "spec": {
+                "strategy": {
+                    "type": "Recreate"
+                },
+                "triggers": [
+                    {
+                        "type": "ImageChange",
+                        "imageChangeParams": {
+                            "automatic": true,
+                            "containerNames": [
+                                "${APPLICATION_NAME}-smartrouter"
+                            ],
+                            "from": {
+                                "kind": "ImageStreamTag",
+                                "namespace": "${IMAGE_STREAM_NAMESPACE}",
+                                "name": "jboss-bpmsuite70-smartrouter-openshift:1.0"
+                            }
+                        }
+                    },
+                    {
+                        "type": "ConfigChange"
+                    }
+                ],
+                "replicas": 1,
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}-smartrouter"
+                },
+                "template": {
+                    "metadata": {
+                        "name": "${APPLICATION_NAME}-smartrouter",
+                        "labels": {
+                            "deploymentConfig": "${APPLICATION_NAME}-smartrouter",
+                            "application": "${APPLICATION_NAME}"
+                        }
+                    },
+                    "spec": {
+                        "terminationGracePeriodSeconds": 60,
+                        "containers": [
+                            {
+                                "name": "${APPLICATION_NAME}-smartrouter",
+                                "image": "jboss-bpmsuite70-smartrouter-openshift",
+                                "imagePullPolicy": "Always",
+                                "ports": [
+                                    {
+                                        "name": "http",
+                                        "containerPort": 9000,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "env": [
+                                    {
+                                        "name": "KIE_ROUTER_PORT",
+                                        "value": "${KIE_ROUTER_PORT}"
+                                    },
+                                    {
+                                        "name": "KIE_ROUTER_URL_EXTERNAL",
+                                        "value": "${KIE_ROUTER_URL_EXTERNAL}"
+                                    },
+                                    {
+                                        "name": "KIE_ROUTER_ID",
+                                        "value": "${KIE_ROUTER_ID}"
+                                    },
+                                    {
+                                        "name": "KIE_ROUTER_NAME",
+                                        "value": "${KIE_ROUTER_NAME}"
+                                    },
+                                    {
+                                        "name": "KIE_ROUTER_CONTROLLER_URL",
+                                        "value": "${KIE_ROUTER_CONTROLLER_URL}"
+                                    },
+                                    {
+                                        "name": "KIE_ROUTER_CONTROLLER_USER",
+                                        "value": "${KIE_ROUTER_CONTROLLER_USER}"
+                                    },
+                                    {
+                                        "name": "KIE_ROUTER_CONTROLLER_PASSWORD",
+                                        "value": "${KIE_ROUTER_CONTROLLER_PASSWORD}"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/bpmsuite/bpmsuite70-executionserver-postgresql-persistent.json
+++ b/bpmsuite/bpmsuite70-executionserver-postgresql-persistent.json
@@ -1,0 +1,797 @@
+{
+    "kind": "Template",
+    "apiVersion": "v1",
+    "metadata": {
+        "annotations": {
+            "description": "Application template for Red Hat JBoss BPM Suite 7.0 which includes an execution server with a PostgreSQL.",
+            "iconClass": "icon-jboss",
+            "tags": "bpmsuite,jboss,xpaas",
+            "version": "1.0.0",
+            "openshift.io/display-name": "Red Hat JBoss BPM Suite 7.0 Execution Server + PostgreSQL (persistent)",
+            "openshift.io/image.insecureRepository": "true"
+        },
+        "name": "bpmsuite70-executionserver-postgresql-persistent"
+    },
+    "labels": {
+        "template": "bpmsuite70-executionserver-postgresql-persistent",
+        "xpaas": "1.4.0"
+    },
+    "message": "A new persistent BPM Suite Execution Server application (using PostgreSQL) has been created in your project. For accessing the PostgreSQL database \"${DB_DATABASE}\" use the credentials \"${DB_USERNAME}/${DB_PASSWORD}\".",
+    "parameters": [
+        {
+            "displayName": "Application Name",
+            "description": "The name for the application.",
+            "name": "APPLICATION_NAME",
+            "value": "myapp",
+            "required": true
+        },
+        {
+            "displayName": "ImageStream Namespace",
+            "description": "Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.",
+            "name": "IMAGE_STREAM_NAMESPACE",
+            "value": "openshift",
+            "required": true
+        },
+        {
+            "displayName": "KIE Server ID",
+            "description": "KIE execution server identifier (Used to set the org.kie.server.id system property)",
+            "name": "KIE_SERVER_ID",
+            "from": "kie-server-[a-zA-Z0-9]{4}",
+            "generate": "expression",
+            "example": "kie-server-0001",
+            "required": false
+        },
+        {
+            "displayName": "KIE Server User",
+            "description": "KIE execution server username (adds the user and sets the org.kie.server.user system property)",
+            "name": "KIE_SERVER_USER",
+            "value": "executionUser",
+            "required": false
+        },
+        {
+            "displayName": "KIE Server Password",
+            "description": "KIE execution server password (adds the user and sets the org.kie.server.pwd system property)",
+            "name": "KIE_SERVER_PWD",
+            "value": "executionPassword",
+            "required": false
+        },
+        {
+            "displayName": "EAP Admin User",
+            "description": "EAP administrator username",
+            "name": "ADMIN_USERNAME",
+            "value": "eapadmin",
+            "required": false
+        },
+        {
+            "displayName": "EAP Admin Password",
+            "description": "EAP administrator password",
+            "name": "ADMIN_PASSWORD",
+            "from": "[a-zA-Z]{6}[0-9]{1}!",
+            "generate": "expression",
+            "required": false
+        },
+        {
+            "displayName": "KIE Admin User",
+            "description": "KIE administrator username",
+            "name": "KIE_ADMIN_USER",
+            "value": "adminUser",
+            "required": false
+        },
+        {
+            "displayName": "KIE Admin Password",
+            "description": "KIE administrator password",
+            "name": "KIE_ADMIN_PWD",
+            "from": "[a-zA-Z]{6}[0-9]{1}!",
+            "generate": "expression",
+            "required": false
+        },
+        {
+            "displayName": "KIE server protocol",
+            "description": "KIE server protocol (Used to set the org.kie.server.location system property)",
+            "name": "KIE_SERVER_PROTOCOL",
+            "value": "http",
+            "required": false
+        },
+        {
+            "displayName": "KIE server host",
+            "description": "KIE server host (Used to set the org.kie.server.location system property)",
+            "name": "KIE_SERVER_HOST",
+            "example": "my-app-exec-server-ocpuser.os.example.com",
+            "required": true
+        },
+        {
+            "displayName": "KIE server port",
+            "description": "KIE server port (Used to set the org.kie.server.location system property)",
+            "name": "KIE_SERVER_PORT",
+            "example": "80",
+            "required": true
+        },
+        {
+            "displayName": "KIE server controller protocol",
+            "description": "KIE server controller protocol (Used to set the org.kie.server.controller system property)",
+            "name": "KIE_SERVER_CONTROLLER_PROTOCOL",
+            "value": "http",
+            "required": false
+        },
+        {
+            "displayName": "KIE server controller service",
+            "description": "KIE server controller service (Used to set the org.kie.server.controller system property if host and port aren't set)",
+            "name": "KIE_SERVER_CONTROLLER_SERVICE",
+            "value": "",
+            "required": false
+        },
+        {
+            "displayName": "KIE server controller host",
+            "description": "KIE server controller host (Used to set the org.kie.server.controller system property)",
+            "name": "KIE_SERVER_CONTROLLER_HOST",
+            "example": "my-app-controller-ocpuser.os.example.com",
+            "required": true
+        },
+        {
+            "displayName": "KIE server controller port",
+            "description": "KIE server controller port (Used to set the org.kie.server.controller system property)",
+            "name": "KIE_SERVER_CONTROLLER_PORT",
+            "example": "8080",
+            "required": true
+        },
+        {
+            "displayName": "KIE Server Controller User",
+            "description": "KIE server controller username (Sets the org.kie.server.controller.user system property)",
+            "name": "KIE_SERVER_CONTROLLER_USER",
+            "value": "controllerUser",
+            "required": false
+        },
+        {
+            "displayName": "KIE Server Controller Password",
+            "description": "KIE server controller password (Sets the org.kie.server.controller.pwd system property)",
+            "name": "KIE_SERVER_CONTROLLER_PWD",
+            "value": "controllerPassword",
+            "required": false
+        },
+        {
+            "displayName": "KIE Server Bypass Auth User",
+            "description": "KIE execution server bypass auth user (Sets the org.kie.server.bypass.auth.user system property)",
+            "name": "KIE_SERVER_BYPASS_AUTH_USER",
+            "value": "false",
+            "required": false
+        },
+        {
+            "displayName": "KIE Server Router protocol",
+            "description": "KIE Server Router protocol (Used to set the org.kie.server.router system property)",
+            "name": "KIE_SERVER_ROUTER_PROTOCOL",
+            "value": "http",
+            "required": false
+        },
+        {
+            "displayName": "KIE Server Router service",
+            "description": "KIE Server Router service (Used to set the org.kie.server.router system property if host and port aren't set)",
+            "name": "KIE_SERVER_ROUTER_SERVICE",
+            "value": "",
+            "example": "smartrouter-myapp",
+            "required": false
+        },
+        {
+            "displayName": "KIE Server Router host",
+            "description": "KIE Server Router host (Used to set the org.kie.server.router system property)",
+            "name": "KIE_SERVER_ROUTER_HOST",
+            "example": "my-app-router-ocpuser.os.example.com",
+            "required": false
+        },
+        {
+            "displayName": "KIE Server Router port",
+            "description": "KIE Server Router port (Used to set the org.kie.server.router system property)",
+            "name": "KIE_SERVER_ROUTER_PORT",
+            "example": "9000",
+            "required": false
+        },
+        {
+            "displayName": "Custom callback method",
+            "description": "Method used to resolve the user roles when operating with human tasks (Sets the org.jbpm.ht.callback system property)",
+            "name": "JBPM_HT_CALLBACK_METHOD",
+            "example": "custom",
+            "required": false
+        },
+        {
+            "displayName": "Custom callback Java class name",
+            "description": "Java class that resolves the user roles when operating with human tasks, when method is 'custom' (Sets the org.jbpm.ht.custom.callback system property)",
+            "name": "JBPM_HT_CALLBACK_CLASS",
+            "example": "com.example.MyUserTaskCallback",
+            "required": false
+        },
+        {
+            "displayName": "KIE Server Persistence Dialect",
+            "description": "KIE execution server persistence dialect (Sets the org.kie.server.persistence.dialect system property)",
+            "name": "KIE_SERVER_PERSISTENCE_DIALECT",
+            "value": "org.hibernate.dialect.PostgreSQLDialect",
+            "required": false
+        },
+        {
+            "displayName": "KIE Server Persistence DS",
+            "description": "KIE execution server persistence datasource (Sets the org.kie.server.persistence.ds system property)",
+            "name": "KIE_SERVER_PERSISTENCE_DS",
+            "value": "java:/jboss/datasources/ExampleDS",
+            "required": false
+        },
+        {
+            "displayName": "KIE Server Persistence TM",
+            "description": "KIE execution server persistence transaction manager (Sets the org.kie.server.persistence.tm system property)",
+            "name": "KIE_SERVER_PERSISTENCE_TM",
+            "value": "org.hibernate.engine.transaction.jta.platform.internal.JBossAppServerJtaPlatform",
+            "required": false
+        },
+        {
+            "displayName": "KIE MBeans",
+            "description": "KIE execution server mbeans enabled/disabled (Sets the kie.mbeans and kie.scanner.mbeans system properties)",
+            "name": "KIE_MBEANS",
+            "value": "enabled",
+            "required": false
+        },
+        {
+            "displayName": "Drools Server Filter Classes",
+            "description": "KIE execution server class filtering (Sets the org.drools.server.filter.classes system property)",
+            "name": "DROOLS_SERVER_FILTER_CLASSES",
+            "value": "true",
+            "required": false
+        },
+        {
+            "displayName": "Execution Server Custom http Route Hostname",
+            "description": "Custom hostname for http service route. Leave blank for default hostname, e.g.: <application-name>-execserv-<project>.<default-domain-suffix>",
+            "name": "EXECUTION_SERVER_HOSTNAME_HTTP",
+            "value": "",
+            "required": false
+        },
+        {
+            "displayName": "Database JNDI Name",
+            "description": "Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/ExampleDS",
+            "name": "DB_JNDI",
+            "value": "java:jboss/datasources/ExampleDS",
+            "required": false
+        },
+        {
+            "displayName": "Database Name",
+            "description": "Database name",
+            "name": "DB_DATABASE",
+            "value": "root",
+            "required": true
+        },
+        {
+            "displayName": "Queues",
+            "description": "Queue names",
+            "name": "HORNETQ_QUEUES",
+            "value": "",
+            "required": false
+        },
+        {
+            "displayName": "Topics",
+            "description": "Topic names",
+            "name": "HORNETQ_TOPICS",
+            "value": "",
+            "required": false
+        },
+        {
+            "displayName": "Database Username",
+            "description": "Database user name",
+            "name": "DB_USERNAME",
+            "from": "user[a-zA-Z0-9]{3}",
+            "generate": "expression",
+            "required": true
+        },
+        {
+            "displayName": "Database Password",
+            "description": "Database user password",
+            "name": "DB_PASSWORD",
+            "from": "[a-zA-Z0-9]{8}",
+            "generate": "expression",
+            "required": true
+        },
+        {
+            "displayName": "Datasource Minimum Pool Size",
+            "description": "Sets xa-pool/min-pool-size for the configured datasource.",
+            "name": "DB_MIN_POOL_SIZE",
+            "required": false
+        },
+        {
+            "displayName": "Datasource Maximum Pool Size",
+            "description": "Sets xa-pool/max-pool-size for the configured datasource.",
+            "name": "DB_MAX_POOL_SIZE",
+            "required": false
+        },
+        {
+            "displayName": "Datasource Transaction Isolation",
+            "description": "Sets transaction-isolation for the configured datasource.",
+            "name": "DB_TX_ISOLATION",
+            "required": false
+        },
+        {
+            "displayName": "Database Volume Capacity",
+            "description": "Size of persistent storage for database volume.",
+            "name": "DB_VOLUME_CAPACITY",
+            "value": "512Mi",
+            "required": true
+        },
+        {
+            "displayName": "HornetQ Password",
+            "description": "HornetQ cluster admin password",
+            "name": "HORNETQ_CLUSTER_PASSWORD",
+            "from": "[a-zA-Z0-9]{8}",
+            "generate": "expression",
+            "required": true
+        },
+        {
+            "displayName": "PostgreSQL Image Stream Tag",
+            "description": "The tag to use for the \"postgresql\" image stream.  Typically, this aligns with the major.minor version of PostgreSQL.",
+            "name": "POSTGRESQL_IMAGE_STREAM_TAG",
+            "value": "latest",
+            "required": true
+        },
+        {
+            "displayName": "Maven repository URL",
+            "description": "Fully qualified URL to a Maven repository. If unspecified, will fall back to Business Central service.",
+            "name": "MAVEN_REPO_URL",
+            "required": false
+        },
+        {
+            "displayName": "Maven repository service",
+            "description": "Maven repository service to lookup if MAVEN_REPO_URL not specified",
+            "name": "MAVEN_REPO_SERVICE",
+            "example": "buscentr-myapp",
+            "required": false
+        },
+        {
+            "displayName": "Maven repository username",
+            "description": "Username to access the Maven repository. If using Business Central, will have to match KIE_ADMIN_USER. Default is \"adminUser\".",
+            "name": "MAVEN_REPO_USERNAME",
+            "value": "adminUser",
+            "required": false
+        },
+        {
+            "displayName": "Maven repository password",
+            "description": "Password to access the Maven repository. If using Business Central, will have to match KIE_ADMIN_PWD. No default specified.",
+            "name": "MAVEN_REPO_PASSWORD",
+            "required": false
+        }
+    ],
+    "objects": [
+        {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "spec": {
+                "ports": [
+                    {
+                        "port": 8080,
+                        "targetPort": 8080
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}-execserv"
+                }
+            },
+            "metadata": {
+                "name": "${APPLICATION_NAME}-execserv",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "annotations": {
+                    "description": "The execution server web server's http port.",
+                    "service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-postgresql\", \"kind\": \"Service\"}]"
+                }
+            }
+        },
+        {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "spec": {
+                "ports": [
+                    {
+                        "port": 5432,
+                        "targetPort": 5432
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}-postgresql"
+                }
+            },
+            "metadata": {
+                "name": "${APPLICATION_NAME}-postgresql",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "annotations": {
+                    "description": "The database server's port."
+                }
+            }
+        },
+        {
+            "kind": "Route",
+            "apiVersion": "v1",
+            "id": "${APPLICATION_NAME}-execserv-http",
+            "metadata": {
+                "name": "${APPLICATION_NAME}-execserv",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "annotations": {
+                    "description": "Route for execution server's http service."
+                }
+            },
+            "spec": {
+                "host": "${EXECUTION_SERVER_HOSTNAME_HTTP}",
+                "to": {
+                    "name": "${APPLICATION_NAME}-execserv"
+                }
+            }
+        },
+        {
+            "kind": "DeploymentConfig",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "${APPLICATION_NAME}-execserv",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                }
+            },
+            "spec": {
+                "strategy": {
+                    "type": "Recreate"
+                },
+                "triggers": [
+                    {
+                        "type": "ImageChange",
+                        "imageChangeParams": {
+                            "automatic": true,
+                            "containerNames": [
+                                "${APPLICATION_NAME}-execserv"
+                            ],
+                            "from": {
+                                "kind": "ImageStreamTag",
+                                "namespace": "${IMAGE_STREAM_NAMESPACE}",
+                                "name": "jboss-bpmsuite70-executionserver-openshift:1.0"
+                            }
+                        }
+                    },
+                    {
+                        "type": "ConfigChange"
+                    }
+                ],
+                "replicas": 1,
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}-execserv"
+                },
+                "template": {
+                    "metadata": {
+                        "name": "${APPLICATION_NAME}-execserv",
+                        "labels": {
+                            "deploymentConfig": "${APPLICATION_NAME}-execserv",
+                            "application": "${APPLICATION_NAME}"
+                        }
+                    },
+                    "spec": {
+                        "terminationGracePeriodSeconds": 60,
+                        "containers": [
+                            {
+                                "name": "${APPLICATION_NAME}-execserv",
+                                "image": "jboss-bpmsuite70-executionserver-openshift",
+                                "imagePullPolicy": "Always",
+                                "livenessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "/bin/bash",
+                                            "-c",
+                                            "/opt/eap/bin/livenessProbe.sh"
+                                        ]
+                                    }
+                                },
+                                "readinessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "/bin/bash",
+                                            "-c",
+                                            "/opt/eap/bin/readinessProbe.sh"
+                                        ]
+                                    }
+                                },
+                                "ports": [
+                                    {
+                                        "name": "jolokia",
+                                        "containerPort": 8778,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "http",
+                                        "containerPort": 8080,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "env": [
+                                    {
+                                        "name": "DROOLS_SERVER_FILTER_CLASSES",
+                                        "value": "${DROOLS_SERVER_FILTER_CLASSES}"
+                                    },
+                                    {
+                                        "name": "KIE_ADMIN_PWD",
+                                        "value": "${KIE_ADMIN_PWD}"
+                                    },
+                                    {
+                                        "name": "KIE_ADMIN_USER",
+                                        "value": "${KIE_ADMIN_USER}"
+                                    },
+                                    {
+                                        "name": "KIE_MBEANS",
+                                        "value": "${KIE_MBEANS}"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_BYPASS_AUTH_USER",
+                                        "value": "${KIE_SERVER_BYPASS_AUTH_USER}"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_CONTROLLER_PROTOCOL",
+                                        "value": "${KIE_SERVER_CONTROLLER_PROTOCOL}"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_CONTROLLER_SERVICE",
+                                        "value": "${KIE_SERVER_CONTROLLER_SERVICE}"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_CONTROLLER_HOST",
+                                        "value": "${KIE_SERVER_CONTROLLER_HOST}"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_CONTROLLER_PORT",
+                                        "value": "${KIE_SERVER_CONTROLLER_PORT}"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_CONTROLLER_USER",
+                                        "value": "${KIE_SERVER_CONTROLLER_USER}"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_CONTROLLER_PWD",
+                                        "value": "${KIE_SERVER_CONTROLLER_PWD}"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_ID",
+                                        "value": "${KIE_SERVER_ID}"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_PROTOCOL",
+                                        "value": "${KIE_SERVER_PROTOCOL}"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_HOST",
+                                        "value": "${KIE_SERVER_HOST}"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_PORT",
+                                        "value": "${KIE_SERVER_PORT}"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_PERSISTENCE_DIALECT",
+                                        "value": "${KIE_SERVER_PERSISTENCE_DIALECT}"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_PERSISTENCE_DS",
+                                        "value": "${KIE_SERVER_PERSISTENCE_DS}"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_PERSISTENCE_TM",
+                                        "value": "${KIE_SERVER_PERSISTENCE_TM}"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_PWD",
+                                        "value": "${KIE_SERVER_PWD}"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_USER",
+                                        "value": "${KIE_SERVER_USER}"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_ROUTER_PROTOCOL",
+                                        "value": "${KIE_SERVER_ROUTER_PROTOCOL}"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_ROUTER_SERVICE",
+                                        "value": "${KIE_SERVER_ROUTER_SERVICE}"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_ROUTER_HOST",
+                                        "value": "${KIE_SERVER_ROUTER_HOST}"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_ROUTER_PORT",
+                                        "value": "${KIE_SERVER_ROUTER_PORT}"
+                                    },
+                                    {
+                                        "name": "JBPM_HT_CALLBACK_METHOD",
+                                        "value": "${JBPM_HT_CALLBACK_METHOD}"
+                                    },
+                                    {
+                                        "name": "JBPM_HT_CALLBACK_CLASS",
+                                        "value": "${JBPM_HT_CALLBACK_CLASS}"
+                                    },
+                                    {
+                                        "name": "MAVEN_REPO_URL",
+                                        "value": "${MAVEN_REPO_URL}"
+                                    },
+                                    {
+                                        "name": "MAVEN_REPO_SERVICE",
+                                        "value": "${MAVEN_REPO_SERVICE}"
+                                    },
+                                    {
+                                        "name": "MAVEN_REPO_PATH",
+                                        "value": "/maven2/"
+                                    },
+                                    {
+                                        "name": "MAVEN_REPO_USERNAME",
+                                        "value": "${MAVEN_REPO_USERNAME}"
+                                    },
+                                    {
+                                        "name": "MAVEN_REPO_PASSWORD",
+                                        "value": "${MAVEN_REPO_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "DB_SERVICE_PREFIX_MAPPING",
+                                        "value": "${APPLICATION_NAME}-postgresql=DB"
+                                    },
+                                    {
+                                        "name": "DB_JNDI",
+                                        "value": "${DB_JNDI}"
+                                    },
+                                    {
+                                        "name": "DB_USERNAME",
+                                        "value": "${DB_USERNAME}"
+                                    },
+                                    {
+                                        "name": "DB_PASSWORD",
+                                        "value": "${DB_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "DB_DATABASE",
+                                        "value": "${DB_DATABASE}"
+                                    },
+                                    {
+                                        "name": "TX_DATABASE_PREFIX_MAPPING",
+                                        "value": "${APPLICATION_NAME}-postgresql=DB"
+                                    },
+                                    {
+                                        "name": "DB_MIN_POOL_SIZE",
+                                        "value": "${DB_MIN_POOL_SIZE}"
+                                    },
+                                    {
+                                        "name": "DB_MAX_POOL_SIZE",
+                                        "value": "${DB_MAX_POOL_SIZE}"
+                                    },
+                                    {
+                                        "name": "DB_TX_ISOLATION",
+                                        "value": "${DB_TX_ISOLATION}"
+                                    },
+                                    {
+                                        "name": "HORNETQ_CLUSTER_PASSWORD",
+                                        "value": "${HORNETQ_CLUSTER_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "HORNETQ_QUEUES",
+                                        "value": "${HORNETQ_QUEUES}"
+                                    },
+                                    {
+                                        "name": "HORNETQ_TOPICS",
+                                        "value": "${HORNETQ_TOPICS}"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "kind": "DeploymentConfig",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "${APPLICATION_NAME}-postgresql",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                }
+            },
+            "spec": {
+                "strategy": {
+                    "type": "Recreate"
+                },
+                "triggers": [
+                    {
+                        "type": "ImageChange",
+                        "imageChangeParams": {
+                            "automatic": true,
+                            "containerNames": [
+                                "${APPLICATION_NAME}-postgresql"
+                            ],
+                            "from": {
+                                "kind": "ImageStreamTag",
+                                "namespace": "openshift",
+                                "name": "postgresql:${POSTGRESQL_IMAGE_STREAM_TAG}"
+                            }
+                        }
+                    },
+                    {
+                        "type": "ConfigChange"
+                    }
+                ],
+                "replicas": 1,
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}-postgresql"
+                },
+                "template": {
+                    "metadata": {
+                        "name": "${APPLICATION_NAME}-postgresql",
+                        "labels": {
+                            "deploymentConfig": "${APPLICATION_NAME}-postgresql",
+                            "application": "${APPLICATION_NAME}"
+                        }
+                    },
+                    "spec": {
+                        "terminationGracePeriodSeconds": 60,
+                        "containers": [
+                            {
+                                "name": "${APPLICATION_NAME}-postgresql",
+                                "image": "postgresql",
+                                "imagePullPolicy": "Always",
+                                "ports": [
+                                    {
+                                        "containerPort": 5432,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/var/lib/postgresql/data",
+                                        "name": "${APPLICATION_NAME}-postgresql-pvol"
+                                    }
+                                ],
+                                "env": [
+                                    {
+                                        "name": "POSTGRESQL_USER",
+                                        "value": "${DB_USERNAME}"
+                                    },
+                                    {
+                                        "name": "POSTGRESQL_PASSWORD",
+                                        "value": "${DB_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "POSTGRESQL_DATABASE",
+                                        "value": "${DB_DATABASE}"
+                                    }
+                                ]
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "name": "${APPLICATION_NAME}-postgresql-pvol",
+                                "persistentVolumeClaim": {
+                                    "claimName": "${APPLICATION_NAME}-postgresql-claim"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "PersistentVolumeClaim",
+            "metadata": {
+                "name": "${APPLICATION_NAME}-postgresql-claim",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                }
+            },
+            "spec": {
+                "accessModes": [
+                    "ReadWriteOnce"
+                ],
+                "resources": {
+                    "requests": {
+                        "storage": "${DB_VOLUME_CAPACITY}"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/bpmsuite/bpmsuite70-full-mysql-persistent.json
+++ b/bpmsuite/bpmsuite70-full-mysql-persistent.json
@@ -15,7 +15,7 @@
         "template": "bpmsuite70-mysql-persistent",
         "xpaas": "1.4.0"
     },
-    "message": "A new persistent BPM Suite application (using MySQL) has been created in your project. The username/password for accessing the BPMS Business Central interface is ${KIE_ADMIN_USER}/${KIE_ADMIN_PASSWORD}. For accessing the MySQL database \"${DB_DATABASE}\" use the credentials ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the \"bpmsuite-service-account\" service account and the secret named \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content.",
+    "message": "A new persistent BPM Suite application (using MySQL) has been created in your project. The username/password for accessing the BPMS Business Central interface is ${KIE_ADMIN_USER}/${KIE_ADMIN_PWD}. For accessing the MySQL database \"${DB_DATABASE}\" use the credentials ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the \"bpmsuite-service-account\" service account and the secret named \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content.",
     "parameters": [
         {
             "displayName": "EAP Admin User",

--- a/bpmsuite/bpmsuite70-full-mysql.json
+++ b/bpmsuite/bpmsuite70-full-mysql.json
@@ -15,7 +15,7 @@
         "template": "bpmsuite70-mysql",
         "xpaas": "1.4.0"
     },
-    "message": "A new BPMS application (using MySQL) has been created in your project. The username/password for accessing the BPMS Business Central interface is ${KIE_ADMIN_USER}/${KIE_ADMIN_PASSWORD}. For accessing the MySQL database \"${DB_DATABASE}\" use the credentials ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the \"bpmsuite-service-account\" service account and the secret named \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content.",
+    "message": "A new BPMS application (using MySQL) has been created in your project. The username/password for accessing the BPMS Business Central interface is ${KIE_ADMIN_USER}/${KIE_ADMIN_PWD}. For accessing the MySQL database \"${DB_DATABASE}\" use the credentials ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the \"bpmsuite-service-account\" service account and the secret named \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content.",
     "parameters": [
         {
             "displayName": "EAP Admin User",


### PR DESCRIPTION
Initial implementation of BPMS templates for OpenShift, including:
* Ephemeral Business Central Monitoring + Smart router
* Execution server + PostgreSQL DB

Remarks:
* Execution server and BC controller credentials (user/pass) are hardcoded so they match on both templates.
* The only HTTP is supported.
* No need to create "bpmsuite-service-account"
