### PR TITLE
[CLOUD-2215] [SSO]Templates contain prestop lifecycle hook for gracef…

### DIFF
--- a/sso/sso71-https.json
+++ b/sso/sso71-https.json
@@ -376,17 +376,6 @@
                                         "readOnly": true
                                     }
                                 ],
-                                "lifecycle": {
-                                    "preStop": {
-                                        "exec": {
-                                            "command": [
-                                                "/opt/eap/bin/jboss-cli.sh",
-                                                "-c",
-                                                ":shutdown(timeout=60)"
-                                            ]
-                                        }
-                                    }
-                                },
                                 "livenessProbe": {
                                     "exec": {
                                         "command": [

--- a/sso/sso71-mysql-persistent.json
+++ b/sso/sso71-mysql-persistent.json
@@ -476,17 +476,6 @@
                                         "readOnly": true
                                     }
                                 ],
-                                "lifecycle": {
-                                    "preStop": {
-                                        "exec": {
-                                            "command": [
-                                                "/opt/eap/bin/jboss-cli.sh",
-                                                "-c",
-                                                ":shutdown(timeout=60)"
-                                            ]
-                                        }
-                                    }
-                                },
                                 "livenessProbe": {
                                     "exec": {
                                         "command": [

--- a/sso/sso71-mysql.json
+++ b/sso/sso71-mysql.json
@@ -476,17 +476,6 @@
                                         "readOnly": true
                                     }
                                 ],
-                                "lifecycle": {
-                                    "preStop": {
-                                        "exec": {
-                                            "command": [
-                                                "/opt/eap/bin/jboss-cli.sh",
-                                                "-c",
-                                                ":shutdown(timeout=60)"
-                                            ]
-                                        }
-                                    }
-                                },
                                 "livenessProbe": {
                                     "exec": {
                                         "command": [

--- a/sso/sso71-postgresql-persistent.json
+++ b/sso/sso71-postgresql-persistent.json
@@ -458,17 +458,6 @@
                                         "readOnly": true
                                     }
                                 ],
-                                "lifecycle": {
-                                    "preStop": {
-                                        "exec": {
-                                            "command": [
-                                                "/opt/eap/bin/jboss-cli.sh",
-                                                "-c",
-                                                ":shutdown(timeout=60)"
-                                            ]
-                                        }
-                                    }
-                                },
                                 "livenessProbe": {
                                     "exec": {
                                         "command": [

--- a/sso/sso71-postgresql.json
+++ b/sso/sso71-postgresql.json
@@ -458,17 +458,6 @@
                                         "readOnly": true
                                     }
                                 ],
-                                "lifecycle": {
-                                    "preStop": {
-                                        "exec": {
-                                            "command": [
-                                                "/opt/eap/bin/jboss-cli.sh",
-                                                "-c",
-                                                ":shutdown(timeout=60)"
-                                            ]
-                                        }
-                                    }
-                                },
                                 "livenessProbe": {
                                     "exec": {
                                         "command": [


### PR DESCRIPTION
…ul shutdown

https://issues.jboss.org/browse/CLOUD-2215

Removing preStop lifecyle hooks from sso71 templates

Needed to remove preStop lifecyle hooks from sso70 templates again as well since the sso-wip branch is behind master branch

Signed-off-by: Kyle Liberti <kliberti@redhat.com>