### PR TITLE
[CLOUD-2367] Rename existing templates using passthrough TLS termination mode

### DIFF
--- a/sso/README.md
+++ b/sso/README.md
@@ -11,13 +11,13 @@ Several templates are provided:
 |                                        | keystores, and RH-SSO truststore, backed by internal H2 database.      |
 | **_sso72-postgresql.json_**            | RH-SSO 7.2/Keycloak template backed by ephemeral PostgreSQL database.  |
 | **_sso72-postgresql-persistent.json_** | RH-SSO 7.2/Keycloak template backed by persistent PostgreSQL database. |
-| **_sso72-x509-postgresql-_**           | RH-SSO 7.2/Keycloak template with auto-generated HTTPS and JGroups     |
-| **_persistent.json_**                  | keystores, and RH-SSO truststore, backed by persistent PostgreSQL      |
+| **_sso72-x509-_**                      | RH-SSO 7.2/Keycloak template with auto-generated HTTPS and JGroups     |
+| **_postgresql-persistent.json_**       | keystores, and RH-SSO truststore, backed by persistent PostgreSQL      |
 |                                        | database.                                                              |
 | **_sso72-mysql.json_**                 | RH-SSO 7.2/Keycloak template backed by ephemeral MySQL database.       |
 | **_sso72-mysql-persistent.json_**      | RH-SSO 7.2/Keycloak template backed by persistent MySQL database.      |
-| **_sso72-x509-mysql-persistent.json_** | RH-SSO 7.2/Keycloak template with auto-generated HTTPS and JGroups     |
-|                                        | keystores, and RH-SSO truststore, backed by persistent MySQL database. |
+| **_sso72-x509-_**                      | RH-SSO 7.2/Keycloak template with auto-generated HTTPS and JGroups     |
+| **_mysql-persistent.json_**            | keystores, and RH-SSO truststore, backed by persistent MySQL database. |
 
 
 The templates are configured with the following basic parameters:

--- a/sso/sso72-https.json
+++ b/sso/sso72-https.json
@@ -6,10 +6,10 @@
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss,hidden",
             "version": "1.4.10",
-            "openshift.io/display-name": "Single Sign-On 7.2",
+            "openshift.io/display-name": "Red Hat Single Sign-On 7.2 (Ephemeral with passthrough TLS)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
-            "description": "An example SSO 7 application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
-            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.2 server based deployment.",
+            "description": "An example RH-SSO 7 application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
+            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.2 server based deployment, securing RH-SSO communication using passthrough TLS.",
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
             "template.openshift.io/support-url": "https://access.redhat.com"
         },
@@ -19,7 +19,7 @@
         "template": "sso72-https",
         "xpaas": "1.4.10"
     },
