### PR TITLE
README: correct filename when importing jboss streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ the following:
 ## Common Image Repositories
 The `jboss-image-streams.json` file contains __ImageStream__ definitions for all
 JBoss Middleware products.  This will need to be
-installed in the common `openshift` namespace (`oc create -f jboss-images-streams.json -n openshift`) before using any of the templates in these folders.  You will also need to install (into the `openshift` namespace) the database image streams supplied by OpenShift to use any of the templates that integrate with MySQL, PostgreSQL or MongoDB.
+installed in the common `openshift` namespace (`oc create -f jboss-image-streams.json -n openshift`) before using any of the templates in these folders.  You will also need to install (into the `openshift` namespace) the database image streams supplied by OpenShift to use any of the templates that integrate with MySQL, PostgreSQL or MongoDB.
 
 ## HTTPS configuration
 The majority of templates contain configuration that requires the creation of resources within your project to support HTTPS, specifically a service account and a secret that can be included into the pod as a volume.  The secrets directory contains a number of examples that can be installed into your project to allow you to test the A-MQ, EAP and JWS templates, you should replace the contents of these with data that is more appropriate for your deployments.


### PR DESCRIPTION
The documentation for creating the jboss image streams references a
file that does not exist:

  $ oc create -f jboss-images-streams.json -n openshift

Corrected to refer to 'jboss-image-streams.json' (i.e., image not
images).