### PR TITLE
[CLOUD-1867] update datavirt-app-config secret to use new src location

### DIFF
--- a/secrets/datavirt-app-secret.yaml
+++ b/secrets/datavirt-app-secret.yaml
@@ -56,7 +56,7 @@ items:
       ACCOUNTS_H2_NONXA=true
       ACCOUNTS_H2_USERNAME=sa
       ACCOUNTS_H2_PASSWORD=sa
-      ACCOUNTS_H2_URL="jdbc:h2:/home/jboss/source/data/databases/h2/accounts"
+      ACCOUNTS_H2_URL="jdbc:h2:/opt/eap/standalone/data/databases/h2/accounts"
       # required, but unused...
       ACCOUNTS_H2_SERVICE_HOST=dummy
       ACCOUNTS_H2_SERVICE_PORT=12345
@@ -70,7 +70,7 @@ items:
       ACCOUNTS_DERBY_TX_ISOLATION=TRANSACTION_READ_UNCOMMITTED
       ACCOUNTS_DERBY_JTA=true
       # Connection info for xa datasource
-      ACCOUNTS_DERBY_XA_CONNECTION_PROPERTY_DatabaseName=/home/jboss/source/data/databases/derby/accounts
+      ACCOUNTS_DERBY_XA_CONNECTION_PROPERTY_DatabaseName=/opt/eap/standalone/data/databases/derby/accounts
       # _HOST and _PORT are required, but not used
       ACCOUNTS_DERBY_SERVICE_HOST=dummy
       ACCOUNTS_DERBY_SERVICE_PORT=1527
@@ -133,7 +133,7 @@ items:
       MARKETDATA_MODULE_SLOT=main
       MARKETDATA_CONNECTION_CLASS=org.teiid.resource.adapter.file.FileManagedConnectionFactory
       MARKETDATA_CONNECTION_JNDI=java:/marketdata-file
-      MARKETDATA_PROPERTY_ParentDirectory='/home/jboss/source/data/teiidfiles/data'
+      MARKETDATA_PROPERTY_ParentDirectory='/opt/eap/standalone/data/teiidfiles/data'
       MARKETDATA_PROPERTY_AllowParentPaths=true
 
       # The "Excel" files.
@@ -143,7 +143,7 @@ items:
       EXCEL_MODULE_ID=org.jboss.teiid.resource-adapter.file
       EXCEL_CONNECTION_CLASS=org.teiid.resource.adapter.file.FileManagedConnectionFactory
       EXCEL_CONNECTION_JNDI=java:/excel-file
-      EXCEL_PROPERTY_ParentDirectory='/home/jboss/source/data/teiidfiles/excelFiles/'
+      EXCEL_PROPERTY_ParentDirectory='/opt/eap/standalone/data/teiidfiles/excelFiles/'
       EXCEL_PROPERTY_AllowParentPaths=true
 
       # JDG configuration for materialization cache


### PR DESCRIPTION
Issue: [CLOUD-1867](https://issues.jboss.org/browse/CLOUD-1867)

Changes default value for APP_DATADIR (== data). Also, change tests to rely on new default value for APP_DATADIR.
Update datavirt-app-config secret to use new src location (/opt/eap/standalone/data/).
Add a new CTF test for custom APP_DATADIR value.

This PR works in conjunction with [#74](https://github.com/jboss-openshift/cct_module/pull/74) in cct_module.
This PR replaces [#305](https://github.com/jboss-openshift/application-templates/pull/305) in application-templates.

Please make sure your PR meets following requirements:

- [x] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull request does not include fixes for other issues than the main ticket
- [x] Attached commits represent unit of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@redhat.com>` - use `git commit -s`