-    "message": "A new SSO service has been created in your project. The admin username/password for accessing the master realm via the SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing SSO requests.",
+    "message": "A new RH-SSO service has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
     "parameters": [
         {
             "displayName": "Application Name",
@@ -30,14 +30,14 @@
         },
         {
             "displayName": "Custom http Route Hostname",
-            "description": "Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>",
+            "description": "Custom hostname for http service route. Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>",
             "name": "HOSTNAME_HTTP",
             "value": "",
             "required": false
         },
         {
             "displayName": "Custom https Route Hostname",
-            "description": "Custom hostname for https service route.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>",
+            "description": "Custom hostname for https service route. Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>",
             "name": "HOSTNAME_HTTPS",
             "value": "",
             "required": false
@@ -139,65 +139,66 @@
             "required": true
         },
         {
-            "displayName": "SSO Admin Username",
-            "description": "SSO Server admin username",
+            "displayName": "RH-SSO Administrator Username",
+            "description": "RH-SSO Server administrator username",
             "name": "SSO_ADMIN_USERNAME",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
             "required": true
         },
         {
-            "displayName": "SSO Admin Password",
-            "description": "SSO Server admin  password",
+            "displayName": "RH-SSO Administrator Password",
+            "description": "RH-SSO Server administrator password",
             "name": "SSO_ADMIN_PASSWORD",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
             "required": true
         },
         {
-            "displayName": "SSO Realm",
-            "description": "Realm to be created in the SSO server (e.g. demo).",
+            "displayName": "RH-SSO Realm",
+            "description": "Realm to be created in the RH-SSO server (e.g. demorealm).",
             "name": "SSO_REALM",
             "value": "",
             "required": false
         },
         {
-            "displayName": "SSO Service Username",
-            "description": "The username used to access the SSO service.  This is used by clients to create the appliction client(s) within the specified SSO realm.",
+            "displayName": "RH-SSO Service Username",
+            "description": "The username used to access the RH-SSO service. This is used by clients to create the appliction client(s) within the specified RH-SSO realm.",
             "name": "SSO_SERVICE_USERNAME",
             "value": "",
             "required": false
         },
         {
-            "displayName": "SSO Service Password",
-            "description": "The password for the SSO service user.",
+            "displayName": "RH-SSO Service Password",
+            "description": "The password for the RH-SSO service user.",
             "name": "SSO_SERVICE_PASSWORD",
             "value": "",
             "required": false
         },
         {
-            "displayName": "SSO Trust Store",
+            "displayName": "RH-SSO Trust Store",
             "description": "The name of the truststore file within the secret (e.g. truststore.jks)",
             "name": "SSO_TRUSTSTORE",
             "value": "",
             "required": false
         },
         {
-            "displayName": "SSO Trust Store Password",
+            "displayName": "RH-SSO Trust Store Password",
             "description": "The password for the truststore and certificate (e.g. mykeystorepass)",
             "name": "SSO_TRUSTSTORE_PASSWORD",
             "value": "",
             "required": false
         },
         {
-            "displayName": "SSO Trust Store Secret",
+            "displayName": "RH-SSO Trust Store Secret",
             "description": "The name of the secret containing the truststore file (e.g. truststore-secret). Used for volume secretName",
             "name": "SSO_TRUSTSTORE_SECRET",
             "value": "sso-app-secret",
             "required": false
         },
         {
-            "description": "Container memory limit",
+            "displayName": "Container Memory Limit",
+            "description": "Container memory limit.",
             "name": "MEMORY_LIMIT",
             "value": "1Gi",
             "required": false

--- a/sso/sso72-mysql-persistent.json
+++ b/sso/sso72-mysql-persistent.json
@@ -4,12 +4,12 @@
     "metadata": {
         "annotations": {
             "iconClass" : "icon-sso",
-            "tags" : "sso,keycloak,jboss",
+            "tags" : "sso,keycloak,jboss,hidden",
             "version": "1.4.10",
-            "openshift.io/display-name": "Single Sign-On 7.2 + MySQL",
+            "openshift.io/display-name": "Red Hat Single Sign-On 7.2 + MySQL (Persistent with passthrough TLS)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
-            "description": "An example SSO 7 application with a MySQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
-            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.2 server based deployment and deployment configuration for MySQL using persistence.",
+            "description": "An example RH-SSO 7 application with a MySQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
+            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.2 server based deployment, deployment configuration for MySQL using persistence, and securing RH-SSO communication using passthrough TLS.",
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
             "template.openshift.io/support-url": "https://access.redhat.com"
         },
@@ -19,7 +19,7 @@
         "template": "sso72-mysql-persistent",
         "xpaas": "1.4.10"
     },
-    "message": "A new persistent SSO service (using MySQL) has been created in your project. The admin username/password for accessing the master realm via the SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the MySQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing SSO requests.",
+    "message": "A new persistent RH-SSO service (using MySQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the MySQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
     "parameters": [
         {
             "displayName": "Application Name",
@@ -30,14 +30,14 @@
         },
         {
             "displayName": "Custom http Route Hostname",
-            "description": "Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>",
+            "description": "Custom hostname for http service route. Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>",
             "name": "HOSTNAME_HTTP",
             "value": "",
             "required": false
         },
         {
             "displayName": "Custom https Route Hostname",
-            "description": "Custom hostname for https service route.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>",
+            "description": "Custom hostname for https service route. Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>",
             "name": "HOSTNAME_HTTPS",
             "value": "",
             "required": false
@@ -206,58 +206,58 @@
             "required": true
         },
         {
-            "displayName": "SSO Admin Username",
-            "description": "SSO Server admin username",
+            "displayName": "RH-SSO Administrator Username",
+            "description": "RH-SSO Server administrator username",
             "name": "SSO_ADMIN_USERNAME",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
             "required": true
         },
         {
-            "displayName": "SSO Admin Password",
-            "description": "SSO Server admin  password",
+            "displayName": "RH-SSO Administrator Password",
+            "description": "RH-SSO Server administrator password",
             "name": "SSO_ADMIN_PASSWORD",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
             "required": true
         },
         {
-            "displayName": "SSO Realm",
-            "description": "Realm to be created in the SSO server (e.g. demo).",
+            "displayName": "RH-SSO Realm",
+            "description": "Realm to be created in the RH-SSO server (e.g. demorealm).",
             "name": "SSO_REALM",
             "value": "",
             "required": false
         },
         {
-            "displayName": "SSO Service Username",
-            "description": "The username used to access the SSO service.  This is used by clients to create the appliction client(s) within the specified SSO realm.",
+            "displayName": "RH-SSO Service Username",
+            "description": "The username used to access the RH-SSO service. This is used by clients to create the appliction client(s) within the specified RH-SSO realm.",
             "name": "SSO_SERVICE_USERNAME",
             "value": "",
             "required": false
         },
         {
-            "displayName": "SSO Service Password",
-            "description": "The password for the SSO service user.",
+            "displayName": "RH-SSO Service Password",
+            "description": "The password for the RH-SSO service user.",
             "name": "SSO_SERVICE_PASSWORD",
             "value": "",
             "required": false
         },
         {
-            "displayName": "SSO Trust Store",
+            "displayName": "RH-SSO Trust Store",
             "description": "The name of the truststore file within the secret (e.g. truststore.jks)",
             "name": "SSO_TRUSTSTORE",
             "value": "",
             "required": false
         },
         {
-            "displayName": "SSO Trust Store Password",
+            "displayName": "RH-SSO Trust Store Password",
             "description": "The password for the truststore and certificate (e.g. mykeystorepass)",
             "name": "SSO_TRUSTSTORE_PASSWORD",
             "value": "",
             "required": false
         },
         {
-            "displayName": "SSO Trust Store Secret",
+            "displayName": "RH-SSO Trust Store Secret",
             "description": "The name of the secret containing the truststore file (e.g. truststore-secret). Used for volume secretName",
             "name": "SSO_TRUSTSTORE_SECRET",
             "value": "sso-app-secret",
@@ -265,13 +265,14 @@
         },
         {
             "displayName": "MySQL Image Stream Tag",
-            "description": "The tag to use for the \"mysql\" image stream.  Typically, this aligns with the major.minor version of MySQL.",
+            "description": "The tag to use for the \"mysql\" image stream. Typically, this aligns with the major.minor version of MySQL.",
             "name": "MYSQL_IMAGE_STREAM_TAG",
             "value": "5.7",
             "required": true
         },
         {
-            "description": "Container memory limit",
+            "displayName": "Container Memory Limit",
+            "description": "Container memory limit.",
             "name": "MEMORY_LIMIT",
             "value": "1Gi",
             "required": false

--- a/sso/sso72-mysql.json
+++ b/sso/sso72-mysql.json
@@ -6,10 +6,10 @@
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss,hidden",
             "version": "1.4.10",
-            "openshift.io/display-name": "Single Sign-On 7.2 + MySQL (Ephemeral)",
+            "openshift.io/display-name": "Red Hat Single Sign-On 7.2 + MySQL (Ephemeral with passthrough TLS)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
-            "description": "An example SSO 7 application with a MySQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
-            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.2 server based deployment and deployment configuration for MySQL using ephemeral (temporary) storage.",
+            "description": "An example RH-SSO 7 application with a MySQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
+            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.2 server based deployment, deployment configuration for MySQL using ephemeral (temporary) storage, and securing RH-SSO communication using passthrough TLS.",
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
             "template.openshift.io/support-url": "https://access.redhat.com"
         },
@@ -19,7 +19,7 @@
         "template": "sso72-mysql",
         "xpaas": "1.4.10"
     },
-    "message": "A new SSO service (using MySQL) has been created in your project. The admin username/password for accessing the master realm via the SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the MySQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing SSO requests.",
+    "message": "A new RH-SSO service (using MySQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the MySQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
     "parameters": [
         {
             "displayName": "Application Name",
@@ -30,14 +30,14 @@
         },
         {
             "displayName": "Custom http Route Hostname",
-            "description": "Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>",
+            "description": "Custom hostname for http service route. Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>",
             "name": "HOSTNAME_HTTP",
             "value": "",
             "required": false
         },
         {
             "displayName": "Custom https Route Hostname",
-            "description": "Custom hostname for https service route.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>",
+            "description": "Custom hostname for https service route. Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>",
             "name": "HOSTNAME_HTTPS",
             "value": "",
             "required": false
@@ -199,58 +199,58 @@
             "required": true
         },
         {
-            "displayName": "SSO Admin Username",
-            "description": "SSO Server admin username",
+            "displayName": "RH-SSO Administrator Username",
+            "description": "RH-SSO Server administrator username",
             "name": "SSO_ADMIN_USERNAME",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
             "required": true
         },
         {
-            "displayName": "SSO Admin Password",
-            "description": "SSO Server admin  password",
+            "displayName": "RH-SSO Administrator Password",
+            "description": "RH-SSO Server administrator password",
             "name": "SSO_ADMIN_PASSWORD",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
             "required": true
         },
         {
-            "displayName": "SSO Realm",
-            "description": "Realm to be created in the SSO server (e.g. demo).",
+            "displayName": "RH-SSO Realm",
+            "description": "Realm to be created in the RH-SSO server (e.g. demorealm).",
             "name": "SSO_REALM",
             "value": "",
             "required": false
         },
         {
-            "displayName": "SSO Service Username",
-            "description": "The username used to access the SSO service.  This is used by clients to create the appliction client(s) within the specified SSO realm.",
+            "displayName": "RH-SSO Service Username",
+            "description": "The username used to access the RH-SSO service. This is used by clients to create the appliction client(s) within the specified RH-SSO realm.",
             "name": "SSO_SERVICE_USERNAME",
             "value": "",
             "required": false
         },
         {
-            "displayName": "SSO Service Password",
-            "description": "The password for the SSO service user.",
+            "displayName": "RH-SSO Service Password",
+            "description": "The password for the RH-SSO service user.",
             "name": "SSO_SERVICE_PASSWORD",
             "value": "",
             "required": false
         },
         {
-            "displayName": "SSO Trust Store",
+            "displayName": "RH-SSO Trust Store",
             "description": "The name of the truststore file within the secret (e.g. truststore.jks)",
             "name": "SSO_TRUSTSTORE",
             "value": "",
             "required": false
         },
         {
-            "displayName": "SSO Trust Store Password",
+            "displayName": "RH-SSO Trust Store Password",
             "description": "The password for the truststore and certificate (e.g. mykeystorepass)",
             "name": "SSO_TRUSTSTORE_PASSWORD",
             "value": "",
             "required": false
         },
         {
-            "displayName": "SSO Trust Store Secret",
+            "displayName": "RH-SSO Trust Store Secret",
             "description": "The name of the secret containing the truststore file (e.g. truststore-secret). Used for volume secretName",
             "name": "SSO_TRUSTSTORE_SECRET",
             "value": "sso-app-secret",
@@ -258,13 +258,14 @@
         },
         {
             "displayName": "MySQL Image Stream Tag",
-            "description": "The tag to use for the \"mysql\" image stream.  Typically, this aligns with the major.minor version of MySQL.",
+            "description": "The tag to use for the \"mysql\" image stream. Typically, this aligns with the major.minor version of MySQL.",
             "name": "MYSQL_IMAGE_STREAM_TAG",
             "value": "5.7",
             "required": true
         },
         {
-            "description": "Container memory limit",
+            "displayName": "Container Memory Limit",
+            "description": "Container memory limit.",
             "name": "MEMORY_LIMIT",
             "value": "1Gi",
             "required": false

--- a/sso/sso72-postgresql-persistent.json
+++ b/sso/sso72-postgresql-persistent.json
@@ -4,12 +4,12 @@
     "metadata": {
         "annotations": {
             "iconClass" : "icon-sso",
-            "tags" : "sso,keycloak,jboss",
+            "tags" : "sso,keycloak,jboss,hidden",
             "version": "1.4.10",
-            "openshift.io/display-name": "Single Sign-On 7.2 + PostgreSQL",
+            "openshift.io/display-name": "Red Hat Single Sign-On 7.2 + PostgreSQL (Persistent with passthrough TLS)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
-            "description": "An example SSO 7 application with a PostgreSQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
-            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.2 server based deployment and deployment configuration for PostgreSQL using persistence.",
+            "description": "An example RH-SSO 7 application with a PostgreSQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
+            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.2 server based deployment, deployment configuration for PostgreSQL using persistence, and securing RH-SSO communication using passthrough TLS.",
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
             "template.openshift.io/support-url": "https://access.redhat.com"
         },
@@ -19,7 +19,7 @@
         "template": "sso72-postgresql-persistent",
         "xpaas": "1.4.10"
     },
-    "message": "A new persistent SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing SSO requests.",
+    "message": "A new persistent RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
     "parameters": [
         {
             "displayName": "Application Name",
@@ -30,14 +30,14 @@
         },
         {
             "displayName": "Custom http Route Hostname",
-            "description": "Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>",
+            "description": "Custom hostname for http service route. Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>",
             "name": "HOSTNAME_HTTP",
             "value": "",
             "required": false
         },
         {
             "displayName": "Custom https Route Hostname",
-            "description": "Custom hostname for https service route.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>",
+            "description": "Custom hostname for https service route. Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>",
             "name": "HOSTNAME_HTTPS",
             "value": "",
             "required": false
@@ -188,58 +188,58 @@
             "required": true
         },
         {
-            "displayName": "SSO Admin Username",
-            "description": "SSO Server admin username",
+            "displayName": "RH-SSO Administrator Username",
+            "description": "RH-SSO Server administrator username",
             "name": "SSO_ADMIN_USERNAME",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
             "required": true
         },
         {
-            "displayName": "SSO Admin Password",
-            "description": "SSO Server admin  password",
+            "displayName": "RH-SSO Administrator Password",
+            "description": "RH-SSO Server administrator password",
             "name": "SSO_ADMIN_PASSWORD",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
             "required": true
         },
         {
-            "displayName": "SSO Realm",
-            "description": "Realm to be created in the SSO server (e.g. demo).",
+            "displayName": "RH-SSO Realm",
+            "description": "Realm to be created in the RH-SSO server (e.g. demorealm).",
             "name": "SSO_REALM",
             "value": "",
             "required": false
         },
         {
-            "displayName": "SSO Service Username",
-            "description": "The username used to access the SSO service.  This is used by clients to create the appliction client(s) within the specified SSO realm.",
+            "displayName": "RH-SSO Service Username",
+            "description": "The username used to access the RH-SSO service. This is used by clients to create the appliction client(s) within the specified RH-SSO realm.",
             "name": "SSO_SERVICE_USERNAME",
             "value": "",
             "required": false
         },
         {
-            "displayName": "SSO Service Password",
-            "description": "The password for the SSO service user.",
+            "displayName": "RH-SSO Service Password",
+            "description": "The password for the RH-SSO service user.",
             "name": "SSO_SERVICE_PASSWORD",
             "value": "",
             "required": false
         },
         {
-            "displayName": "SSO Trust Store",
+            "displayName": "RH-SSO Trust Store",
             "description": "The name of the truststore file within the secret (e.g. truststore.jks)",
             "name": "SSO_TRUSTSTORE",
             "value": "",
             "required": false
         },
         {
-            "displayName": "SSO Trust Store Password",
+            "displayName": "RH-SSO Trust Store Password",
             "description": "The password for the truststore and certificate (e.g. mykeystorepass)",
             "name": "SSO_TRUSTSTORE_PASSWORD",
             "value": "",
             "required": false
         },
         {
-            "displayName": "SSO Trust Store Secret",
+            "displayName": "RH-SSO Trust Store Secret",
             "description": "The name of the secret containing the truststore file (e.g. truststore-secret). Used for volume secretName",
             "name": "SSO_TRUSTSTORE_SECRET",
             "value": "sso-app-secret",
@@ -247,13 +247,14 @@
         },
         {
             "displayName": "PostgreSQL Image Stream Tag",
-            "description": "The tag to use for the \"postgresql\" image stream.  Typically, this aligns with the major.minor version of PostgreSQL.",
+            "description": "The tag to use for the \"postgresql\" image stream. Typically, this aligns with the major.minor version of PostgreSQL.",
             "name": "POSTGRESQL_IMAGE_STREAM_TAG",
             "value": "9.5",
             "required": true
         },
         {
-            "description": "Container memory limit",
+            "displayName": "Container Memory Limit",
+            "description": "Container memory limit.",
             "name": "MEMORY_LIMIT",
             "value": "1Gi",
             "required": false

--- a/sso/sso72-postgresql.json
+++ b/sso/sso72-postgresql.json
@@ -6,10 +6,10 @@
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss,hidden",
             "version": "1.4.10",
-            "openshift.io/display-name": "Single Sign-On 7.2 + PostgreSQL (Ephemeral)",
+            "openshift.io/display-name": "Red Hat Single Sign-On 7.2 + PostgreSQL (Ephemeral with passthrough TLS)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
-            "description": "An example SSO 7 application with a PostgreSQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
-            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.2 server based deployment and deployment configuration for PostgreSQL using ephemeral (temporary) storage.",
+            "description": "An example RH-SSO 7 application with a PostgreSQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
+            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.2 server based deployment, deployment configuration for PostgreSQL using ephemeral (temporary) storage, and securing RH-SSO communication using passthrough TLS.",
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
             "template.openshift.io/support-url": "https://access.redhat.com"
         },
@@ -19,7 +19,7 @@
         "template": "sso72-postgresql",
         "xpaas": "1.4.10"
     },
-    "message": "A new SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing SSO requests.",
+    "message": "A new RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
     "parameters": [
         {
             "displayName": "Application Name",
@@ -30,14 +30,14 @@
         },
         {
             "displayName": "Custom http Route Hostname",
-            "description": "Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>",
+            "description": "Custom hostname for http service route. Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>",
             "name": "HOSTNAME_HTTP",
             "value": "",
             "required": false
         },
         {
             "displayName": "Custom https Route Hostname",
-            "description": "Custom hostname for https service route.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>",
+            "description": "Custom hostname for https service route. Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>",
             "name": "HOSTNAME_HTTPS",
             "value": "",
             "required": false
@@ -181,58 +181,58 @@
             "required": true
         },
         {
-            "displayName": "SSO Admin Username",
-            "description": "SSO Server admin username",
+            "displayName": "RH-SSO Administrator Username",
+            "description": "RH-SSO Server administrator username",
             "name": "SSO_ADMIN_USERNAME",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
             "required": true
         },
         {
-            "displayName": "SSO Admin Password",
-            "description": "SSO Server admin  password",
+            "displayName": "RH-SSO Administrator Password",
+            "description": "RH-SSO Server administrator password",
             "name": "SSO_ADMIN_PASSWORD",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
             "required": true
         },
         {
-            "displayName": "SSO Realm",
-            "description": "Realm to be created in the SSO server (e.g. demo).",
+            "displayName": "RH-SSO Realm",
+            "description": "Realm to be created in the RH-SSO server (e.g. demorealm).",
             "name": "SSO_REALM",
             "value": "",
             "required": false
         },
         {
-            "displayName": "SSO Service Username",
-            "description": "The username used to access the SSO service.  This is used by clients to create the appliction client(s) within the specified SSO realm.",
+            "displayName": "RH-SSO Service Username",
+            "description": "The username used to access the RH-SSO service. This is used by clients to create the appliction client(s) within the specified RH-SSO realm.",
             "name": "SSO_SERVICE_USERNAME",
             "value": "",
             "required": false
         },
         {
-            "displayName": "SSO Service Password",
-            "description": "The password for the SSO service user.",
+            "displayName": "RH-SSO Service Password",
+            "description": "The password for the RH-SSO service user.",
             "name": "SSO_SERVICE_PASSWORD",
             "value": "",
             "required": false
         },
         {
-            "displayName": "SSO Trust Store",
+            "displayName": "RH-SSO Trust Store",
             "description": "The name of the truststore file within the secret (e.g. truststore.jks)",
             "name": "SSO_TRUSTSTORE",
             "value": "",
             "required": false
         },
         {
-            "displayName": "SSO Trust Store Password",
+            "displayName": "RH-SSO Trust Store Password",
             "description": "The password for the truststore and certificate (e.g. mykeystorepass)",
             "name": "SSO_TRUSTSTORE_PASSWORD",
             "value": "",
             "required": false
         },
         {
-            "displayName": "SSO Trust Store Secret",
+            "displayName": "RH-SSO Trust Store Secret",
             "description": "The name of the secret containing the truststore file (e.g. truststore-secret). Used for volume secretName",
             "name": "SSO_TRUSTSTORE_SECRET",
             "value": "sso-app-secret",
@@ -240,13 +240,14 @@
         },
         {
             "displayName": "PostgreSQL Image Stream Tag",
-            "description": "The tag to use for the \"postgresql\" image stream.  Typically, this aligns with the major.minor version of PostgreSQL.",
+            "description": "The tag to use for the \"postgresql\" image stream. Typically, this aligns with the major.minor version of PostgreSQL.",
             "name": "POSTGRESQL_IMAGE_STREAM_TAG",
             "value": "9.5",
             "required": true
         },
         {
-            "description": "Container memory limit",
+            "displayName": "Container Memory Limit",
+            "description": "Container memory limit.",
             "name": "MEMORY_LIMIT",
             "value": "1Gi",
             "required": false

--- a/sso/sso72-x509-https.json
+++ b/sso/sso72-x509-https.json
@@ -4,12 +4,12 @@
     "metadata": {
         "annotations": {
             "iconClass" : "icon-sso",
-            "tags" : "sso,keycloak,jboss,hidden",
+            "tags" : "sso,keycloak,jboss",
             "version": "1.4.10",
-            "openshift.io/display-name": "Single Sign-On 7.2",
+            "openshift.io/display-name": "Red Hat Single Sign-On 7.2 (Ephemeral)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example RH-SSO 7 application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
-            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.2 server based deployment.",
+            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.2 server based deployment, securing RH-SSO communication using re-encrypt TLS.",
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
             "template.openshift.io/support-url": "https://access.redhat.com"
         },

--- a/sso/sso72-x509-mysql-persistent.json
+++ b/sso/sso72-x509-mysql-persistent.json
@@ -6,10 +6,10 @@
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss",
             "version": "1.4.10",
-            "openshift.io/display-name": "Single Sign-On 7.2 + MySQL",
+            "openshift.io/display-name": "Red Hat Single Sign-On 7.2 + MySQL (Persistent)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example RH-SSO 7 application with a MySQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
-            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.2 server based deployment and deployment configuration for MySQL using persistence.",
+            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.2 server based deployment, deployment configuration for MySQL using persistence, and securing RH-SSO communication using re-encrypt TLS.",
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
             "template.openshift.io/support-url": "https://access.redhat.com"
         },

--- a/sso/sso72-x509-postgresql-persistent.json
+++ b/sso/sso72-x509-postgresql-persistent.json
@@ -6,10 +6,10 @@
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss",
             "version": "1.4.10",
-            "openshift.io/display-name": "Single Sign-On 7.2 + PostgreSQL",
+            "openshift.io/display-name": "Red Hat Single Sign-On 7.2 + PostgreSQL (Persistent)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example RH-SSO 7 application with a PostgreSQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
-            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.2 server based deployment and deployment configuration for PostgreSQL using persistence.",
+            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.2 server based deployment, deployment configuration for PostgreSQL using persistence, and securing RH-SSO communication using re-encrypt TLS.",
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
             "template.openshift.io/support-url": "https://access.redhat.com"
         },


### PR DESCRIPTION
```
Renamed:    sso72-mysql-persistent.json -> sso72-passthrough-mysql-persistent.json
Renamed:    sso72-mysql.json -> sso72-passthrough-mysql.json
Renamed:    sso72-postgresql-persistent.json -> sso72-passthrough-postgresql-persistent.json
Renamed:    sso72-postgresql.json -> sso72-passthrough-postgresql.json
Renamed:    sso72-https.json -> sso72-passthrough.json
```
Also:
* Replace 'SSO' with 'RH-SSO' where appropriate,
* Add 'displayName' field to MEMORY_LIMIT variable

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Note: This is a replacement for original CLOUD-2367 one. Instead of removing the `HTTP_HOSTNAME` / `HTTPS_HOSTNAME` variables, the agreement was to:
* Keep the `HTTP_HOSTNAME` / HTTPS_HOSTNAME` variables,
* Rename the templates using `passthrough` TLS termination mode for routes

instead of the original approach.