### PR TITLE
Align to simplified naming (java) and tagging :8

### DIFF
--- a/jboss-image-streams.json
+++ b/jboss-image-streams.json
@@ -856,7 +856,7 @@
             "kind": "ImageStream",
             "apiVersion": "v1",
             "metadata": {
-                "name": "redhat-openjdk18-openshift",
+                "name": "java",
                 "annotations": {
                     "openshift.io/display-name": "Red Hat OpenJDK 8"
                 }
@@ -864,34 +864,25 @@
             "spec": {
                 "dockerImageRepository": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift",
                 "tags": [
-                    {
-                        "name": "1.0",
-                        "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
-                            "iconClass": "icon-jboss",
-                            "tags": "builder,java,xpaas,openjdk",
-                            "supports": "java:8,xpaas:1.0",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "1.0"
-                        }
-                    },
-                    {
-                        "name": "1.1",
-                        "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
-                            "iconClass": "icon-jboss",
-                            "tags": "builder,java,xpaas,openjdk",
-                            "supports": "java:8,xpaas:1.4",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "1.1"
-                        }
-                    }
+                  {
+                      "name": "8",
+                      "annotations": {
+                          "openshift.io/display-name": "Red Hat OpenJDK 8",
+                          "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                          "iconClass": "icon-jboss",
+                          "tags": "builder,java,xpaas,openjdk",
+                          "supports": "java:8,xpaas:1.0",
+                          "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                          "sampleContextDir": "undertow-servlet",
+                          "version": "1.1"
+                      },
+                      "from": {
+                        "kind": "ImageStreamTag",
+                        "name": "1.1-11"
+                      }
+                  }
                 ]
             }
-        }
+          }
     ]
 }


### PR DESCRIPTION
Goals of this PR are to align with expected naming "java" and what the developer would think as the version "8". So they'd think of it as java:8 and later java:9.

Alternatively, we may consider 2 image-streams. One that follows the traditional naming and a new one that adds the simple "java" name and the simple tags "8" or "9" as an example.