### PR TITLE
Various updates for service catalog/OSBAPI - Part 1

### DIFF
--- a/jboss-image-streams.json
+++ b/jboss-image-streams.json
@@ -1,1665 +1,1655 @@
 {
-    "kind": "List",
-    "apiVersion": "v1",
-    "metadata": {
-        "name": "jboss-image-streams",
-        "annotations": {
-            "description": "ImageStream definitions for JBoss Middleware products."
+    "kind":"List",
+    "apiVersion":"v1",
+    "metadata":{
+        "name":"jboss-image-streams",
+        "annotations":{
+            "description":"ImageStream definitions for JBoss Middleware products.",
+            "openshift.io/provider-display-name":"Red Hat, Inc."
         }
     },
-    "items": [
+    "items":[
         {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "jboss-webserver30-tomcat7-openshift",
-                "annotations": {
-                    "openshift.io/display-name": "Red Hat JBoss Web Server 3.0 Tomcat 7",
-                    "version": "1.4.6"
+            "kind":"ImageStream",
+            "apiVersion":"v1",
+            "metadata":{
+                "name":"jboss-webserver30-tomcat7-openshift",
+                "annotations":{
+                    "openshift.io/display-name":"Red Hat JBoss Web Server 3.0 Tomcat 7",
+                    "openshift.io/provider-display-name":"Red Hat, Inc.",
+                    "version":"1.4.6"
                 }
             },
-            "labels": {
-                "xpaas": "1.4.6"
+            "labels":{
+                "xpaas":"1.4.6"
             },
-            "spec": {
-                "tags": [
+            "spec":{
+                "tags":[
                     {
-                        "name": "1.1",
-                        "annotations": {
-                            "description": "JBoss Web Server 3.0 Tomcat 7 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "hidden,builder,tomcat,tomcat7,java,jboss,xpaas",
-                            "supports": "tomcat7:3.0,tomcat:7,java:8,xpaas:1.1",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-                            "sampleContextDir": "tomcat-websocket-chat",
-                            "version": "1.1",
-                            "openshift.io/display-name": "Red Hat JBoss Web Server 3.0 Tomcat 7"
+                        "name":"1.1",
+                        "annotations":{
+                            "description":"JBoss Web Server 3.0 Tomcat 7 S2I images.",
+                            "iconClass":"icon-tomcat",
+                            "tags":"builder,tomcat,tomcat7,java,jboss,hidden",
+                            "supports":"tomcat7:3.0,tomcat:7,java:8:1.1",
+                            "sampleRepo":"https://github.com/jboss-openshift/openshift-quickstarts.git",
+                            "sampleContextDir":"tomcat-websocket-chat",
+                            "version":"1.1",
+                            "openshift.io/display-name":"Red Hat JBoss Web Server 3.0 Tomcat 7"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-webserver-3/webserver30-tomcat7-openshift:1.1"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-webserver-3/webserver30-tomcat7-openshift:1.1"
                         }
                     },
                     {
-                        "name": "1.2",
-                        "annotations": {
-                            "description": "JBoss Web Server 3.0 Tomcat 7 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "hidden,builder,tomcat,tomcat7,java,jboss,xpaas",
-                            "supports": "tomcat7:3.0,tomcat:7,java:8,xpaas:1.2",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-                            "sampleContextDir": "tomcat-websocket-chat",
-                            "version": "1.2",
-                            "openshift.io/display-name": "Red Hat JBoss Web Server 3.0 Tomcat 7"
+                        "name":"1.2",
+                        "annotations":{
+                            "description":"JBoss Web Server 3.0 Tomcat 7 S2I images.",
+                            "iconClass":"icon-tomcat",
+                            "tags":"builder,tomcat,tomcat7,java,jboss,hidden",
+                            "supports":"tomcat7:3.0,tomcat:7,java:8:1.2",
+                            "sampleRepo":"https://github.com/jboss-openshift/openshift-quickstarts.git",
+                            "sampleContextDir":"tomcat-websocket-chat",
+                            "version":"1.2",
+                            "openshift.io/display-name":"Red Hat JBoss Web Server 3.0 Tomcat 7"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-webserver-3/webserver30-tomcat7-openshift:1.2"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-webserver-3/webserver30-tomcat7-openshift:1.2"
                         }
                     },
                     {
-                        "name": "1.3",
-                        "annotations": {
-                            "description": "JBoss Web Server 3.0 Tomcat 7 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "hidden,builder,tomcat,tomcat7,java,jboss,xpaas",
-                            "supports":"tomcat7:3.0,tomcat:7,java:8,xpaas:1.3",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-                            "sampleContextDir": "tomcat-websocket-chat",
-                            "version": "1.3"
+                        "name":"1.3",
+                        "annotations":{
+                            "description":"JBoss Web Server 3.0 Tomcat 7 S2I images.",
+                            "iconClass":"icon-tomcat",
+                            "tags":"builder,tomcat,tomcat7,java,jboss,hidden",
+                            "supports":"tomcat7:3.0,tomcat:7,java:8:1.3",
+                            "sampleRepo":"https://github.com/jboss-openshift/openshift-quickstarts.git",
+                            "sampleContextDir":"tomcat-websocket-chat",
+                            "version":"1.3",
+                            "openshift.io/display-name":"Red Hat JBoss Web Server 3.0 Tomcat 7"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-webserver-3/webserver30-tomcat7-openshift:1.3"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-webserver-3/webserver30-tomcat7-openshift:1.3"
                         }
                     }
                 ]
             }
         },
         {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "jboss-webserver30-tomcat8-openshift",
-                "annotations": {
-                    "openshift.io/display-name": "Red Hat JBoss Web Server 3.0 Tomcat 8",
-                    "version": "1.4.6"
+            "kind":"ImageStream",
+            "apiVersion":"v1",
+            "metadata":{
+                "name":"jboss-webserver30-tomcat8-openshift",
+                "annotations":{
+                    "openshift.io/display-name":"Red Hat JBoss Web Server 3.0 Tomcat 8",
+                    "openshift.io/provider-display-name":"Red Hat, Inc.",
+                    "version":"1.4.6"
                 }
             },
-            "labels": {
-                "xpaas": "1.4.6"
+            "labels":{
+                "xpaas":"1.4.6"
             },
-            "spec": {
-                "tags": [
+            "spec":{
+                "tags":[
                     {
-                        "name": "1.1",
-                        "annotations": {
-                            "description": "JBoss Web Server 3.0 Tomcat 8 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "hidden,builder,tomcat,tomcat8,java,jboss,xpaas",
-                            "supports": "tomcat8:3.0,tomcat:8,java:8,xpaas:1.1",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-                            "sampleContextDir": "tomcat-websocket-chat",
-                            "version": "1.1",
-                            "openshift.io/display-name": "Red Hat JBoss Web Server 3.0 Tomcat 8"
+                        "name":"1.1",
+                        "annotations":{
+                            "description":"JBoss Web Server 3.0 Tomcat 8 S2I images.",
+                            "iconClass":"icon-tomcat",
+                            "tags":"builder,tomcat,tomcat8,java,jboss,hidden",
+                            "supports":"tomcat8:3.0,tomcat:8,java:8:1.1",
+                            "sampleRepo":"https://github.com/jboss-openshift/openshift-quickstarts.git",
+                            "sampleContextDir":"tomcat-websocket-chat",
+                            "version":"1.1",
+                            "openshift.io/display-name":"Red Hat JBoss Web Server 3.0 Tomcat 8"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-webserver-3/webserver30-tomcat8-openshift:1.1"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-webserver-3/webserver30-tomcat8-openshift:1.1"
                         }
                     },
                     {
-                        "name": "1.2",
-                        "annotations": {
-                            "description": "JBoss Web Server 3.0 Tomcat 8 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "hidden,builder,tomcat,tomcat8,java,jboss,xpaas",
-                            "supports": "tomcat8:3.0,tomcat:8,java:8,xpaas:1.2",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-                            "sampleContextDir": "tomcat-websocket-chat",
-                            "version": "1.2",
-                            "openshift.io/display-name": "Red Hat JBoss Web Server 3.0 Tomcat 8"
+                        "name":"1.2",
+                        "annotations":{
+                            "description":"JBoss Web Server 3.0 Tomcat 8 S2I images.",
+                            "iconClass":"icon-tomcat",
+                            "tags":"builder,tomcat,tomcat8,java,jboss,hidden",
+                            "supports":"tomcat8:3.0,tomcat:8,java:8:1.2",
+                            "sampleRepo":"https://github.com/jboss-openshift/openshift-quickstarts.git",
+                            "sampleContextDir":"tomcat-websocket-chat",
+                            "version":"1.2",
+                            "openshift.io/display-name":"Red Hat JBoss Web Server 3.0 Tomcat 8"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-webserver-3/webserver30-tomcat8-openshift:1.2"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-webserver-3/webserver30-tomcat8-openshift:1.2"
                         }
                     },
                     {
-                        "name": "1.3",
-                        "annotations": {
-                            "description": "JBoss Web Server 3.0 Tomcat 8 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "hidden,builder,tomcat,tomcat8,java,jboss,xpaas",
-                            "supports":"tomcat8:3.0,tomcat:8,java:8,xpaas:1.3",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-                            "sampleContextDir": "tomcat-websocket-chat",
-                            "version": "1.3"
+                        "name":"1.3",
+                        "annotations":{
+                            "description":"JBoss Web Server 3.0 Tomcat 8 S2I images.",
+                            "iconClass":"icon-tomcat",
+                            "tags":"builder,tomcat,tomcat8,java,jboss,hidden",
+                            "supports":"tomcat8:3.0,tomcat:8,java:8:1.3",
+                            "sampleRepo":"https://github.com/jboss-openshift/openshift-quickstarts.git",
+                            "sampleContextDir":"tomcat-websocket-chat",
+                            "version":"1.3",
+                            "openshift.io/display-name":"Red Hat JBoss Web Server 3.0 Tomcat 8"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-webserver-3/webserver30-tomcat8-openshift:1.3"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-webserver-3/webserver30-tomcat8-openshift:1.3"
                         }
                     }
                 ]
             }
         },
         {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "jboss-webserver31-tomcat7-openshift",
-                "annotations": {
-                    "openshift.io/display-name": "Red Hat JBoss Web Server 3.1 Tomcat 7",
-                    "version": "1.4.6"
+            "kind":"ImageStream",
+            "apiVersion":"v1",
+            "metadata":{
+                "name":"jboss-webserver31-tomcat7-openshift",
+                "annotations":{
+                    "openshift.io/display-name":"Red Hat JBoss Web Server 3.1 Tomcat 7",
+                    "openshift.io/provider-display-name":"Red Hat, Inc.",
+                    "version":"1.4.6"
                 }
             },
-            "labels": {
-                "xpaas": "1.4.6"
+            "labels":{
+                "xpaas":"1.4.6"
             },
-            "spec": {
-                "tags": [
+            "spec":{
+                "tags":[
                     {
-                        "name": "TP",
-                        "annotations": {
-                            "description": "JBoss Web Server 3.1 Tomcat 7 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "builder,tomcat,tomcat7,java,jboss,xpaas",
-                            "supports": "tomcat7:3.1,tomcat:7,java:8,xpaas:1.4",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-                            "sampleContextDir": "tomcat-websocket-chat",
-                            "version": "TP",
-                            "openshift.io/display-name": "Red Hat JBoss Web Server 3.1 Tomcat 7 (Tech Preview)"
+                        "name":"TP",
+                        "annotations":{
+                            "description":"JBoss Web Server 3.1 Tomcat 7 S2I images.",
+                            "iconClass":"icon-tomcat",
+                            "tags":"builder,tomcat,tomcat7,java,jboss,hidden",
+                            "supports":"tomcat7:3.1,tomcat:7,java:8:1.4",
+                            "sampleRepo":"https://github.com/jboss-openshift/openshift-quickstarts.git",
+                            "sampleContextDir":"tomcat-websocket-chat",
+                            "version":"TP",
+                            "openshift.io/display-name":"Red Hat JBoss Web Server 3.1 Tomcat 7 (Tech Preview)"
                         },
-                        "from": {
-                            "kind": "ImageStreamTag",
-                            "name": "1.1-TP"
+                        "from":{
+                            "kind":"ImageStreamTag",
+                            "name":"1.1-TP"
                         }
                     },
                     {
-                        "name": "1.0",
-                        "annotations": {
-                            "description": "JBoss Web Server 3.1 Tomcat 7 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "builder,tomcat,tomcat7,java,jboss,xpaas",
-                            "supports": "tomcat7:3.1,tomcat:7,java:8,xpaas:1.4",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-                            "sampleContextDir": "tomcat-websocket-chat",
-                            "version": "1.0",
-                            "openshift.io/display-name": "Red Hat JBoss Web Server 3.1 Tomcat 7"
+                        "name":"1.0",
+                        "annotations":{
+                            "description":"JBoss Web Server 3.1 Tomcat 7 S2I images.",
+                            "iconClass":"icon-tomcat",
+                            "tags":"builder,tomcat,tomcat7,java,jboss,hidden",
+                            "supports":"tomcat7:3.1,tomcat:7,java:8:1.4",
+                            "sampleRepo":"https://github.com/jboss-openshift/openshift-quickstarts.git",
+                            "sampleContextDir":"tomcat-websocket-chat",
+                            "version":"1.0",
+                            "openshift.io/display-name":"Red Hat JBoss Web Server 3.1 Tomcat 7"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-webserver-3/webserver31-tomcat7-openshift:1.0"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-webserver-3/webserver31-tomcat7-openshift:1.0"
                         }
                     },
                     {
-                        "name": "1.1-TP",
-                        "annotations": {
-                            "description": "JBoss Web Server 3.1 Tomcat 7 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "builder,tomcat,tomcat7,java,jboss,xpaas",
-                            "supports": "tomcat7:3.1,tomcat:7,java:8,xpaas:1.4",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-                            "sampleContextDir": "tomcat-websocket-chat",
-                            "version": "1.1",
-                            "openshift.io/display-name": "Red Hat JBoss Web Server 3.1 Tomcat 7 (Tech Preview)"
+                        "name":"1.1-TP",
+                        "annotations":{
+                            "description":"JBoss Web Server 3.1 Tomcat 7 S2I images.",
+                            "iconClass":"icon-tomcat",
+                            "tags":"builder,tomcat,tomcat7,java,jboss,hidden",
+                            "supports":"tomcat7:3.1,tomcat:7,java:8:1.4",
+                            "sampleRepo":"https://github.com/jboss-openshift/openshift-quickstarts.git",
+                            "sampleContextDir":"tomcat-websocket-chat",
+                            "version":"1.1",
+                            "openshift.io/display-name":"Red Hat JBoss Web Server 3.1 Tomcat 7 (Tech Preview)"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-webserver-3-tech-preview/webserver31-tomcat7-openshift:1.1"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-webserver-3-tech-preview/webserver31-tomcat7-openshift:1.1"
                         }
                     }
                 ]
             }
         },
         {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "jboss-webserver31-tomcat8-openshift",
-                "annotations": {
-                    "openshift.io/display-name": "Red Hat JBoss Web Server 3.1 Tomcat 8",
-                    "version": "1.4.6"
+            "kind":"ImageStream",
+            "apiVersion":"v1",
+            "metadata":{
+                "name":"jboss-webserver31-tomcat8-openshift",
+                "annotations":{
+                    "openshift.io/display-name":"JBoss Web Server 3.1 Tomcat 8",
+                    "openshift.io/provider-display-name":"Red Hat, Inc.",
+                    "version":"1.4.6"
                 }
             },
-            "labels": {
-                "xpaas": "1.4.6"
+            "labels":{
+                "xpaas":"1.4.6"
             },
-            "spec": {
-                "tags": [
+            "spec":{
+                "tags":[
                     {
-                        "name": "TP",
-                        "annotations": {
-                            "description": "JBoss Web Server 3.1 Tomcat 8 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "builder,tomcat,tomcat8,java,jboss,xpaas",
-                            "supports": "tomcat8:3.1,tomcat:8,java:8,xpaas:1.4",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-                            "sampleContextDir": "tomcat-websocket-chat",
-                            "version": "TP",
-                            "openshift.io/display-name": "Red Hat JBoss Web Server 3.1 Tomcat 8 (Tech Preview)"
+                        "name":"TP",
+                        "annotations":{
+                            "description":"JBoss Web Server 3.1 Tomcat 8 S2I images.",
+                            "iconClass":"icon-tomcat",
+                            "tags":"builder,tomcat,tomcat8,java,jboss,hidden",
+                            "supports":"tomcat8:3.1,tomcat:8,java:8:1.4",
+                            "sampleRepo":"https://github.com/jboss-openshift/openshift-quickstarts.git",
+                            "sampleContextDir":"tomcat-websocket-chat",
+                            "version":"TP",
+                            "openshift.io/display-name":"Red Hat JBoss Web Server 3.1 Tomcat 8 (Tech Preview)"
                         },
-                        "from": {
-                            "kind": "ImageStreamTag",
-                            "name": "1.1-TP"
+                        "from":{
+                            "kind":"ImageStreamTag",
+                            "name":"1.1-TP"
                         }
                     },
                     {
-                        "name": "1.0",
-                        "annotations": {
-                            "description": "JBoss Web Server 3.1 Tomcat 8 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "builder,tomcat,tomcat8,java,jboss,xpaas",
-                            "supports": "tomcat8:3.1,tomcat:8,java:8,xpaas:1.4",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-                            "sampleContextDir": "tomcat-websocket-chat",
-                            "version": "1.0",
-                            "openshift.io/display-name": "Red Hat JBoss Web Server 3.1 Tomcat 8"
+                        "name":"1.0",
+                        "annotations":{
+                            "description":"JBoss Web Server 3.1 Tomcat 8 S2I images.",
+                            "iconClass":"icon-tomcat",
+                            "tags":"builder,tomcat,tomcat8,java,jboss,hidden",
+                            "supports":"tomcat8:3.1,tomcat:8,java:8:1.4",
+                            "sampleRepo":"https://github.com/jboss-openshift/openshift-quickstarts.git",
+                            "sampleContextDir":"tomcat-websocket-chat",
+                            "version":"1.0",
+                            "openshift.io/display-name":"JBoss Web Server 3.1 Tomcat 8"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-webserver-3/webserver31-tomcat8-openshift:1.0"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-webserver-3/webserver31-tomcat8-openshift:1.0"
                         }
                     },
                     {
-                        "name": "1.1-TP",
-                        "annotations": {
-                            "description": "JBoss Web Server 3.1 Tomcat 8 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "builder,tomcat,tomcat8,java,jboss,xpaas",
-                            "supports": "tomcat8:3.1,tomcat:8,java:8,xpaas:1.4",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-                            "sampleContextDir": "tomcat-websocket-chat",
-                            "version": "1.1",
-                            "openshift.io/display-name": "Red Hat JBoss Web Server 3.1 Tomcat 8 (Tech Preview)"
+                        "name":"1.1-TP",
+                        "annotations":{
+                            "description":"JBoss Web Server 3.1 Tomcat 8 S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"builder,tomcat,tomcat8,java,jboss,hidden",
+                            "supports":"tomcat8:3.1,tomcat:8,java:8:1.4",
+                            "sampleRepo":"https://github.com/jboss-openshift/openshift-quickstarts.git",
+                            "sampleContextDir":"tomcat-websocket-chat",
+                            "version":"1.1",
+                            "openshift.io/display-name":"Red Hat JBoss Web Server 3.1 Tomcat 8 (Tech Preview)"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-webserver-3-tech-preview/webserver31-tomcat8-openshift:1.1"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-webserver-3-tech-preview/webserver31-tomcat8-openshift:1.1"
                         }
                     }
                 ]
             }
         },
         {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "jboss-eap64-openshift",
-                "annotations": {
-                    "openshift.io/display-name": "Red Hat JBoss EAP 6.4",
-                    "version": "1.4.6"
+            "kind":"ImageStream",
+            "apiVersion":"v1",
+            "metadata":{
+                "name":"jboss-eap64-openshift",
+                "annotations":{
+                    "openshift.io/display-name":"Red Hat JBoss EAP 6.4",
+                    "openshift.io/provider-display-name":"Red Hat, Inc.",
+                    "version":"1.4.6"
                 }
             },
-            "labels": {
-                "xpaas": "1.4.6"
+            "labels":{
+                "xpaas":"1.4.6"
             },
-            "spec": {
-                "tags": [
+            "spec":{
+                "tags":[
                     {
-                        "name": "TP",
-                        "annotations": {
-                            "description": "JBoss EAP 6.4 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "builder,eap,javaee,java,jboss,xpaas",
-                            "supports": "eap:6.4,javaee:6,java:8,xpaas:1.1",
-                            "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
-                            "sampleContextDir": "kitchensink",
-                            "sampleRef": "6.4.x",
-                            "version": "TP",
-                            "openshift.io/display-name": "Red Hat JBoss EAP 6.4 (Tech Preview)"
+                        "name":"TP",
+                        "annotations":{
+                            "description":"JBoss EAP 6.4 S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"builder,eap,javaee,java,jboss,hidden",
+                            "supports":"eap:6.4,javaee:6,java:8:1.1",
+                            "sampleRepo":"https://github.com/jboss-developer/jboss-eap-quickstarts.git",
+                            "sampleContextDir":"kitchensink",
+                            "sampleRef":"6.4.x",
+                            "version":"TP",
+                            "openshift.io/display-name":"Red Hat JBoss EAP 6.4 (Tech Preview)"
                         },
-                        "from": {
-                            "kind": "ImageStreamTag",
-                            "name": "1.6-TP"
+                        "from":{
+                            "kind":"ImageStreamTag",
+                            "name":"1.6-TP"
                         }
                     },
                     {
-                        "name": "1.1",
-                        "annotations": {
-                            "description": "JBoss EAP 6.4 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "builder,eap,javaee,java,jboss,xpaas",
-                            "supports": "eap:6.4,javaee:6,java:8,xpaas:1.1",
-                            "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
-                            "sampleContextDir": "kitchensink",
-                            "sampleRef": "6.4.x",
-                            "version": "1.1",
-                            "openshift.io/display-name": "Red Hat JBoss EAP 6.4"
+                        "name":"1.1",
+                        "annotations":{
+                            "description":"JBoss EAP 6.4 S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"builder,eap,javaee,java,jboss,hidden",
+                            "supports":"eap:6.4,javaee:6,java:8:1.1",
+                            "sampleRepo":"https://github.com/jboss-developer/jboss-eap-quickstarts.git",
+                            "sampleContextDir":"kitchensink",
+                            "sampleRef":"6.4.x",
+                            "version":"1.1",
+                            "openshift.io/display-name":"Red Hat JBoss EAP 6.4"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-eap-6/eap64-openshift:1.1"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-eap-6/eap64-openshift:1.1"
                         }
                     },
                     {
-                        "name": "1.2",
-                        "annotations": {
-                            "description": "JBoss EAP 6.4 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "builder,eap,javaee,java,jboss,xpaas",
-                            "supports": "eap:6.4,javaee:6,java:8,xpaas:1.2",
-                            "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
-                            "sampleContextDir": "kitchensink",
-                            "sampleRef": "6.4.x",
-                            "version": "1.2",
-                            "openshift.io/display-name": "Red Hat JBoss EAP 6.4"
+                        "name":"1.2",
+                        "annotations":{
+                            "description":"JBoss EAP 6.4 S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"builder,eap,javaee,java,jboss,hidden",
+                            "supports":"eap:6.4,javaee:6,java:8:1.2",
+                            "sampleRepo":"https://github.com/jboss-developer/jboss-eap-quickstarts.git",
+                            "sampleContextDir":"kitchensink",
+                            "sampleRef":"6.4.x",
+                            "version":"1.2",
+                            "openshift.io/display-name":"Red Hat JBoss EAP 6.4"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-eap-6/eap64-openshift:1.2"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-eap-6/eap64-openshift:1.2"
                         }
                     },
                     {
-                        "name": "1.3",
-                        "annotations": {
-                            "description": "JBoss EAP 6.4 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "builder,eap,javaee,java,jboss,xpaas",
-                            "supports": "eap:6.4,javaee:6,java:8,xpaas:1.3",
-                            "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
-                            "sampleContextDir": "kitchensink",
-                            "sampleRef": "6.4.x",
-                            "version": "1.3",
-                            "openshift.io/display-name": "Red Hat JBoss EAP 6.4"
+                        "name":"1.3",
+                        "annotations":{
+                            "description":"JBoss EAP 6.4 S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"builder,eap,javaee,java,jboss,hidden",
+                            "supports":"eap:6.4,javaee:6,java:8:1.3",
+                            "sampleRepo":"https://github.com/jboss-developer/jboss-eap-quickstarts.git",
+                            "sampleContextDir":"kitchensink",
+                            "sampleRef":"6.4.x",
+                            "version":"1.3",
+                            "openshift.io/display-name":"Red Hat JBoss EAP 6.4"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-eap-6/eap64-openshift:1.3"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-eap-6/eap64-openshift:1.3"
                         }
                     },
                     {
-                        "name": "1.4",
-                        "annotations": {
-                            "description": "JBoss EAP 6.4 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "builder,eap,javaee,java,jboss,xpaas",
-                            "supports": "eap:6.4,javaee:6,java:8,xpaas:1.4",
-                            "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
-                            "sampleContextDir": "kitchensink",
-                            "sampleRef": "6.4.x",
-                            "version": "1.4",
-                            "openshift.io/display-name": "Red Hat JBoss EAP 6.4"
+                        "name":"1.4",
+                        "annotations":{
+                            "description":"JBoss EAP 6.4 S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"builder,eap,javaee,java,jboss,hidden",
+                            "supports":"eap:6.4,javaee:6,java:8:1.4",
+                            "sampleRepo":"https://github.com/jboss-developer/jboss-eap-quickstarts.git",
+                            "sampleContextDir":"kitchensink",
+                            "sampleRef":"6.4.x",
+                            "version":"1.4",
+                            "openshift.io/display-name":"Red Hat JBoss EAP 6.4"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-eap-6/eap64-openshift:1.4"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-eap-6/eap64-openshift:1.4"
                         }
                     },
                     {
-                        "name": "1.5",
-                        "annotations": {
-                            "description": "JBoss EAP 6.4 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "builder,eap,javaee,java,jboss,xpaas",
-                            "supports":"eap:6.4,javaee:6,java:8,xpaas:1.5",
-                            "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
-                            "sampleContextDir": "kitchensink",
-                            "sampleRef": "6.4.x",
-                            "version": "1.5",
-                            "openshift.io/display-name": "Red Hat JBoss EAP 6.4"
+                        "name":"1.5",
+                        "annotations":{
+                            "description":"JBoss EAP 6.4 S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"builder,eap,javaee,java,jboss,hidden",
+                            "supports":"eap:6.4,javaee:6,java:8:1.5",
+                            "sampleRepo":"https://github.com/jboss-developer/jboss-eap-quickstarts.git",
+                            "sampleContextDir":"kitchensink",
+                            "sampleRef":"6.4.x",
+                            "version":"1.5",
+                            "openshift.io/display-name":"Red Hat JBoss EAP 6.4"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-eap-6/eap64-openshift:1.5"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-eap-6/eap64-openshift:1.5"
                         }
                     },
                     {
-                        "name": "1.6-TP",
-                        "annotations": {
-                            "description": "JBoss EAP 6.4 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "builder,eap,javaee,java,jboss,xpaas",
-                            "supports":"eap:6.4,javaee:6,java:8,xpaas:1.5",
-                            "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
-                            "sampleContextDir": "kitchensink",
-                            "sampleRef": "6.4.x",
-                            "version": "1.6",
-                            "openshift.io/display-name": "Red Hat JBoss EAP 6.4 (Tech Preview)"
+                        "name":"1.6-TP",
+                        "annotations":{
+                            "description":"JBoss EAP 6.4 S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"builder,eap,javaee,java,jboss,hidden",
+                            "supports":"eap:6.4,javaee:6,java:8:1.5",
+                            "sampleRepo":"https://github.com/jboss-developer/jboss-eap-quickstarts.git",
+                            "sampleContextDir":"kitchensink",
+                            "sampleRef":"6.4.x",
+                            "version":"1.6",
+                            "openshift.io/display-name":"Red Hat JBoss EAP 6.4 (Tech Preview)"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-eap-6-tech-preview/eap64-openshift:1.6"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-eap-6-tech-preview/eap64-openshift:1.6"
                         }
                     }
                 ]
             }
         },
         {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "jboss-eap70-openshift",
-                "annotations": {
-                    "openshift.io/display-name": "Red Hat JBoss EAP 7.0",
-                    "version": "1.4.6"
+            "kind":"ImageStream",
+            "apiVersion":"v1",
+            "metadata":{
+                "name":"jboss-eap70-openshift",
+                "annotations":{
+                    "openshift.io/display-name":"Red Hat JBoss EAP 7.0",
+                    "openshift.io/provider-display-name":"Red Hat, Inc.",
+                    "version":"1.4.6"
                 }
             },
-            "labels": {
-                "xpaas": "1.4.6"
+            "labels":{
+                "xpaas":"1.4.6"
             },
-            "spec": {
-                "tags": [
+            "spec":{
+                "tags":[
                     {
-                        "name": "TP",
-                        "annotations": {
-                            "description": "JBoss EAP 7.0 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "builder,eap,javaee,java,jboss,xpaas",
-                            "supports": "eap:7.0,javaee:7,java:8,xpaas:1.3",
-                            "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
-                            "sampleContextDir": "kitchensink",
-                            "sampleRef": "7.0.0.GA",
-                            "version": "TP",
-                            "openshift.io/display-name": "Red Hat JBoss EAP 7.0 (Tech Preview)"
+                        "name":"TP",
+                        "annotations":{
+                            "description":"JBoss EAP 7.0 S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"builder,eap,javaee,java,jboss,hidden",
+                            "supports":"eap:7.0,javaee:7,java:8:1.3",
+                            "sampleRepo":"https://github.com/jboss-developer/jboss-eap-quickstarts.git",
+                            "sampleContextDir":"kitchensink",
+                            "sampleRef":"7.0.0.GA",
+                            "version":"TP",
+                            "openshift.io/display-name":"Red Hat JBoss EAP 7.0 (Tech Preview)"
                         },
-                        "from": {
-                            "kind": "ImageStreamTag",
-                            "name": "1.6-TP"
+                        "from":{
+                            "kind":"ImageStreamTag",
+                            "name":"1.6-TP"
                         }
                     },
                     {
-                        "name": "1.3",
-                        "annotations": {
-                            "description": "JBoss EAP 7.0 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "builder,eap,javaee,java,jboss,xpaas",
-                            "supports": "eap:7.0,javaee:7,java:8,xpaas:1.3",
-                            "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
-                            "sampleContextDir": "kitchensink",
-                            "sampleRef": "7.0.0.GA",
-                            "version": "1.3",
-                            "openshift.io/display-name": "Red Hat JBoss EAP 7.0"
+                        "name":"1.3",
+                        "annotations":{
+                            "description":"JBoss EAP 7.0 S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"builder,eap,javaee,java,jboss,hidden",
+                            "supports":"eap:7.0,javaee:7,java:8:1.3",
+                            "sampleRepo":"https://github.com/jboss-developer/jboss-eap-quickstarts.git",
+                            "sampleContextDir":"kitchensink",
+                            "sampleRef":"7.0.0.GA",
+                            "version":"1.3",
+                            "openshift.io/display-name":"Red Hat JBoss EAP 7.0"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-eap-7/eap70-openshift:1.3"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-eap-7/eap70-openshift:1.3"
                         }
                     },
                     {
-                        "name": "1.4",
-                        "annotations": {
-                            "description": "JBoss EAP 7.0 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "builder,eap,javaee,java,jboss,xpaas",
-                            "supports": "eap:7.0,javaee:7,java:8,xpaas:1.4",
-                            "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
-                            "sampleContextDir": "kitchensink",
-                            "sampleRef": "7.0.0.GA",
-                            "version": "1.4",
-                            "openshift.io/display-name": "Red Hat JBoss EAP 7.0"
+                        "name":"1.4",
+                        "annotations":{
+                            "description":"JBoss EAP 7.0 S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"builder,eap,javaee,java,jboss,hidden",
+                            "supports":"eap:7.0,javaee:7,java:8:1.4",
+                            "sampleRepo":"https://github.com/jboss-developer/jboss-eap-quickstarts.git",
+                            "sampleContextDir":"kitchensink",
+                            "sampleRef":"7.0.0.GA",
+                            "version":"1.4",
+                            "openshift.io/display-name":"Red Hat JBoss EAP 7.0"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-eap-7/eap70-openshift:1.4"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-eap-7/eap70-openshift:1.4"
                         }
                     },
                     {
-                        "name": "1.5",
-                        "annotations": {
-                            "description": "JBoss EAP 7.0 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "builder,eap,javaee,java,jboss,xpaas",
-                            "supports":"eap:7.0,javaee:7,java:8,xpaas:1.5",
-                            "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
-                            "sampleContextDir": "kitchensink",
-                            "sampleRef": "7.0.0.GA",
-                            "version": "1.5",
-                            "openshift.io/display-name": "Red Hat JBoss EAP 7.0"
+                        "name":"1.5",
+                        "annotations":{
+                            "description":"JBoss EAP 7.0 S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"builder,eap,javaee,java,jboss,hidden",
+                            "supports":"eap:7.0,javaee:7,java:8:1.5",
+                            "sampleRepo":"https://github.com/jboss-developer/jboss-eap-quickstarts.git",
+                            "sampleContextDir":"kitchensink",
+                            "sampleRef":"7.0.0.GA",
+                            "version":"1.5",
+                            "openshift.io/display-name":"Red Hat JBoss EAP 7.0"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-eap-7/eap70-openshift:1.5"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-eap-7/eap70-openshift:1.5"
                         }
                     },
                     {
-                        "name": "1.6-TP",
-                        "annotations": {
-                            "description": "JBoss EAP 7.0 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "builder,eap,javaee,java,jboss,xpaas",
-                            "supports":"eap:7.0,javaee:7,java:8,xpaas:1.5",
-                            "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
-                            "sampleContextDir": "kitchensink",
-                            "sampleRef": "7.0.0.GA",
-                            "version": "1.6",
-                            "openshift.io/display-name": "Red Hat JBoss EAP 7.0 (Tech Preview)"
+                        "name":"1.6-TP",
+                        "annotations":{
+                            "description":"JBoss EAP 7.0 S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"builder,eap,javaee,java,jboss,hidden",
+                            "supports":"eap:7.0,javaee:7,java:8:1.5",
+                            "sampleRepo":"https://github.com/jboss-developer/jboss-eap-quickstarts.git",
+                            "sampleContextDir":"kitchensink",
+                            "sampleRef":"7.0.0.GA",
+                            "version":"1.6",
+                            "openshift.io/display-name":"Red Hat JBoss EAP 7.0 (Tech Preview)"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-eap-7-tech-preview/eap70-openshift:1.6"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-eap-7-tech-preview/eap70-openshift:1.6"
                         }
                     }
                 ]
             }
         },
         {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "jboss-eap71-openshift",
-                "annotations": {
-                    "openshift.io/display-name": "Red Hat JBoss EAP 7.1",
-                    "version": "1.4.6"
+            "kind":"ImageStream",
+            "apiVersion":"v1",
+            "metadata":{
+                "name":"jboss-eap71-openshift",
+                "annotations":{
+                    "openshift.io/display-name":"Red Hat JBoss EAP 7.1",
+                    "openshift.io/provider-display-name":"Red Hat, Inc.",
+                    "version":"1.4.6"
                 }
             },
-            "labels": {
-                "xpaas": "1.4.6"
+            "labels":{
+                "xpaas":"1.4.6"
             },
-            "spec": {
-                "tags": [
+            "spec":{
+                "tags":[
                     {
-                        "name": "TP",
-                        "annotations": {
-                            "description": "JBoss EAP 7.1 Tech Preview.",
-                            "iconClass": "icon-jboss",
-                            "tags": "builder,eap,javaee,java,jboss,xpaas",
-                            "supports":"eap:7.1,javaee:7,java:8,xpaas:1.0",
-                            "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
-                            "sampleContextDir": "kitchensink",
-                            "sampleRef": "7.0.0.GA",
-                            "version": "TP",
-                            "openshift.io/display-name": "Red Hat JBoss EAP 7.1 (Tech Preview)"
+                        "name":"TP",
+                        "annotations":{
+                            "description":"JBoss EAP 7.1 Tech Preview.",
+                            "iconClass":"icon-jboss",
+                            "tags":"builder,eap,javaee,java,jboss,hidden",
+                            "supports":"eap:7.1,javaee:7,java:8:1.0",
+                            "sampleRepo":"https://github.com/jboss-developer/jboss-eap-quickstarts.git",
+                            "sampleContextDir":"kitchensink",
+                            "sampleRef":"7.0.0.GA",
+                            "version":"TP",
+                            "openshift.io/display-name":"Red Hat JBoss EAP 7.1 (Tech Preview)"
                         },
-                        "from": {
-                          "kind": "ImageStreamTag",
-                          "name": "1.0-TP"
+                        "from":{
+                            "kind":"ImageStreamTag",
+                            "name":"1.0-TP"
                         }
                     },
                     {
-                        "name": "1.0-TP",
-                        "annotations": {
-                            "description": "JBoss EAP 7.1 Tech Preview.",
-                            "iconClass": "icon-jboss",
-                            "tags": "builder,eap,javaee,java,jboss,xpaas",
-                            "supports":"eap:7.1,javaee:7,java:8,xpaas:1.0",
-                            "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
-                            "sampleContextDir": "kitchensink",
-                            "sampleRef": "7.0.0.GA",
-                            "version": "1.0",
-                            "openshift.io/display-name": "Red Hat JBoss EAP 7.1 (Tech Preview)"
+                        "name":"1.0-TP",
+                        "annotations":{
+                            "description":"JBoss EAP 7.1 Tech Preview.",
+                            "iconClass":"icon-jboss",
+                            "tags":"builder,eap,javaee,java,jboss,hidden",
+                            "supports":"eap:7.1,javaee:7,java:8:1.0",
+                            "sampleRepo":"https://github.com/jboss-developer/jboss-eap-quickstarts.git",
+                            "sampleContextDir":"kitchensink",
+                            "sampleRef":"7.0.0.GA",
+                            "version":"1.0",
+                            "openshift.io/display-name":"Red Hat JBoss EAP 7.1 (Tech Preview)"
                         },
-                        "from": {
-                          "kind": "DockerImage",
-                          "name": "registry.access.redhat.com/jboss-eap-7-tech-preview/eap71-openshift:1.0"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-eap-7-tech-preview/eap71-openshift:1.0"
                         }
                     }
                 ]
             }
         },
         {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "jboss-decisionserver62-openshift",
-                "annotations": {
-                    "openshift.io/display-name": "Red Hat JBoss BRMS 6.2 decision server",
-                    "version": "1.4.6"
+            "kind":"ImageStream",
+            "apiVersion":"v1",
+            "metadata":{
+                "name":"jboss-decisionserver62-openshift",
+                "annotations":{
+                    "openshift.io/display-name":"Red Hat JBoss BRMS 6.2 decision server",
+                    "version":"1.4.6"
                 }
             },
-            "labels": {
-                "xpaas": "1.4.6"
+            "labels":{
+                "xpaas":"1.4.6"
             },
-            "spec": {
-                "dockerImageRepository": "registry.access.redhat.com/jboss-decisionserver-6/decisionserver62-openshift",
-                "tags": [
+            "spec":{
+                "tags":[
                     {
-                        "name": "1.2",
-                        "annotations": {
-                            "description": "Red Hat JBoss BRMS 6.2 decision server S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "hidden,builder,decisionserver,xpaas",
-                            "supports": "decisionserver:6.2,xpaas:1.2",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-                            "sampleContextDir": "decisionserver/hellorules",
-                            "sampleRef": "1.2",
-                            "version": "1.2",
-                            "openshift.io/display-name": "Red Hat JBoss BRMS 6.2 decision server"
+                        "name":"1.2",
+                        "annotations":{
+                            "description":"Red Hat JBoss BRMS 6.2 decision server S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"hidden,builder,decisionserver,hidden",
+                            "supports":"decisionserver:6.2:1.2",
+                            "sampleRepo":"https://github.com/jboss-openshift/openshift-quickstarts.git",
+                            "sampleContextDir":"decisionserver/hellorules",
+                            "sampleRef":"1.2",
+                            "version":"1.2",
+                            "openshift.io/display-name":"Red Hat JBoss BRMS 6.2 decision server"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-decisionserver-6/decisionserver62-openshift:1.2"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-decisionserver-6/decisionserver62-openshift:1.2"
                         }
                     }
                 ]
             }
         },
         {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "jboss-decisionserver63-openshift",
-                "annotations": {
-                    "openshift.io/display-name": "Red Hat JBoss BRMS 6.3 decision server",
-                    "version": "1.4.6"
+            "kind":"ImageStream",
+            "apiVersion":"v1",
+            "metadata":{
+                "name":"jboss-decisionserver63-openshift",
+                "annotations":{
+                    "openshift.io/display-name":"Red Hat JBoss BRMS 6.3 decision server",
+                    "openshift.io/provider-display-name":"Red Hat, Inc.",
+                    "version":"1.4.6"
                 }
             },
-            "labels": {
-                "xpaas": "1.4.6"
+            "labels":{
+                "xpaas":"1.4.6"
             },
-            "spec": {
-                "tags": [
+            "spec":{
+                "tags":[
                     {
-                        "name": "1.3",
-                        "annotations": {
-                            "description": "Red Hat JBoss BRMS 6.3 decision server S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "hidden,builder,decisionserver,xpaas",
-                            "supports": "decisionserver:6.3,xpaas:1.3",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-                            "sampleContextDir": "decisionserver/hellorules",
-                            "sampleRef": "1.3",
-                            "version": "1.3",
-                            "openshift.io/display-name": "Red Hat JBoss BRMS 6.3 decision server"
+                        "name":"1.3",
+                        "annotations":{
+                            "description":"Red Hat JBoss BRMS 6.3 decision server S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"builder,decisionserver,hidden",
+                            "supports":"decisionserver:6.3:1.3",
+                            "sampleRepo":"https://github.com/jboss-openshift/openshift-quickstarts.git",
+                            "sampleContextDir":"decisionserver/hellorules",
+                            "sampleRef":"1.3",
+                            "version":"1.3",
+                            "openshift.io/display-name":"Red Hat JBoss BRMS 6.3 decision server"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-decisionserver-6/decisionserver63-openshift:1.3"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-decisionserver-6/decisionserver63-openshift:1.3"
                         }
                     },
                     {
-                        "name": "1.4",
-                        "annotations": {
-                            "description": "Red Hat JBoss BRMS 6.3 decision server S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "hidden,builder,decisionserver,java,xpaas",
-                            "supports":"decisionserver:6.3,java:8,xpaas:1.4",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-                            "sampleContextDir": "decisionserver/hellorules",
-                            "sampleRef": "1.3",
-                            "version": "1.4",
-                            "openshift.io/display-name": "Red Hat JBoss BRMS 6.3 decision server"
+                        "name":"1.4",
+                        "annotations":{
+                            "description":"Red Hat JBoss BRMS 6.3 decision server S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"builder,decisionserver,java,hidden",
+                            "supports":"decisionserver:6.3,java:8:1.4",
+                            "sampleRepo":"https://github.com/jboss-openshift/openshift-quickstarts.git",
+                            "sampleContextDir":"decisionserver/hellorules",
+                            "sampleRef":"1.3",
+                            "version":"1.4",
+                            "openshift.io/display-name":"Red Hat JBoss BRMS 6.3 decision server"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-decisionserver-6/decisionserver63-openshift:1.4"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-decisionserver-6/decisionserver63-openshift:1.4"
                         }
                     }
                 ]
             }
         },
         {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "jboss-decisionserver64-openshift",
-                "annotations": {
-                    "openshift.io/display-name": "Red Hat JBoss BRMS 6.4 decision server",
-                    "version": "1.4.6"
+            "kind":"ImageStream",
+            "apiVersion":"v1",
+            "metadata":{
+                "name":"jboss-decisionserver64-openshift",
+                "annotations":{
+                    "openshift.io/display-name":"Red Hat JBoss BRMS 6.4 decision server",
+                    "openshift.io/provider-display-name":"Red Hat, Inc.",
+                    "version":"1.4.6"
                 }
             },
-            "labels": {
-                "xpaas": "1.4.6"
+            "labels":{
+                "xpaas":"1.4.6"
             },
-            "spec": {
-                "tags": [
+            "spec":{
+                "tags":[
                     {
-                        "name": "TP",
-                        "annotations": {
-                            "description": "Red Hat JBoss BRMS 6.4 decision server S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "builder,decisionserver,java,xpaas",
-                            "supports":"decisionserver:6.4,java:8,xpaas:1.4",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-                            "sampleContextDir": "decisionserver/hellorules",
-                            "sampleRef": "1.3",
-                            "version": "TP",
-                            "openshift.io/display-name": "Red Hat JBoss BRMS 6.4 decision server (Tech Preview)"
+                        "name":"TP",
+                        "annotations":{
+                            "description":"Red Hat JBoss BRMS 6.4 decision server S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"builder,decisionserver,java,hidden",
+                            "supports":"decisionserver:6.4,java:8:1.4",
+                            "sampleRepo":"https://github.com/jboss-openshift/openshift-quickstarts.git",
+                            "sampleContextDir":"decisionserver/hellorules",
+                            "sampleRef":"1.3",
+                            "version":"TP",
+                            "openshift.io/display-name":"Red Hat JBoss BRMS 6.4 decision server (Tech Preview)"
                         },
-                        "from": {
-                            "kind": "ImageStreamTag",
-                            "name": "1.1-TP"
+                        "from":{
+                            "kind":"ImageStreamTag",
+                            "name":"1.1-TP"
                         }
                     },
                     {
-                        "name": "1.0",
-                        "annotations": {
-                            "description": "Red Hat JBoss BRMS 6.4 decision server S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "builder,decisionserver,java,xpaas",
-                            "supports":"decisionserver:6.4,java:8,xpaas:1.4",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-                            "sampleContextDir": "decisionserver/hellorules",
-                            "sampleRef": "1.3",
-                            "version": "1.0",
-                            "openshift.io/display-name": "Red Hat JBoss BRMS 6.4 decision server"
+                        "name":"1.0",
+                        "annotations":{
+                            "description":"Red Hat JBoss BRMS 6.4 decision server S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"builder,decisionserver,java,hidden",
+                            "supports":"decisionserver:6.4,java:8:1.4",
+                            "sampleRepo":"https://github.com/jboss-openshift/openshift-quickstarts.git",
+                            "sampleContextDir":"decisionserver/hellorules",
+                            "sampleRef":"1.3",
+                            "version":"1.0",
+                            "openshift.io/display-name":"Red Hat JBoss BRMS 6.4 decision server"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-decisionserver-6/decisionserver64-openshift:1.0"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-decisionserver-6/decisionserver64-openshift:1.0"
                         }
                     },
                     {
-                        "name": "1.1-TP",
-                        "annotations": {
-                            "description": "Red Hat JBoss BRMS 6.4 decision server S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "builder,decisionserver,java,xpaas",
-                            "supports":"decisionserver:6.4,java:8,xpaas:1.4",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-                            "sampleContextDir": "decisionserver/hellorules",
-                            "sampleRef": "1.3",
-                            "version": "1.1",
-                            "openshift.io/display-name": "Red Hat JBoss BRMS 6.4 decision server (Tech Preview)"
+                        "name":"1.1-TP",
+                        "annotations":{
+                            "description":"Red Hat JBoss BRMS 6.4 decision server S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"builder,decisionserver,java,hidden",
+                            "supports":"decisionserver:6.4,java:8:1.4",
+                            "sampleRepo":"https://github.com/jboss-openshift/openshift-quickstarts.git",
+                            "sampleContextDir":"decisionserver/hellorules",
+                            "sampleRef":"1.3",
+                            "version":"1.1",
+                            "openshift.io/display-name":"Red Hat JBoss BRMS 6.4 decision server (Tech Preview)"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-decisionserver-6-tech-preview/decisionserver64-openshift:1.1"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-decisionserver-6-tech-preview/decisionserver64-openshift:1.1"
                         }
                     }
                 ]
             }
         },
         {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "jboss-processserver63-openshift",
-                "annotations": {
-                    "openshift.io/display-name": "Red Hat JBoss BPM Suite 6.3 intelligent process server",
-                    "version": "1.4.6"
+            "kind":"ImageStream",
+            "apiVersion":"v1",
+            "metadata":{
+                "name":"jboss-processserver63-openshift",
+                "annotations":{
+                    "openshift.io/display-name":"Red Hat JBoss BPM Suite 6.3 intelligent process server",
+                    "openshift.io/provider-display-name":"Red Hat, Inc.",
+                    "version":"1.4.6"
                 }
             },
-            "labels": {
-                "xpaas": "1.4.6"
+            "labels":{
+                "xpaas":"1.4.6"
             },
-            "spec": {
-                "tags": [
+            "spec":{
+                "tags":[
                     {
-                        "name": "1.3",
-                        "annotations": {
-                            "description": "Red Hat JBoss BPM Suite 6.3 intelligent process server S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "hidden,builder,processserver,xpaas",
-                            "supports": "processserver:6.3,xpaas:1.3",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-                            "sampleContextDir": "processserver/library",
-                            "sampleRef": "1.3",
-                            "version": "1.3",
-                            "openshift.io/display-name": "Red Hat JBoss BPM Suite 6.3 intelligent process server"
+                        "name":"1.3",
+                        "annotations":{
+                            "description":"Red Hat JBoss BPM Suite 6.3 intelligent process server S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"builder,processserver,hidden",
+                            "supports":"processserver:6.3:1.3",
+                            "sampleRepo":"https://github.com/jboss-openshift/openshift-quickstarts.git",
+                            "sampleContextDir":"processserver/library",
+                            "sampleRef":"1.3",
+                            "version":"1.3",
+                            "openshift.io/display-name":"Red Hat JBoss BPM Suite 6.3 intelligent process server"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-processserver-6/processserver63-openshift:1.3"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-processserver-6/processserver63-openshift:1.3"
                         }
                     },
                     {
-                        "name": "1.4",
-                        "annotations": {
-                            "description": "Red Hat JBoss BPM Suite 6.3 intelligent process server S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "hidden,builder,processserver,java,xpaas",
-                            "supports":"processserver:6.3,java:8,xpaas:1.4",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-                            "sampleContextDir": "processserver/library",
-                            "sampleRef": "1.3",
-                            "version": "1.4",
-                            "openshift.io/display-name": "Red Hat JBoss BPM Suite 6.3 intelligent process server"
+                        "name":"1.4",
+                        "annotations":{
+                            "description":"Red Hat JBoss BPM Suite 6.3 intelligent process server S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"builder,processserver,java,hidden",
+                            "supports":"processserver:6.3,java:8:1.4",
+                            "sampleRepo":"https://github.com/jboss-openshift/openshift-quickstarts.git",
+                            "sampleContextDir":"processserver/library",
+                            "sampleRef":"1.3",
+                            "version":"1.4",
+                            "openshift.io/display-name":"Red Hat JBoss BPM Suite 6.3 intelligent process server"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-processserver-6/processserver63-openshift:1.4"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-processserver-6/processserver63-openshift:1.4"
                         }
                     }
                 ]
             }
         },
         {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "jboss-processserver64-openshift",
-                "annotations": {
-                    "openshift.io/display-name": "Red Hat JBoss BPM Suite 6.4 intelligent process server",
-                    "version": "1.4.6"
+            "kind":"ImageStream",
+            "apiVersion":"v1",
+            "metadata":{
+                "name":"jboss-processserver64-openshift",
+                "annotations":{
+                    "openshift.io/display-name":"Red Hat JBoss BPM Suite 6.3 intelligent process server",
+                    "openshift.io/provider-display-name":"Red Hat, Inc.",
+                    "version":"1.4.6"
                 }
             },
-            "labels": {
-                "xpaas": "1.4.6"
+            "labels":{
+                "xpaas":"1.4.6"
             },
-            "spec": {
-                "tags": [
+            "spec":{
+                "tags":[
                     {
-                        "name": "TP",
-                        "annotations": {
-                            "description": "Red Hat JBoss BPM Suite 6.4 intelligent process server S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "builder,processserver,java,xpaas",
-                            "supports":"processserver:6.4,java:8,xpaas:1.4",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-                            "sampleContextDir": "processserver/library",
-                            "sampleRef": "1.3",
-                            "version": "TP",
-                            "openshift.io/display-name": "Red Hat JBoss BPM Suite 6.4 intelligent process server (Tech Preview)"
+                        "name":"TP",
+                        "annotations":{
+                            "description":"Red Hat JBoss BPM Suite 6.4 intelligent process server S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"builder,processserver,java,hidden",
+                            "supports":"processserver:6.4,java:8:1.4",
+                            "sampleRepo":"https://github.com/jboss-openshift/openshift-quickstarts.git",
+                            "sampleContextDir":"processserver/library",
+                            "sampleRef":"1.3",
+                            "version":"TP",
+                            "openshift.io/display-name":"Red Hat JBoss BPM Suite 6.4 intelligent process server (Tech Preview)"
                         },
-                        "from": {
-                            "kind": "ImageStreamTag",
-                            "name": "1.1-TP"
+                        "from":{
+                            "kind":"ImageStreamTag",
+                            "name":"1.1-TP"
                         }
                     },
                     {
-                        "name": "1.0",
-                        "annotations": {
-                            "description": "Red Hat JBoss BPM Suite 6.4 intelligent process server S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "builder,processserver,java,xpaas",
-                            "supports":"processserver:6.4,java:8,xpaas:1.4",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-                            "sampleContextDir": "processserver/library",
-                            "sampleRef": "1.3",
-                            "version": "1.0",
-                            "openshift.io/display-name": "Red Hat JBoss BPM Suite 6.4 intelligent process server"
+                        "name":"1.0",
+                        "annotations":{
+                            "description":"Red Hat JBoss BPM Suite 6.4 intelligent process server S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"builder,processserver,java,hidden",
+                            "supports":"processserver:6.4,java:8:1.4",
+                            "sampleRepo":"https://github.com/jboss-openshift/openshift-quickstarts.git",
+                            "sampleContextDir":"processserver/library",
+                            "sampleRef":"1.3",
+                            "version":"1.0",
+                            "openshift.io/display-name":"Red Hat JBoss BPM Suite 6.4 intelligent process server"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-processserver-6/processserver64-openshift:1.0"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-processserver-6/processserver64-openshift:1.0"
                         }
                     },
                     {
-                        "name": "1.1-TP",
-                        "annotations": {
-                            "description": "Red Hat JBoss BPM Suite 6.4 intelligent process server S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "builder,processserver,java,xpaas",
-                            "supports":"processserver:6.4,java:8,xpaas:1.4",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-                            "sampleContextDir": "processserver/library",
-                            "sampleRef": "1.3",
-                            "version": "1.1",
-                            "openshift.io/display-name": "Red Hat JBoss BPM Suite 6.4 intelligent process server (Tech Preview)"
+                        "name":"1.1-TP",
+                        "annotations":{
+                            "description":"Red Hat JBoss BPM Suite 6.4 intelligent process server S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"builder,processserver,java,hidden",
+                            "supports":"processserver:6.4,java:8:1.4",
+                            "sampleRepo":"https://github.com/jboss-openshift/openshift-quickstarts.git",
+                            "sampleContextDir":"processserver/library",
+                            "sampleRef":"1.3",
+                            "version":"1.1",
+                            "openshift.io/display-name":"Red Hat JBoss BPM Suite 6.4 intelligent process server (Tech Preview)"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-processserver-6-tech-preview/processserver64-openshift:1.1"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-processserver-6-tech-preview/processserver64-openshift:1.1"
                         }
                     }
                 ]
             }
         },
         {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "jboss-datagrid65-openshift",
-                "annotations": {
-                    "openshift.io/display-name": "Red Hat JBoss Data Grid 6.5",
-                    "version": "1.4.6"
+            "kind":"ImageStream",
+            "apiVersion":"v1",
+            "metadata":{
+                "name":"jboss-datagrid65-openshift",
+                "annotations":{
+                    "openshift.io/display-name":"Red Hat JBoss Data Grid 6.5",
+                    "openshift.io/provider-display-name":"Red Hat, Inc.",
+                    "version":"1.4.6"
                 }
             },
-            "labels": {
-                "xpaas": "1.4.6"
+            "labels":{
+                "xpaas":"1.4.6"
             },
-            "spec": {
-                "tags": [
+            "spec":{
+                "tags":[
                     {
-                        "name": "TP",
-                        "annotations": {
-                            "description": "JBoss Data Grid 6.5 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "datagrid,jboss,xpaas",
-                            "supports": "datagrid:6.5,xpaas:1.2",
-                            "version": "TP",
-                            "openshift.io/display-name": "Red Hat JBoss Data Grid 6.5 (Tech Preview)"
+                        "name":"TP",
+                        "annotations":{
+                            "description":"JBoss Data Grid 6.5 S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"datagrid,jboss,hidden",
+                            "supports":"datagrid:6.5:1.2",
+                            "version":"TP",
+                            "openshift.io/display-name":"Red Hat JBoss Data Grid 6.5 (Tech Preview)"
                         },
-                        "from": {
-                            "kind": "ImageStreamTag",
-                            "name": "1.5-TP"
+                        "from":{
+                            "kind":"ImageStreamTag",
+                            "name":"1.5-TP"
                         }
                     },
                     {
-                        "name": "1.2",
-                        "annotations": {
-                            "description": "JBoss Data Grid 6.5 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "datagrid,jboss,xpaas",
-                            "supports": "datagrid:6.5,xpaas:1.2",
-                            "version": "1.2",
-                            "openshift.io/display-name": "Red Hat JBoss Data Grid 6.5"
+                        "name":"1.2",
+                        "annotations":{
+                            "description":"JBoss Data Grid 6.5 S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"datagrid,jboss,hidden",
+                            "supports":"datagrid:6.5:1.2",
+                            "version":"1.2",
+                            "openshift.io/display-name":"Red Hat JBoss Data Grid 6.5"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-datagrid-6/datagrid65-openshift:1.2"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-datagrid-6/datagrid65-openshift:1.2"
                         }
                     },
                     {
-                        "name": "1.3",
-                        "annotations": {
-                            "description": "JBoss Data Grid 6.5 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "datagrid,jboss,xpaas",
-                            "supports": "datagrid:6.5,xpaas:1.4",
-                            "version": "1.3",
-                            "openshift.io/display-name": "Red Hat JBoss Data Grid 6.5"
+                        "name":"1.3",
+                        "annotations":{
+                            "description":"JBoss Data Grid 6.5 S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"datagrid,jboss,hidden",
+                            "supports":"datagrid:6.5:1.4",
+                            "version":"1.3",
+                            "openshift.io/display-name":"Red Hat JBoss Data Grid 6.5"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-datagrid-6/datagrid65-openshift:1.3"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-datagrid-6/datagrid65-openshift:1.3"
                         }
                     },
                     {
-                        "name": "1.4",
-                        "annotations": {
-                            "description": "JBoss Data Grid 6.5 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "datagrid,jboss,xpaas",
-                            "supports":"datagrid:6.5,xpaas:1.4",
-                            "version": "1.4",
-                            "openshift.io/display-name": "Red Hat JBoss Data Grid 6.5"
+                        "name":"1.4",
+                        "annotations":{
+                            "description":"JBoss Data Grid 6.5 S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"datagrid,jboss,hidden",
+                            "supports":"datagrid:6.5:1.4",
+                            "version":"1.4"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-datagrid-6/datagrid65-openshift:1.4"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-datagrid-6/datagrid65-openshift:1.4"
                         }
                     },
                     {
-                        "name": "1.5-TP",
-                        "annotations": {
-                            "description": "JBoss Data Grid 6.5 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "datagrid,jboss,xpaas",
-                            "supports":"datagrid:6.5,xpaas:1.4",
-                            "version": "1.5",
-                            "openshift.io/display-name": "Red Hat JBoss Data Grid 6.5 (Tech Preview)"
+                        "name":"1.5-TP",
+                        "annotations":{
+                            "description":"JBoss Data Grid 6.5 S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"datagrid,jboss,hidden",
+                            "supports":"datagrid:6.5:1.4",
+                            "version":"1.5",
+                            "openshift.io/display-name":"Red Hat JBoss Data Grid 6.5 (Tech Preview)"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-datagrid-6-tech-preview/datagrid65-openshift:1.5"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-datagrid-6-tech-preview/datagrid65-openshift:1.5"
                         }
                     }
                 ]
             }
         },
         {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "jboss-datagrid71-openshift",
-                "annotations": {
-                    "openshift.io/display-name": "Red Hat JBoss Data Grid 7.1",
-                    "version": "1.4.6"
+            "kind":"ImageStream",
+            "apiVersion":"v1",
+            "metadata":{
+                "name":"jboss-datagrid71-openshift",
+                "annotations":{
+                    "openshift.io/display-name":"Red Hat JBoss Data Grid 7.1",
+                    "openshift.io/provider-display-name":"Red Hat, Inc.",
+                    "version":"1.4.6"
                 }
             },
-            "labels": {
-                "xpaas": "1.4.6"
+            "labels":{
+                "xpaas":"1.4.6"
             },
-            "spec": {
-                "tags": [
+            "spec":{
+                "tags":[
                     {
-                        "name": "TP",
-                        "annotations": {
-                            "description": "JBoss Data Grid 7.1 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "datagrid,jboss,xpaas",
-                            "supports": "datagrid:7.1,xpaas:1.0",
-                            "version": "TP",
-                            "openshift.io/display-name": "Red Hat JBoss Data Grid 7.1 (Tech Preview)"
+                        "name":"TP",
+                        "annotations":{
+                            "description":"JBoss Data Grid 7.1 S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"datagrid,jboss,hidden",
+                            "supports":"datagrid:7.1:1.0",
+                            "version":"TP",
+                            "openshift.io/display-name":"Red Hat JBoss Data Grid 7.1 (Tech Preview)"
                         },
-                        "from": {
-                            "kind": "ImageStreamTag",
-                            "name": "1.1-TP"
+                        "from":{
+                            "kind":"ImageStreamTag",
+                            "name":"1.1-TP"
                         }
                     },
                     {
-                        "name": "1.0",
-                        "annotations": {
-                            "description": "JBoss Data Grid 7.1 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "datagrid,jboss,xpaas",
-                            "supports": "datagrid:7.1,xpaas:1.0",
-                            "version": "1.0",
-                            "openshift.io/display-name": "Red Hat JBoss Data Grid 7.1"
+                        "name":"1.0",
+                        "annotations":{
+                            "description":"JBoss Data Grid 7.1 S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"datagrid,jboss,hidden",
+                            "supports":"datagrid:7.1:1.0",
+                            "version":"1.0",
+                            "openshift.io/display-name":"Red Hat JBoss Data Grid 7.1"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-datagrid-7/datagrid71-openshift:1.0"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-datagrid-7/datagrid71-openshift:1.0"
                         }
                     },
                     {
-                        "name": "1.1-TP",
-                        "annotations": {
-                            "description": "JBoss Data Grid 7.1 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "datagrid,jboss,xpaas",
-                            "supports": "datagrid:7.1,xpaas:1.0",
-                            "version": "1.1",
-                            "openshift.io/display-name": "Red Hat JBoss Data Grid 7.1 (Tech Preview)"
+                        "name":"1.1-TP",
+                        "annotations":{
+                            "description":"JBoss Data Grid 7.1 S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"datagrid,jboss,hidden",
+                            "supports":"datagrid:7.1:1.0",
+                            "version":"1.1",
+                            "openshift.io/display-name":"Red Hat JBoss Data Grid 7.1 (Tech Preview)"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-datagrid-7-tech-preview/datagrid71-openshift:1.1"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-datagrid-7-tech-preview/datagrid71-openshift:1.1"
                         }
                     }
                 ]
             }
         },
         {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "jboss-datagrid65-client-openshift",
-                "annotations": {
-                    "openshift.io/display-name": "Red Hat JBoss Data Grid 6.5 Client Modules for EAP",
-                    "version": "1.4.6"
+            "kind":"ImageStream",
+            "apiVersion":"v1",
+            "metadata":{
+                "name":"jboss-datagrid65-client-openshift",
+                "annotations":{
+                    "openshift.io/display-name":"Red Hat JBoss Data Grid 6.5 Client Modules for EAP",
+                    "openshift.io/provider-display-name":"Red Hat, Inc.",
+                    "version":"1.4.6"
                 }
             },
-            "labels": {
-                "xpaas": "1.4.6"
+            "labels":{
+                "xpaas":"1.4.6"
             },
-            "spec": {
-                "tags": [
+            "spec":{
+                "tags":[
                     {
-                        "name": "1.0",
-                        "annotations": {
-                            "description": "JBoss Data Grid 6.5 Client Modules for EAP.",
-                            "iconClass": "icon-jboss",
-                            "tags": "client,jboss,xpaas",
-                            "version": "1.0",
-                            "openshift.io/display-name": "Red Hat JBoss Data Grid 6.5 Client Modules for EAP"
+                        "name":"1.0",
+                        "annotations":{
+                            "description":"JBoss Data Grid 6.5 Client Modules for EAP.",
+                            "iconClass":"icon-jboss",
+                            "tags":"client,jboss,hidden",
+                            "version":"1.0",
+                            "openshift.io/display-name":"Red Hat JBoss Data Grid 6.5 Client Modules for EAP"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-datagrid-6/datagrid65-client-openshift:1.0"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-datagrid-6/datagrid65-client-openshift:1.0"
                         }
                     },
                     {
-                        "name": "1.1",
-                        "annotations": {
-                            "description": "JBoss Data Grid 6.5 Client Modules for EAP.",
-                            "iconClass": "icon-jboss",
-                            "tags": "client,jboss,xpaas",
-                            "version": "1.1",
-                            "openshift.io/display-name": "Red Hat JBoss Data Grid 6.5 Client Modules for EAP"
+                        "name":"1.1",
+                        "annotations":{
+                            "description":"JBoss Data Grid 6.5 Client Modules for EAP.",
+                            "iconClass":"icon-jboss",
+                            "tags":"client,jboss,hidden",
+                            "version":"1.1",
+                            "openshift.io/display-name":"Red Hat JBoss Data Grid 6.5 Client Modules for EAP"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-datagrid-6/datagrid65-client-openshift:1.1"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-datagrid-6/datagrid65-client-openshift:1.1"
                         }
                     }
                 ]
             }
         },
         {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "jboss-datagrid71-client-openshift",
-                "annotations": {
-                    "openshift.io/display-name": "Red Hat JBoss Data Grid 7.1 Client Modules for EAP",
-                    "version": "1.4.6"
+            "kind":"ImageStream",
+            "apiVersion":"v1",
+            "metadata":{
+                "name":"jboss-datagrid71-client-openshift",
+                "annotations":{
+                    "openshift.io/display-name":"Red Hat JBoss Data Grid 7.1 Client Modules for EAP",
+                    "openshift.io/provider-display-name":"Red Hat, Inc.",
+                    "version":"1.4.6"
                 }
             },
-            "labels": {
-                "xpaas": "1.4.6"
+            "labels":{
+                "xpaas":"1.4.6"
             },
-            "spec": {
-                "tags": [
+            "spec":{
+                "tags":[
                     {
-                        "name": "1.0",
-                        "annotations": {
-                            "description": "JBoss Data Grid 7.1 Client Modules for EAP.",
-                            "iconClass": "icon-jboss",
-                            "tags": "client,jboss,xpaas",
-                            "version": "1.0",
-                            "openshift.io/display-name": "Red Hat JBoss Data Grid 7.1 Client Modules for EAP"
+                        "name":"1.0",
+                        "annotations":{
+                            "description":"JBoss Data Grid 7.1 Client Modules for EAP.",
+                            "iconClass":"icon-jboss",
+                            "tags":"client,jboss,hidden",
+                            "version":"1.0",
+                            "openshift.io/display-name":"Red Hat JBoss Data Grid 7.1 Client Modules for EAP"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-datagrid-7/datagrid71-client-openshift:1.0"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-datagrid-7/datagrid71-client-openshift:1.0"
                         }
                     }
                 ]
             }
         },
         {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "jboss-datavirt63-openshift",
-                "annotations": {
-                    "openshift.io/display-name": "Red Hat JBoss Data Virtualization 6.3",
-                    "version": "1.4.6"
+            "kind":"ImageStream",
+            "apiVersion":"v1",
+            "metadata":{
+                "name":"jboss-datavirt63-openshift",
+                "annotations":{
+                    "openshift.io/display-name":"Red Hat JBoss Data Virtualization 6.3",
+                    "openshift.io/provider-display-name":"Red Hat, Inc.",
+                    "version":"1.4.6"
                 }
             },
-            "labels": {
-                "xpaas": "1.4.6"
+            "labels":{
+                "xpaas":"1.4.6"
             },
-            "spec": {
-                "tags": [
+            "spec":{
+                "tags":[
                     {
-                        "name": "TP",
-                        "annotations": {
-                            "description": "Red Hat JBoss Data Virtualization 6.3 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "datavirt,jboss,xpaas",
-                            "supports": "datavirt:6.3,xpaas:1.4",
-                            "version": "TP",
-                            "openshift.io/display-name": "Red Hat JBoss Data Virtualization 6.3 (Tech Preview)"
+                        "name":"TP",
+                        "annotations":{
+                            "description":"Red Hat JBoss Data Virtualization 6.3 S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"datavirt,jboss,hidden",
+                            "supports":"datavirt:6.3:1.4",
+                            "version":"TP",
+                            "openshift.io/display-name":"Red Hat JBoss Data Virtualization 6.3 (Tech Preview)"
                         },
-                        "from": {
-                            "kind": "ImageStreamTag",
-                            "name": "1.3-TP"
+                        "from":{
+                            "kind":"ImageStreamTag",
+                            "name":"1.3-TP"
                         }
                     },
                     {
-                        "name": "1.0",
-                        "annotations": {
-                            "description": "Red Hat JBoss Data Virtualization 6.3 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "datavirt,jboss,xpaas",
-                            "supports": "datavirt:6.3,xpaas:1.4",
-                            "version": "1.0",
-                            "openshift.io/display-name": "Red Hat JBoss Data Virtualization 6.3"
+                        "name":"1.0",
+                        "annotations":{
+                            "description":"Red Hat JBoss Data Virtualization 6.3 S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"datavirt,jboss,hidden",
+                            "supports":"datavirt:6.3:1.4",
+                            "version":"1.0",
+                            "openshift.io/display-name":"Red Hat JBoss Data Virtualization 6.3"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-datavirt-6/datavirt63-openshift:1.0"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-datavirt-6/datavirt63-openshift:1.0"
                         }
                     },
                     {
-                        "name": "1.1",
-                        "annotations": {
-                            "description": "Red Hat JBoss Data Virtualization 6.3 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "datavirt,jboss,xpaas",
-                            "supports": "datavirt:6.3,xpaas:1.4",
-                            "version": "1.1",
-                            "openshift.io/display-name": "Red Hat JBoss Data Virtualization 6.3"
+                        "name":"1.1",
+                        "annotations":{
+                            "description":"Red Hat JBoss Data Virtualization 6.3 S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"datavirt,jboss,hidden",
+                            "supports":"datavirt:6.3:1.4",
+                            "version":"1.1",
+                            "openshift.io/display-name":"Red Hat JBoss Data Virtualization 6.3"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-datavirt-6/datavirt63-openshift:1.1"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-datavirt-6/datavirt63-openshift:1.1"
                         }
                     },
                     {
-                        "name": "1.2",
-                        "annotations": {
-                            "description": "Red Hat JBoss Data Virtualization 6.3 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "datavirt,jboss,xpaas",
-                            "supports":"datavirt:6.3,xpaas:1.4",
-                            "version": "1.2",
-                            "openshift.io/display-name": "Red Hat JBoss Data Virtualization 6.3"
+                        "name":"1.2",
+                        "annotations":{
+                            "description":"Red Hat JBoss Data Virtualization 6.3 S2I images.",
+                            "iconClass":"icon-jboss",
+                            "tags":"datavirt,jboss,hidden",
+                            "supports":"datavirt:6.3:1.4",
+                            "version":"1.2"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-datavirt-6/datavirt63-openshift:1.2"
-                        }
-                    },
-                    {
-                        "name": "1.3-TP",
-                        "annotations": {
-                            "description": "Red Hat JBoss Data Virtualization 6.3 S2I images.",
-                            "iconClass": "icon-jboss",
-                            "tags": "datavirt,jboss,xpaas",
-                            "supports":"datavirt:6.3,xpaas:1.4",
-                            "version": "1.3",
-                            "openshift.io/display-name": "Red Hat JBoss Data Virtualization 6.3 (Tech Preview)"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-datavirt-6-tech-preview/datavirt63-openshift:1.3"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-datavirt-6/datavirt63-openshift:1.2"
                         }
                     }
                 ]
             }
         },
         {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "jboss-datavirt63-driver-openshift",
-                "annotations": {
-                    "openshift.io/display-name": "Red Hat JBoss Data Virtualization 6.5 JDBC Driver Modules for EAP",
-                    "version": "1.4.6"
+            "kind":"ImageStream",
+            "apiVersion":"v1",
+            "metadata":{
+                "name":"jboss-datavirt63-driver-openshift",
+                "annotations":{
+                    "openshift.io/display-name":"Red Hat JBoss Data Virtualization 6.5 JDBC Driver Modules for EAP",
+                    "openshift.io/provider-display-name":"Red Hat, Inc.",
+                    "version":"1.4.6"
                 }
             },
-            "labels": {
-                "xpaas": "1.4.6"
+            "labels":{
+                "xpaas":"1.4.6"
             },
-            "spec": {
-                "tags": [
+            "spec":{
+                "tags":[
                     {
-                        "name": "1.0",
-                        "annotations": {
-                            "description": "JBoss Data Virtualization 6.5 JDBC Driver Modules for EAP.",
-                            "iconClass": "icon-jboss",
-                            "tags": "client,jboss,xpaas",
-                            "version": "1.0",
-                            "openshift.io/display-name": "Red Hat JBoss Data Virtualization 6.5 JDBC Driver Modules for EAP"
+                        "name":"1.0",
+                        "annotations":{
+                            "description":"JBoss Data Virtualization 6.5 JDBC Driver Modules for EAP.",
+                            "iconClass":"icon-jboss",
+                            "tags":"client,jboss,hidden",
+                            "version":"1.0",
+                            "openshift.io/display-name":"Red Hat JBoss Data Virtualization 6.5 JDBC Driver Modules for EAP"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-datavirt-6/datavirt63-driver-openshift:1.0"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-datavirt-6/datavirt63-driver-openshift:1.0"
                         }
                     },
                     {
-                        "name": "1.1",
-                        "annotations": {
-                            "description": "JBoss Data Virtualization 6.5 JDBC Driver Modules for EAP.",
-                            "iconClass": "icon-jboss",
-                            "tags": "client,jboss,xpaas",
-                            "version": "1.1",
-                            "openshift.io/display-name": "Red Hat JBoss Data Virtualization 6.5 JDBC Driver Modules for EAP"
+                        "name":"1.1",
+                        "annotations":{
+                            "description":"JBoss Data Virtualization 6.5 JDBC Driver Modules for EAP.",
+                            "iconClass":"icon-jboss",
+                            "tags":"client,jboss,hidden",
+                            "version":"1.1",
+                            "openshift.io/display-name":"Red Hat JBoss Data Virtualization 6.5 JDBC Driver Modules for EAP"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-datavirt-6/datavirt63-driver-openshift:1.1"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-datavirt-6/datavirt63-driver-openshift:1.1"
                         }
                     }
                 ]
             }
         },
         {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "jboss-amq-62",
-                "annotations": {
-                    "openshift.io/display-name": "Red Hat JBoss A-MQ 6.2",
-                    "version": "1.4.6"
+            "kind":"ImageStream",
+            "apiVersion":"v1",
+            "metadata":{
+                "name":"jboss-amq-62",
+                "annotations":{
+                    "openshift.io/display-name":"Red Hat JBoss A-MQ 6.2",
+                    "openshift.io/provider-display-name":"Red Hat, Inc.",
+                    "version":"1.4.6"
                 }
             },
-            "labels": {
-                "xpaas": "1.4.6"
+            "labels":{
+                "xpaas":"1.4.6"
             },
-            "spec": {
-                "tags": [
+            "spec":{
+                "tags":[
                     {
-                        "name": "TP",
-                        "annotations": {
-                            "description": "JBoss A-MQ 6.2 broker image.",
-                            "iconClass": "icon-jboss",
-                            "tags": "messaging,amq,jboss,xpaas",
-                            "supports": "amq:6.2,messaging,xpaas:1.1",
-                            "version": "TP",
-                            "openshift.io/display-name": "Red Hat JBoss A-MQ 6.2 (Tech Preview)"
+                        "name":"TP",
+                        "annotations":{
+                            "description":"JBoss A-MQ 6.2 broker image.",
+                            "iconClass":"icon-jboss",
+                            "tags":"messaging,amq,jboss,hidden",
+                            "supports":"amq:6.2,messaging:1.1",
+                            "version":"TP",
+                            "openshift.io/display-name":"Red Hat JBoss A-MQ 6.2 (Tech Preview)"
                         },
-                        "from": {
-                            "kind": "ImageStreamTag",
-                            "name": "1.6-TP"
+                        "from":{
+                            "kind":"ImageStreamTag",
+                            "name":"1.6-TP"
                         }
                     },
                     {
-                        "name": "1.1",
-                        "annotations": {
-                            "description": "JBoss A-MQ 6.2 broker image.",
-                            "iconClass": "icon-jboss",
-                            "tags": "messaging,amq,jboss,xpaas",
-                            "supports": "amq:6.2,messaging,xpaas:1.1",
-                            "version": "1.1",
-                            "openshift.io/display-name": "Red Hat JBoss A-MQ 6.2"
+                        "name":"1.1",
+                        "annotations":{
+                            "description":"JBoss A-MQ 6.2 broker image.",
+                            "iconClass":"icon-jboss",
+                            "tags":"messaging,amq,jboss,hidden",
+                            "supports":"amq:6.2,messaging:1.1",
+                            "version":"1.1",
+                            "openshift.io/display-name":"Red Hat JBoss A-MQ 6.2"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-amq-6/amq62-openshift:1.1"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-amq-6/amq62-openshift:1.1"
                         }
                     },
                     {
-                        "name": "1.2",
-                        "annotations": {
-                            "description": "JBoss A-MQ 6.2 broker image.",
-                            "iconClass": "icon-jboss",
-                            "tags": "messaging,amq,jboss,xpaas",
-                            "supports": "amq:6.2,messaging,xpaas:1.2",
-                            "version": "1.2",
-                            "openshift.io/display-name": "Red Hat JBoss A-MQ 6.2"
+                        "name":"1.2",
+                        "annotations":{
+                            "description":"JBoss A-MQ 6.2 broker image.",
+                            "iconClass":"icon-jboss",
+                            "tags":"messaging,amq,jboss,hidden",
+                            "supports":"amq:6.2,messaging:1.2",
+                            "version":"1.2",
+                            "openshift.io/display-name":"Red Hat JBoss A-MQ 6.2"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-amq-6/amq62-openshift:1.2"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-amq-6/amq62-openshift:1.2"
                         }
                     },
                     {
-                        "name": "1.3",
-                        "annotations": {
-                            "description": "JBoss A-MQ 6.2 broker image.",
-                            "iconClass": "icon-jboss",
-                            "tags": "messaging,amq,jboss,xpaas",
-                            "supports": "amq:6.2,messaging,xpaas:1.3",
-                            "version": "1.3",
-                            "openshift.io/display-name": "Red Hat JBoss A-MQ 6.2"
+                        "name":"1.3",
+                        "annotations":{
+                            "description":"JBoss A-MQ 6.2 broker image.",
+                            "iconClass":"icon-jboss",
+                            "tags":"messaging,amq,jboss,hidden",
+                            "supports":"amq:6.2,messaging:1.3",
+                            "version":"1.3",
+                            "openshift.io/display-name":"Red Hat JBoss A-MQ 6.2"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-amq-6/amq62-openshift:1.3"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-amq-6/amq62-openshift:1.3"
                         }
                     },
                     {
-                        "name": "1.4",
-                        "annotations": {
-                            "description": "JBoss A-MQ 6.2 broker image.",
-                            "iconClass": "icon-jboss",
-                            "tags": "messaging,amq,jboss,xpaas",
-                            "supports":"amq:6.2,messaging,xpaas:1.4",
-                            "version": "1.4",
-                            "openshift.io/display-name": "Red Hat JBoss A-MQ 6.2"
+                        "name":"1.4",
+                        "annotations":{
+                            "description":"JBoss A-MQ 6.2 broker image.",
+                            "iconClass":"icon-jboss",
+                            "tags":"messaging,amq,jboss,hidden",
+                            "supports":"amq:6.2,messaging:1.4",
+                            "version":"1.4"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-amq-6/amq62-openshift:1.4"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-amq-6/amq62-openshift:1.4"
                         }
                     },
                     {
-                        "name": "1.5",
-                        "annotations": {
-                            "description": "JBoss A-MQ 6.2 broker image.",
-                            "iconClass": "icon-jboss",
-                            "tags": "messaging,amq,jboss,xpaas",
-                            "supports":"amq:6.2,messaging,xpaas:1.5",
-                            "version": "1.5",
-                            "openshift.io/display-name": "Red Hat JBoss A-MQ 6.2"
+                        "name":"1.5",
+                        "annotations":{
+                            "description":"JBoss A-MQ 6.2 broker image.",
+                            "iconClass":"icon-jboss",
+                            "tags":"messaging,amq,jboss,hidden",
+                            "supports":"amq:6.2,messaging:1.5",
+                            "version":"1.5"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-amq-6/amq62-openshift:1.5"
-                        }
-                    },
-                    {
-                        "name": "1.6-TP",
-                        "annotations": {
-                            "description": "JBoss A-MQ 6.2 broker image.",
-                            "iconClass": "icon-jboss",
-                            "tags": "messaging,amq,jboss,xpaas",
-                            "supports":"amq:6.2,messaging,xpaas:1.5",
-                            "version": "1.6",
-                            "openshift.io/display-name": "Red Hat JBoss A-MQ 6.2 (Tech Preview)"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-amq-6-tech-preview/amq62-openshift:1.6"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-amq-6/amq62-openshift:1.5"
                         }
                     }
                 ]
             }
         },
         {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "jboss-amq-63",
-                "annotations": {
-                    "openshift.io/display-name": "Red Hat JBoss A-MQ 6.3",
-                    "version": "1.4.6"
+            "kind":"ImageStream",
+            "apiVersion":"v1",
+            "metadata":{
+                "name":"jboss-amq-63",
+                "annotations":{
+                    "openshift.io/display-name":"Red Hat JBoss A-MQ 6.3",
+                    "openshift.io/provider-display-name":"Red Hat, Inc.",
+                    "version":"1.4.6"
                 }
             },
-            "labels": {
-                "xpaas": "1.4.6"
+            "labels":{
+                "xpaas":"1.4.6"
             },
-            "spec": {
-                "tags": [
+            "spec":{
+                "tags":[
                     {
-                        "name": "TP",
-                        "annotations": {
-                            "description": "JBoss A-MQ 6.3 broker image.",
-                            "iconClass": "icon-jboss",
-                            "tags": "messaging,amq,jboss,xpaas",
-                            "supports": "amq:6.3,messaging,xpaas:1.0",
-                            "version": "TP",
-                            "openshift.io/display-name": "Red Hat JBoss A-MQ 6.3 (Tech Preview)"
+                        "name":"TP",
+                        "annotations":{
+                            "description":"JBoss A-MQ 6.3 broker image.",
+                            "iconClass":"icon-jboss",
+                            "tags":"messaging,amq,jboss,hidden",
+                            "supports":"amq:6.3,messaging:1.0",
+                            "version":"TP",
+                            "openshift.io/display-name":"Red Hat JBoss A-MQ 6.3 (Tech Preview)"
                         },
-                        "from": {
-                            "kind": "ImageStreamTag",
-                            "name": "1.2-TP"
+                        "from":{
+                            "kind":"ImageStreamTag",
+                            "name":"1.2-TP"
                         }
                     },
                     {
-                        "name": "1.0",
-                        "annotations": {
-                            "description": "JBoss A-MQ 6.3 broker image.",
-                            "iconClass": "icon-jboss",
-                            "tags": "messaging,amq,jboss,xpaas",
-                            "supports": "amq:6.3,messaging,xpaas:1.0",
-                            "version": "1.0",
-                            "openshift.io/display-name": "Red Hat JBoss A-MQ 6.3"
+                        "name":"1.0",
+                        "annotations":{
+                            "description":"JBoss A-MQ 6.3 broker image.",
+                            "iconClass":"icon-jboss",
+                            "tags":"messaging,amq,jboss,hidden",
+                            "supports":"amq:6.3,messaging:1.0",
+                            "version":"1.0",
+                            "openshift.io/display-name":"Red Hat JBoss A-MQ 6.3"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-amq-6/amq63-openshift:1.0"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-amq-6/amq63-openshift:1.0"
                         }
                     },
                     {
-                        "name": "1.1",
-                        "annotations": {
-                            "description": "JBoss A-MQ 6.3 broker image.",
-                            "iconClass": "icon-jboss",
-                            "tags": "messaging,amq,jboss,xpaas",
-                            "supports": "amq:6.3,messaging,xpaas:1.1",
-                            "version": "1.1",
-                            "openshift.io/display-name": "Red Hat JBoss A-MQ 6.3"
+                        "name":"1.1",
+                        "annotations":{
+                            "description":"JBoss A-MQ 6.3 broker image.",
+                            "iconClass":"icon-jboss",
+                            "tags":"messaging,amq,jboss,hidden",
+                            "supports":"amq:6.3,messaging:1.1",
+                            "version":"1.1",
+                            "openshift.io/display-name":"Red Hat JBoss A-MQ 6.3"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-amq-6/amq63-openshift:1.1"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-amq-6/amq63-openshift:1.1"
                         }
                     },
                     {
-                        "name": "1.2-TP",
-                        "annotations": {
-                            "description": "JBoss A-MQ 6.3 broker image.",
-                            "iconClass": "icon-jboss",
-                            "tags": "messaging,amq,jboss,xpaas",
-                            "supports": "amq:6.3,messaging,xpaas:1.1",
-                            "version": "1.2",
-                            "openshift.io/display-name": "Red Hat JBoss A-MQ 6.3 (Tech Preview)"
+                        "name":"1.2-TP",
+                        "annotations":{
+                            "description":"JBoss A-MQ 6.3 broker image.",
+                            "iconClass":"icon-jboss",
+                            "tags":"messaging,amq,jboss,hidden",
+                            "supports":"amq:6.3,messaging:1.1",
+                            "version":"1.2",
+                            "openshift.io/display-name":"Red Hat JBoss A-MQ 6.3 (Tech Preview)"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-amq-6-tech-preview/amq63-openshift:1.2"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/jboss-amq-6-tech-preview/amq63-openshift:1.2"
                         }
                     }
                 ]
             }
         },
         {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "redhat-sso70-openshift",
-                "annotations": {
-                    "description": "Red Hat SSO 7.0",
-                    "openshift.io/display-name": "Red Hat Single Sign-On 7.0",
-                    "version": "1.4.6"
+            "kind":"ImageStream",
+            "apiVersion":"v1",
+            "metadata":{
+                "name":"redhat-sso70-openshift",
+                "annotations":{
+                    "description":"Red Hat SSO 7.0",
+                    "openshift.io/display-name":"Red Hat Single Sign-On 7.0",
+                    "openshift.io/provider-display-name":"Red Hat, Inc.",
+                    "version":"1.4.6"
                 }
             },
-            "labels": {
-                "xpaas": "1.4.6"
+            "labels":{
+                "xpaas":"1.4.6"
             },
-            "spec": {
-                "tags": [
+            "spec":{
+                "tags":[
                     {
-                        "name": "1.3",
-                        "annotations": {
-                            "description": "Red Hat SSO 7.0",
-                            "iconClass": "icon-jboss",
-                            "tags": "hidden,sso,keycloak,redhat",
-                            "supports": "sso:7.0,xpaas:1.3",
-                            "version": "1.3",
-                            "openshift.io/display-name": "Red Hat Single Sign-On 7.0"
+                        "name":"1.3",
+                        "annotations":{
+                            "description":"Red Hat SSO 7.0",
+                            "iconClass":"icon-jboss",
+                            "tags":"sso,keycloak,redhat,hidden",
+                            "supports":"sso:7.0:1.3",
+                            "version":"1.3",
+                            "openshift.io/display-name":"Red Hat Single Sign-On 7.0"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/redhat-sso-7/sso70-openshift:1.3"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/redhat-sso-7/sso70-openshift:1.3"
                         }
                     },
                     {
-                        "name": "1.4",
-                        "annotations": {
-                            "description": "Red Hat SSO 7.0",
-                            "iconClass": "icon-jboss",
-                            "tags": "hidden,sso,keycloak,redhat",
-                            "supports": "sso:7.0,xpaas:1.4",
-                            "version": "1.4",
-                            "openshift.io/display-name": "Red Hat Single Sign-On 7.0"
+                        "name":"1.4",
+                        "annotations":{
+                            "description":"Red Hat SSO 7.0",
+                            "iconClass":"icon-jboss",
+                            "tags":"sso,keycloak,redhat,hidden",
+                            "supports":"sso:7.0:1.4",
+                            "version":"1.4",
+                            "openshift.io/display-name":"Red Hat Single Sign-On 7.0"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/redhat-sso-7/sso70-openshift:1.4"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/redhat-sso-7/sso70-openshift:1.4"
                         }
                     }
                 ]
             }
         },
         {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "redhat-sso71-openshift",
-                "annotations": {
-                    "description": "Red Hat SSO 7.1",
-                    "openshift.io/display-name": "Red Hat Single Sign-On 7.1",
-                    "version": "1.4.6"
+            "kind":"ImageStream",
+            "apiVersion":"v1",
+            "metadata":{
+                "name":"redhat-sso71-openshift",
+                "annotations":{
+                    "description":"Red Hat SSO 7.1",
+                    "openshift.io/display-name":"Red Hat Single Sign-On 7.1",
+                    "openshift.io/provider-display-name":"Red Hat, Inc.",
+                    "version":"1.4.6"
                 }
             },
-            "labels": {
-                "xpaas": "1.4.6"
+            "labels":{
+                "xpaas":"1.4.6"
             },
-            "spec": {
-                "tags": [
+            "spec":{
+                "tags":[
                     {
-                        "name": "TP",
-                        "annotations": {
-                            "description": "Red Hat SSO 7.1",
-                            "iconClass": "icon-jboss",
-                            "tags": "sso,keycloak,redhat",
-                            "supports": "sso:7.1,xpaas:1.4",
-                            "version": "1.0",
-                            "openshift.io/display-name": "Red Hat Single Sign-On 7.1 (Tech Preview)"
+                        "name":"TP",
+                        "annotations":{
+                            "description":"Red Hat SSO 7.1",
+                            "iconClass":"icon-jboss",
+                            "tags":"sso,keycloak,redhat,hidden",
+                            "supports":"sso:7.1:1.4",
+                            "version":"1.0",
+                            "openshift.io/display-name":"Red Hat Single Sign-On 7.1 (Tech Preview)"
                         },
-                        "from": {
-                            "kind": "ImageStreamTag",
-                            "name": "1.2-TP"
+                        "from":{
+                            "kind":"ImageStreamTag",
+                            "name":"1.2-TP"
                         }
                     },
                     {
-                        "name": "1.0",
-                        "annotations": {
-                            "description": "Red Hat SSO 7.1",
-                            "iconClass": "icon-jboss",
-                            "tags": "sso,keycloak,redhat",
-                            "supports": "sso:7.1,xpaas:1.4",
-                            "version": "1.0",
-                            "openshift.io/display-name": "Red Hat Single Sign-On 7.1"
+                        "name":"1.0",
+                        "annotations":{
+                            "description":"Red Hat SSO 7.1",
+                            "iconClass":"icon-jboss",
+                            "tags":"sso,keycloak,redhat,hidden",
+                            "supports":"sso:7.1:1.4",
+                            "version":"1.0",
+                            "openshift.io/display-name":"Red Hat Single Sign-On 7.1"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/redhat-sso-7/sso71-openshift:1.0"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/redhat-sso-7/sso71-openshift:1.0"
                         }
                     },
                     {
-                        "name": "1.1",
-                        "annotations": {
-                            "description": "Red Hat SSO 7.1",
-                            "iconClass": "icon-jboss",
-                            "tags": "sso,keycloak,redhat",
-                            "supports": "sso:7.1,xpaas:1.4",
-                            "version": "1.1",
-                            "openshift.io/display-name": "Red Hat Single Sign-On 7.1"
+                        "name":"1.1",
+                        "annotations":{
+                            "description":"Red Hat SSO 7.1",
+                            "iconClass":"icon-jboss",
+                            "tags":"sso,keycloak,redhat,hidden",
+                            "supports":"sso:7.1:1.4",
+                            "version":"1.1",
+                            "openshift.io/display-name":"Red Hat Single Sign-On 7.1"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/redhat-sso-7/sso71-openshift:1.1"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/redhat-sso-7/sso71-openshift:1.1"
                         }
                     },
                     {
-                        "name": "1.2-TP",
-                        "annotations": {
-                            "description": "Red Hat SSO 7.1",
-                            "iconClass": "icon-jboss",
-                            "tags": "sso,keycloak,redhat",
-                            "supports": "sso:7.1,xpaas:1.4",
-                            "version": "1.2",
-                            "openshift.io/display-name": "Red Hat Single Sign-On 7.1 (Tech Preview)"
+                        "name":"1.2-TP",
+                        "annotations":{
+                            "description":"Red Hat SSO 7.1",
+                            "iconClass":"icon-jboss",
+                            "tags":"sso,keycloak,redhat,hidden",
+                            "supports":"sso:7.1:1.4",
+                            "version":"1.2",
+                            "openshift.io/display-name":"Red Hat Single Sign-On 7.1 (Tech Preview)"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/redhat-sso-7-tech-preview/sso71-openshift:1.2"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/redhat-sso-7-tech-preview/sso71-openshift:1.2"
                         }
                     }
                 ]
             }
         },
         {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "redhat-openjdk18-openshift",
-                "annotations": {
-                    "openshift.io/display-name": "Red Hat OpenJDK 8",
-                    "version": "1.4.6"
+            "kind":"ImageStream",
+            "apiVersion":"v1",
+            "metadata":{
+                "name":"redhat-openjdk18-openshift",
+                "annotations":{
+                    "openshift.io/display-name":"Red Hat OpenJDK 8",
+                    "openshift.io/provider-display-name":"Red Hat, Inc.",
+                    "version":"1.4.6"
                 }
             },
-            "labels": {
-                "xpaas": "1.4.6"
+            "labels":{
+                "xpaas":"1.4.6"
             },
-            "spec": {
-                "tags": [
+            "spec":{
+                "tags":[
                     {
-                        "name": "TP",
-                        "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8 (Tech Preview)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
-                            "iconClass": "icon-jboss",
-                            "tags": "builder,java,xpaas,openjdk",
-                            "supports": "java:8,xpaas:1.0",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "TP"
+                        "name":"TP",
+                        "annotations":{
+                            "openshift.io/display-name":"Red Hat OpenJDK 8 (Tech Preview)",
+                            "description":"Build and run Java applications using Maven and OpenJDK 8.",
+                            "iconClass":"icon-openjdk",
+                            "tags":"builder,java,openjdk",
+                            "supports":"java:8:1.0",
+                            "sampleRepo":"https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir":"undertow-servlet",
+                            "version":"TP"
                         },
-                        "from": {
-                            "kind": "ImageStreamTag",
-                            "name": "1.2-TP"
+                        "from":{
+                            "kind":"ImageStreamTag",
+                            "name":"1.2-TP"
                         }
                     },
                     {
-                        "name": "1.0",
-                        "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
-                            "iconClass": "icon-jboss",
-                            "tags": "builder,java,xpaas,openjdk",
-                            "supports": "java:8,xpaas:1.0",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "1.0"
+                        "name":"1.0",
+                        "annotations":{
+                            "openshift.io/display-name":"Red Hat OpenJDK 8",
+                            "description":"Build and run Java applications using Maven and OpenJDK 8.",
+                            "iconClass":"icon-openjdk",
+                            "tags":"builder,java,openjdk,hidden",
+                            "supports":"java:8:1.0",
+                            "sampleRepo":"https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir":"undertow-servlet",
+                            "version":"1.0"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.0"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.0"
                         }
                     },
                     {
-                        "name": "1.1",
-                        "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
-                            "iconClass": "icon-jboss",
-                            "tags": "builder,java,xpaas,openjdk",
-                            "supports": "java:8,xpaas:1.4",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "1.1"
+                        "name":"1.1",
+                        "annotations":{
+                            "openshift.io/display-name":"Red Hat OpenJDK 8",
+                            "description":"Build and run Java applications using Maven and OpenJDK 8.",
+                            "iconClass":"icon-openjdk",
+                            "tags":"builder,java,openjdk",
+                            "supports":"java:8:1.4",
+                            "sampleRepo":"https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir":"undertow-servlet",
+                            "version":"1.1"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.1"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.1"
                         }
                     },
                     {
-                        "name": "1.2-TP",
-                        "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8 (Tech Preview)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
-                            "iconClass": "icon-jboss",
-                            "tags": "builder,java,xpaas,openjdk",
-                            "supports": "java:8,xpaas:1.4",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "1.2"
+                        "name":"1.2-TP",
+                        "annotations":{
+                            "openshift.io/display-name":"Red Hat OpenJDK 8 (Tech Preview)",
+                            "description":"Build and run Java applications using Maven and OpenJDK 8.",
+                            "iconClass":"icon-openjdk",
+                            "tags":"builder,java,openjdk",
+                            "supports":"java:8:1.4",
+                            "sampleRepo":"https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir":"undertow-servlet",
+                            "version":"1.2"
                         },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/redhat-openjdk-18-tech-preview/openjdk18-openshift:1.2"
+                        "from":{
+                            "kind":"DockerImage",
+                            "name":"registry.access.redhat.com/redhat-openjdk-18-tech-preview/openjdk18-openshift:1.2"
                         }
                     }
                 ]

--- a/webserver/jws31-tomcat7-basic-s2i.json
+++ b/webserver/jws31-tomcat7-basic-s2i.json
@@ -4,10 +4,11 @@
     "metadata": {
         "annotations": {
             "iconClass": "icon-tomcat",
+            "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "Application template for JWS applications built using S2I.",
-            "tags": "tomcat,tomcat7,java,jboss,xpaas",
+            "tags": "tomcat,tomcat7,java,jboss,hidden",
             "version": "1.4.6",
-            "openshift.io/display-name": "Red Hat JBoss Web Server 3.1 Tomcat 7 (no https)"
+            "openshift.io/display-name": "JBoss Web Server 3.1 Tomcat 7 (no https)"
         },
         "name": "jws31-tomcat7-basic-s2i"
     },

--- a/webserver/jws31-tomcat7-https-s2i.json
+++ b/webserver/jws31-tomcat7-https-s2i.json
@@ -4,10 +4,15 @@
     "metadata": {
         "annotations": {
             "iconClass": "icon-tomcat",
-            "description": "Application template for JWS applications built using S2I.",
-            "tags": "tomcat,tomcat7,java,jboss,xpaas",
+            "openshift.io/provider-display-name": "Red Hat, Inc.",
+            "description": "An example JBoss Web Server application configured for use with https. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
+            "tags": "tomcat,tomcat7,java,jboss",
             "version": "1.4.6",
-            "openshift.io/display-name": "Red Hat JBoss Web Server 3.1 Tomcat 7 (with https)"
+            "openshift.io/display-name": "JBoss Web Server 3.1 Tomcat 7 (with https)",
+            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 3.1 Tomcat 7 based application, including a build configuration, and application deployment configuration. This also illustrations how to connect to the web applicaiton using https.",
+            "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-web-server/",
+            "template.openshift.io/support-url": "https://access.redhat.com"
+
         },
         "name": "jws31-tomcat7-https-s2i"
     },

--- a/webserver/jws31-tomcat7-mongodb-persistent-s2i.json
+++ b/webserver/jws31-tomcat7-mongodb-persistent-s2i.json
@@ -4,10 +4,14 @@
     "metadata": {
         "annotations": {
             "iconClass": "icon-tomcat",
-            "description": "Application template for JWS MongoDB applications with persistent storage built using S2I.",
-            "tags": "tomcat,tomcat7,java,jboss,xpaas",
+            "openshift.io/provider-display-name": "Red Hat, Inc.",
+            "tags": "tomcat,tomcat7,java,jboss",
             "version": "1.4.6",
-            "openshift.io/display-name": "Red Hat JBoss Web Server 3.1 Tomcat 7 + MongoDB (Persistent with https)"
+            "openshift.io/display-name": "JBoss Web Server 3.1 Tomcat 7 + MongoDB (with https)",
+            "description": "An example JBoss Web Server application with a MongoDB database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
+            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 3.1 Tomcat 7 based application, including a build configuration, application deployment configuration, database deployment configuration for MongoDB using persistence and secure communication using https.",
+            "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-web-server/",
+            "template.openshift.io/support-url": "https://access.redhat.com"
         },
         "name": "jws31-tomcat7-mongodb-persistent-s2i"
     },

--- a/webserver/jws31-tomcat7-mongodb-s2i.json
+++ b/webserver/jws31-tomcat7-mongodb-s2i.json
@@ -4,10 +4,11 @@
     "metadata": {
         "annotations": {
             "iconClass": "icon-tomcat",
+            "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "Application template for JWS MongoDB applications built using S2I.",
-            "tags": "tomcat,tomcat7,java,jboss,xpaas",
+            "tags": "tomcat,tomcat7,java,jboss,hidden",
             "version": "1.4.6",
-            "openshift.io/display-name": "Red Hat JBoss Web Server 3.1 Tomcat 7 + MongoDB (Ephemeral with https)"
+            "openshift.io/display-name": "JBoss Web Server 3.1 Tomcat 7 + MongoDB (Ephemeral with https)"
         },
         "name": "jws31-tomcat7-mongodb-s2i"
     },

--- a/webserver/jws31-tomcat7-mysql-persistent-s2i.json
+++ b/webserver/jws31-tomcat7-mysql-persistent-s2i.json
@@ -4,10 +4,15 @@
     "metadata": {
         "annotations": {
             "iconClass": "icon-tomcat",
-            "description": "Application template for JWS MySQL applications with persistent storage built using S2I.",
-            "tags": "tomcat,tomcat7,java,jboss,xpaas",
+            "openshift.io/provider-display-name": "Red Hat, Inc.",
+            "tags": "tomcat,tomcat7,java,jboss",
             "version": "1.4.6",
-            "openshift.io/display-name": "Red Hat JBoss Web Server 3.1 Tomcat 7 + MySQL (Persistent with https)"
+            "openshift.io/display-name": "Red Hat JBoss Web Server 3.1 Tomcat 7 + MySQL (with https)",
+            "description": "An example JBoss Web Server application with a MySQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
+            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 3.1 Tomcat 7 based application, including a build configuration, application deployment configuration, database deployment configuration for MySQL using persistence and secure communication using https.",
+            "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-web-server/",
+            "template.openshift.io/support-url": "https://access.redhat.com"
+
         },
         "name": "jws31-tomcat7-mysql-persistent-s2i"
     },

--- a/webserver/jws31-tomcat7-mysql-s2i.json
+++ b/webserver/jws31-tomcat7-mysql-s2i.json
@@ -4,10 +4,11 @@
     "metadata": {
         "annotations": {
             "iconClass": "icon-tomcat",
+            "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "Application template for JWS MySQL applications built using S2I.",
-            "tags": "tomcat,tomcat7,java,jboss,xpaas",
+            "tags": "tomcat,tomcat7,java,jboss,hidden",
             "version": "1.4.6",
-            "openshift.io/display-name": "Red Hat JBoss Web Server 3.1 Tomcat 7 + MySQL (Ephemeral with https)"
+            "openshift.io/display-name": "JBoss Web Server 3.1 Tomcat 7 + MySQL (Ephemeral with https)"
         },
         "name": "jws31-tomcat7-mysql-s2i"
     },

--- a/webserver/jws31-tomcat7-postgresql-persistent-s2i.json
+++ b/webserver/jws31-tomcat7-postgresql-persistent-s2i.json
@@ -4,10 +4,14 @@
     "metadata": {
         "annotations": {
             "iconClass": "icon-tomcat",
-            "description": "Application template for JWS PostgreSQL applications with persistent storage built using S2I.",
-            "tags": "tomcat,tomcat7,java,jboss,xpaas",
+            "openshift.io/provider-display-name": "Red Hat, Inc.",
+            "tags": "tomcat,tomcat7,java,jboss",
             "version": "1.4.6",
-            "openshift.io/display-name": "Red Hat JBoss Web Server 3.1 Tomcat 7 + PostgreSQL (Persistent with https)"
+            "openshift.io/display-name": "JBoss Web Server 3.1 Tomcat 7 + PostgreSQL (with https)",
+            "description": "An example JBoss Web Server application with a PostgreSQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
+            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 3.1 Tomcat 8 based application, including a build configuration, application deployment configuration, database deployment configuration for PostgreSQL using persistence and secure communication using https.",
+            "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-web-server/",
+            "template.openshift.io/support-url": "https://access.redhat.com"
         },
         "name": "jws31-tomcat7-postgresql-persistent-s2i"
     },

--- a/webserver/jws31-tomcat7-postgresql-s2i.json
+++ b/webserver/jws31-tomcat7-postgresql-s2i.json
@@ -4,10 +4,11 @@
     "metadata": {
         "annotations": {
             "iconClass": "icon-tomcat",
+            "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "Application template for JWS PostgreSQL applications built using S2I.",
-            "tags": "tomcat,tomcat7,java,jboss,xpaas",
+            "tags": "tomcat,tomcat7,java,jboss,hidden",
             "version": "1.4.6",
-            "openshift.io/display-name": "Red Hat JBoss Web Server 3.1 Tomcat 7 + PostgreSQL (Ephemeral with https)"
+            "openshift.io/display-name": "JBoss Web Server 3.1 Tomcat 7 + PostgreSQL (Ephemeral with https)"
         },
         "name": "jws31-tomcat7-postgresql-s2i"
     },

--- a/webserver/jws31-tomcat8-basic-s2i.json
+++ b/webserver/jws31-tomcat8-basic-s2i.json
@@ -4,10 +4,14 @@
     "metadata": {
         "annotations": {
             "iconClass": "icon-tomcat",
-            "description": "Application template for JWS applications built using S2I.",
-            "tags": "tomcat,tomcat8,java,jboss,xpaas",
+            "openshift.io/provider-display-name": "Red Hat, Inc.",
+            "tags": "tomcat,tomcat8,java,jboss",
             "version": "1.4.6",
-            "openshift.io/display-name": "Red Hat JBoss Web Server 3.1 Tomcat 8 (no https)"
+            "openshift.io/display-name": "JBoss Web Server 3.1 Tomcat 8 (no https)",
+            "description": "An example JBoss Web Server application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
+            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 3.1 Tomcat 8 based application, including a build configuration, and an application deployment configuration.",
+            "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-web-server/",
+            "template.openshift.io/support-url": "https://access.redhat.com"
         },
         "name": "jws31-tomcat8-basic-s2i"
     },

--- a/webserver/jws31-tomcat8-https-s2i.json
+++ b/webserver/jws31-tomcat8-https-s2i.json
@@ -4,10 +4,15 @@
     "metadata": {
         "annotations": {
             "iconClass": "icon-tomcat",
-            "description": "Application template for JWS applications built using S2I.",
-            "tags": "tomcat,tomcat8,java,jboss,xpaas",
+            "openshift.io/provider-display-name": "Red Hat, Inc.",
+            "tags": "tomcat,tomcat8,java,jboss",
             "version": "1.4.6",
-            "openshift.io/display-name": "Red Hat JBoss Web Server 3.1 Tomcat 8 (with https)"
+            "openshift.io/display-name": "JBoss Web Server 3.1 Tomcat 8 (with https)",
+            "description": "An example JBoss Web Server application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
+            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 3.1 Tomcat 8 based application, including a build configuration, application deployment configuration, and secure communication using https.",
+            "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-web-server/",
+            "template.openshift.io/support-url": "https://access.redhat.com"
+
         },
         "name": "jws31-tomcat8-https-s2i"
     },

--- a/webserver/jws31-tomcat8-mongodb-persistent-s2i.json
+++ b/webserver/jws31-tomcat8-mongodb-persistent-s2i.json
@@ -3,11 +3,16 @@
     "apiVersion": "v1",
     "metadata": {
         "annotations": {
-            "iconClass": "icon-tomcat",
-            "description": "Application template for JWS MongoDB applications with persistent storage built using S2I.",
-            "tags": "tomcat,tomcat8,java,jboss,xpaas",
+            "tags": "tomcat,tomcat8,java,jboss",
             "version": "1.4.6",
-            "openshift.io/display-name": "Red Hat JBoss Web Server 3.1 Tomcat 8 + MongoDB (Persistent with https)"
+            "iconClass": "icon-tomcat",
+            "openshift.io/provider-display-name": "Red Hat, Inc.",
+            "openshift.io/display-name": "JBoss Web Server 3.1 Tomcat 8 + MongoDB (with https)",
+            "description": "An example JBoss Web Server application with a MongoDB database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
+            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 3.1 Tomcat 8 based application, including a build configuration, application deployment configuration, database deployment configuration for MongoDB using persistence and secure communication using https.",
+            "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-web-server/",
+            "template.openshift.io/support-url": "https://access.redhat.com"
+
         },
         "name": "jws31-tomcat8-mongodb-persistent-s2i"
     },

--- a/webserver/jws31-tomcat8-mongodb-s2i.json
+++ b/webserver/jws31-tomcat8-mongodb-s2i.json
@@ -4,10 +4,11 @@
     "metadata": {
         "annotations": {
             "iconClass": "icon-tomcat",
+            "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "Application template for JWS MongoDB applications built using S2I.",
-            "tags": "tomcat,tomcat8,java,jboss,xpaas",
+            "tags": "tomcat,tomcat8,java,jboss,hidden",
             "version": "1.4.6",
-            "openshift.io/display-name": "Red Hat JBoss Web Server 3.1 Tomcat 8 + MongoDB (Ephemeral with https)"
+            "openshift.io/display-name": "JBoss Web Server 3.1 Tomcat 8 + MongoDB (Ephemeral with https)"
         },
         "name": "jws31-tomcat8-mongodb-s2i"
     },

--- a/webserver/jws31-tomcat8-mysql-persistent-s2i.json
+++ b/webserver/jws31-tomcat8-mysql-persistent-s2i.json
@@ -4,10 +4,14 @@
     "metadata": {
         "annotations": {
             "iconClass": "icon-tomcat",
-            "description": "Application template for JWS MySQL applications with persistent storage built using S2I.",
-            "tags": "tomcat,tomcat8,java,jboss,xpaas",
+            "openshift.io/provider-display-name": "Red Hat, Inc.",
+            "tags": "tomcat,tomcat8,java,jboss",
             "version": "1.4.6",
-            "openshift.io/display-name": "Red Hat JBoss Web Server 3.1 Tomcat 8 + MySQL (Persistent with https)"
+            "openshift.io/display-name": "JBoss Web Server 3.1 Tomcat 8 + MySQL (with https)",
+            "description": "An example JBoss Web Server application with a MySQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
+            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 3.1 Tomcat 8 based application, including a build configuration, application deployment configuration, database deployment configuration for MySQL using persistence and secure communication using https.",
+            "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-web-server/",
+            "template.openshift.io/support-url": "https://access.redhat.com"
         },
         "name": "jws31-tomcat8-mysql-persistent-s2i"
     },

--- a/webserver/jws31-tomcat8-mysql-s2i.json
+++ b/webserver/jws31-tomcat8-mysql-s2i.json
@@ -4,10 +4,11 @@
     "metadata": {
         "annotations": {
             "iconClass": "icon-tomcat",
+            "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "Application template for JWS MySQL applications built using S2I.",
-            "tags": "tomcat,tomcat8,java,jboss,xpaas",
+            "tags": "tomcat,tomcat8,java,jboss,hidden",
             "version": "1.4.6",
-            "openshift.io/display-name": "Red Hat JBoss Web Server 3.1 Tomcat 8 + MySQL (Ephemeral with https)"
+            "openshift.io/display-name": "JBoss Web Server 3.1 Tomcat 8 + MySQL (Ephemeral with https)"
         },
         "name": "jws31-tomcat8-mysql-s2i"
     },

--- a/webserver/jws31-tomcat8-postgresql-persistent-s2i.json
+++ b/webserver/jws31-tomcat8-postgresql-persistent-s2i.json
@@ -4,10 +4,11 @@
     "metadata": {
         "annotations": {
             "iconClass": "icon-tomcat",
+            "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "Application template for JWS PostgreSQL applications with persistent storage built using S2I.",
-            "tags": "tomcat,tomcat8,java,jboss,xpaas",
+            "tags": "tomcat,tomcat8,java,jboss,hidden",
             "version": "1.4.6",
-            "openshift.io/display-name": "Red Hat JBoss Web Server 3.1 Tomcat 8 + PostgreSQL (Persistent with https)"
+            "openshift.io/display-name": "JBoss Web Server 3.1 Tomcat 8 + PostgreSQL (with https)"
         },
         "name": "jws31-tomcat8-postgresql-persistent-s2i"
     },

--- a/webserver/jws31-tomcat8-postgresql-s2i.json
+++ b/webserver/jws31-tomcat8-postgresql-s2i.json
@@ -4,10 +4,11 @@
     "metadata": {
         "annotations": {
             "iconClass": "icon-tomcat",
+            "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "Application template for JWS PostgreSQL applications built using S2I.",
-            "tags": "tomcat,tomcat8,java,jboss,xpaas",
+            "tags": "tomcat,tomcat8,java,jboss,hidden",
             "version": "1.4.6",
-            "openshift.io/display-name": "Red Hat JBoss Web Server 3.0 Tomcat 8 + PostgreSQL (Ephemeral with https)" 
+            "openshift.io/display-name": "JBoss Web Server 3.0 Tomcat 8 + PostgreSQL (Ephemeral with https)"
         },
         "name": "jws31-tomcat8-postgresql-s2i"
     },


### PR DESCRIPTION
This includes image-stream and JWS template updates to better align
with changes for the OpenShift 3.7 new catalog experience.

This includes:
* Standard annotations for:
  * support URL
  * documentation URL
  * provider display name
  * long description
* Tagged some templates as 'hidden' to streamline content in UI

If these are agreed upon, I can help with the rest of the templates.
I'm not sure how the spacing/formatting for the image-stream got so far off. 