### PR TITLE
AMQ: Add TP tags to 6.3 templates

### DIFF
--- a/amq/amq63-basic.json
+++ b/amq/amq63-basic.json
@@ -215,7 +215,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "jboss-amq-63:1.2"
+                                "name": "jboss-amq-63:TP"
                             }
                         }
                     },

--- a/amq/amq63-persistent-ssl.json
+++ b/amq/amq63-persistent-ssl.json
@@ -360,7 +360,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "jboss-amq-63:1.2"
+                                "name": "jboss-amq-63:TP"
                             }
                         }
                     },

--- a/amq/amq63-persistent.json
+++ b/amq/amq63-persistent.json
@@ -229,7 +229,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "jboss-amq-63:1.2"
+                                "name": "jboss-amq-63:TP"
                             }
                         }
                     },

--- a/amq/amq63-ssl.json
+++ b/amq/amq63-ssl.json
@@ -346,7 +346,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "jboss-amq-63:1.2"
+                                "name": "jboss-amq-63:TP"
                             }
                         }
                     },


### PR DESCRIPTION
Complementary of ca5d5f92 (CLOUD-2063 add TP tags to image stream definitions)