### PR TITLE
CLOUD-2365 - allow MAVEN_ARGS_APPEND to work for S2I builds

### DIFF
--- a/eap/eap71-amq-persistent-s2i.json
+++ b/eap/eap71-amq-persistent-s2i.json
@@ -251,6 +251,13 @@
             "required": false
         },
         {
+            "displayName": "Maven Additional Arguments",
+            "description": "Maven additional arguments to use for S2I builds",
+            "name": "MAVEN_ARGS_APPEND",
+            "value": "",
+            "required": false
+        },
+        {
             "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
             "name": "ARTIFACT_DIR",
             "value": "",
@@ -468,6 +475,10 @@
                             {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "MAVEN_ARGS_APPEND",
+                                "value": "${MAVEN_ARGS_APPEND}"
                             },
                             {
                                 "name": "ARTIFACT_DIR",

--- a/eap/eap71-amq-s2i.json
+++ b/eap/eap71-amq-s2i.json
@@ -237,6 +237,13 @@
             "required": false
         },
         {
+            "displayName": "Maven Additional Arguments",
+            "description": "Maven additional arguments to use for S2I builds",
+            "name": "MAVEN_ARGS_APPEND",
+            "value": "",
+            "required": false
+        },
+        {
             "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
             "name": "ARTIFACT_DIR",
             "value": "",
@@ -454,6 +461,10 @@
                             {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "MAVEN_ARGS_APPEND",
+                                "value": "${MAVEN_ARGS_APPEND}"
                             },
                             {
                                 "name": "ARTIFACT_DIR",

--- a/eap/eap71-basic-s2i.json
+++ b/eap/eap71-basic-s2i.json
@@ -46,7 +46,7 @@
             "displayName": "Git Reference",
             "description": "Git branch/tag reference",
             "name": "SOURCE_REPOSITORY_REF",
-            "value": "7.0.0.GA",
+            "value": "7.1.0.GA",
             "required": false
         },
         {
@@ -121,6 +121,13 @@
             "description": "Maven mirror to use for S2I builds",
             "name": "MAVEN_MIRROR_URL",
             "value": "",
+            "required": false
+        },
+        {
+            "displayName": "Maven Additional Arguments",
+            "description": "Maven additional arguments to use for S2I builds",
+            "name": "MAVEN_ARGS_APPEND",
+            "value": "-Dcom.redhat.xpaas.repo.jbossorg",
             "required": false
         },
         {
@@ -242,6 +249,10 @@
                             {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "MAVEN_ARGS_APPEND",
+                                "value": "${MAVEN_ARGS_APPEND}"
                             },
                             {
                                 "name": "ARTIFACT_DIR",

--- a/eap/eap71-https-s2i.json
+++ b/eap/eap71-https-s2i.json
@@ -53,7 +53,7 @@
             "displayName": "Git Reference",
             "description": "Git branch/tag reference",
             "name": "SOURCE_REPOSITORY_REF",
-            "value": "7.0.0.GA",
+            "value": "7.1.0.GA",
             "required": false
         },
         {
@@ -191,6 +191,13 @@
             "description": "Maven mirror to use for S2I builds",
             "name": "MAVEN_MIRROR_URL",
             "value": "",
+            "required": false
+        },
+        {
+            "displayName": "Maven Additional Arguments",
+            "description": "Maven additional arguments to use for S2I builds",
+            "name": "MAVEN_ARGS_APPEND",
+            "value": "-Dcom.redhat.xpaas.repo.jbossorg",
             "required": false
         },
         {
@@ -359,6 +366,10 @@
                             {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "MAVEN_ARGS_APPEND",
+                                "value": "${MAVEN_ARGS_APPEND}"
                             },
                             {
                                 "name": "ARTIFACT_DIR",

--- a/eap/eap71-image-stream.json
+++ b/eap/eap71-image-stream.json
@@ -34,7 +34,7 @@
                             "supports": "eap:7.1,javaee:7,java:8,xpass:1.0",
                             "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
                             "sampleContextDir": "kitchensink",
-                            "sampleRef": "7.0.0.GA",
+                            "sampleRef": "7.1.0.GA",
                             "version": "TP",
                             "openshift.io/display-name": "Red Hat JBoss EAP 7.1 (Tech Preview)"
                         },
@@ -52,7 +52,7 @@
                             "supports": "eap:7.1,javaee:7,java:8",
                             "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
                             "sampleContextDir": "kitchensink",
-                            "sampleRef": "7.0.0.GA",
+                            "sampleRef": "7.1.0.GA",
                             "version": "1.0",
                             "openshift.io/display-name": "Red Hat JBoss EAP 7.1 (Tech Preview)"
                         },
@@ -70,7 +70,7 @@
                             "supports": "eap:7.1,javaee:7,java:8",
                             "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
                             "sampleContextDir": "kitchensink",
-                            "sampleRef": "7.0.0.GA",
+                            "sampleRef": "7.1.0.GA",
                             "version": "1.0",
                             "openshift.io/display-name": "Red Hat JBoss EAP 7.1"
                         },
@@ -88,7 +88,7 @@
                             "supports": "eap:7.1,javaee:7,java:8",
                             "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
                             "sampleContextDir": "kitchensink",
-                            "sampleRef": "7.0.0.GA",
+                            "sampleRef": "7.1.0.GA",
                             "version": "1.2",
                             "openshift.io/display-name": "Red Hat JBoss EAP 7.1"
                         },

--- a/eap/eap71-mongodb-persistent-s2i.json
+++ b/eap/eap71-mongodb-persistent-s2i.json
@@ -275,6 +275,13 @@
             "required": false
         },
         {
+            "displayName": "Maven Additional Arguments",
+            "description": "Maven additional arguments to use for S2I builds",
+            "name": "MAVEN_ARGS_APPEND",
+            "value": "",
+            "required": false
+        },
+        {
             "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
             "name": "ARTIFACT_DIR",
             "value": "",
@@ -473,6 +480,10 @@
                             {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "MAVEN_ARGS_APPEND",
+                                "value": "${MAVEN_ARGS_APPEND}"
                             },
                             {
                                 "name": "ARTIFACT_DIR",

--- a/eap/eap71-mongodb-s2i.json
+++ b/eap/eap71-mongodb-s2i.json
@@ -268,6 +268,13 @@
             "required": false
         },
         {
+            "displayName": "Maven Additional Arguments",
+            "description": "Maven additional arguments to use for S2I builds",
+            "name": "MAVEN_ARGS_APPEND",
+            "value": "",
+            "required": false
+        },
+        {
             "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
             "name": "ARTIFACT_DIR",
             "value": "",
@@ -466,6 +473,10 @@
                             {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "MAVEN_ARGS_APPEND",
+                                "value": "${MAVEN_ARGS_APPEND}"
                             },
                             {
                                 "name": "ARTIFACT_DIR",

--- a/eap/eap71-mysql-persistent-s2i.json
+++ b/eap/eap71-mysql-persistent-s2i.json
@@ -279,6 +279,13 @@
             "required": false
         },
         {
+            "displayName": "Maven Additional Arguments",
+            "description": "Maven additional arguments to use for S2I builds",
+            "name": "MAVEN_ARGS_APPEND",
+            "value": "",
+            "required": false
+        },
+        {
             "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
             "name": "ARTIFACT_DIR",
             "value": "",
@@ -477,6 +484,10 @@
                             {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "MAVEN_ARGS_APPEND",
+                                "value": "${MAVEN_ARGS_APPEND}"
                             },
                             {
                                 "name": "ARTIFACT_DIR",

--- a/eap/eap71-mysql-s2i.json
+++ b/eap/eap71-mysql-s2i.json
@@ -272,6 +272,13 @@
             "required": false
         },
         {
+            "displayName": "Maven Additional Arguments",
+            "description": "Maven additional arguments to use for S2I builds",
+            "name": "MAVEN_ARGS_APPEND",
+            "value": "",
+            "required": false
+        },
+        {
             "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
             "name": "ARTIFACT_DIR",
             "value": "",
@@ -470,6 +477,10 @@
                             {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "MAVEN_ARGS_APPEND",
+                                "value": "${MAVEN_ARGS_APPEND}"
                             },
                             {
                                 "name": "ARTIFACT_DIR",

--- a/eap/eap71-postgresql-persistent-s2i.json
+++ b/eap/eap71-postgresql-persistent-s2i.json
@@ -261,6 +261,13 @@
             "required": false
         },
         {
+            "displayName": "Maven Additional Arguments",
+            "description": "Maven additional arguments to use for S2I builds",
+            "name": "MAVEN_ARGS_APPEND",
+            "value": "",
+            "required": false
+        },
+        {
             "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
             "name": "ARTIFACT_DIR",
             "value": "",
@@ -459,6 +466,10 @@
                             {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "MAVEN_ARGS_APPEND",
+                                "value": "${MAVEN_ARGS_APPEND}"
                             },
                             {
                                 "name": "ARTIFACT_DIR",

--- a/eap/eap71-postgresql-s2i.json
+++ b/eap/eap71-postgresql-s2i.json
@@ -254,6 +254,13 @@
             "required": false
         },
         {
+            "displayName": "Maven Additional Arguments",
+            "description": "Maven additional arguments to use for S2I builds",
+            "name": "MAVEN_ARGS_APPEND",
+            "value": "",
+            "required": false
+        },
+        {
             "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
             "name": "ARTIFACT_DIR",
             "value": "",
@@ -452,6 +459,10 @@
                             {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "MAVEN_ARGS_APPEND",
+                                "value": "${MAVEN_ARGS_APPEND}"
                             },
                             {
                                 "name": "ARTIFACT_DIR",

--- a/eap/eap71-sso-s2i.json
+++ b/eap/eap71-sso-s2i.json
@@ -328,6 +328,13 @@
             "required": false
         },
         {
+            "displayName": "Maven Additional Arguments",
+            "description": "Maven additional arguments to use for S2I builds",
+            "name": "MAVEN_ARGS_APPEND",
+            "value": "",
+            "required": false
+        },
+        {
             "description": "Container memory limit",
             "name": "MEMORY_LIMIT",
             "value": "1Gi",
@@ -495,12 +502,12 @@
                                 "value": "${ARTIFACT_DIR}"
                             },
                             {
-                                "name": "MAVEN_ARGS_APPEND",
-                                "value": ""
-                            },
-                            {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "MAVEN_ARGS_APPEND",
+                                "value": "${MAVEN_ARGS_APPEND}"
                             }
                         ]
                     }

--- a/eap/eap71-third-party-db-s2i.json
+++ b/eap/eap71-third-party-db-s2i.json
@@ -222,6 +222,13 @@
             "required": false
         },
         {
+            "displayName": "Maven Additional Arguments",
+            "description": "Maven additional arguments to use for S2I builds",
+            "name": "MAVEN_ARGS_APPEND",
+            "value": "",
+            "required": false
+        },
+        {
             "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
             "name": "ARTIFACT_DIR",
             "value": "",
@@ -402,6 +409,10 @@
                             {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "MAVEN_ARGS_APPEND",
+                                "value": "${MAVEN_ARGS_APPEND}"
                             },
                             {
                                 "name": "CUSTOM_INSTALL_DIRECTORIES",

--- a/eap/eap71-tx-recovery-s2i.json
+++ b/eap/eap71-tx-recovery-s2i.json
@@ -46,7 +46,7 @@
             "displayName": "Git Reference",
             "description": "Git branch/tag reference",
             "name": "SOURCE_REPOSITORY_REF",
-            "value": "7.0.0.GA",
+            "value": "7.1.0.GA",
             "required": false
         },
         {
@@ -121,6 +121,13 @@
             "description": "Maven mirror to use for S2I builds",
             "name": "MAVEN_MIRROR_URL",
             "value": "",
+            "required": false
+        },
+        {
+            "displayName": "Maven Additional Arguments",
+            "description": "Maven additional arguments to use for S2I builds",
+            "name": "MAVEN_ARGS_APPEND",
+            "value": "-Dcom.redhat.xpaas.repo.jbossorg",
             "required": false
         },
         {
@@ -256,6 +263,10 @@
                             {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "MAVEN_ARGS_APPEND",
+                                "value": "${MAVEN_ARGS_APPEND}"
                             },
                             {
                                 "name": "ARTIFACT_DIR",


### PR DESCRIPTION
This is needed to fetch the parent pom used in the EAP 7.1.0.GA quickstarts.
https://issues.jboss.org/browse/CLOUD-2365
https://issues.jboss.org/browse/CLOUD-2206