### PR TITLE
[CLOUD-2261] adding permisssion to list pods

### DIFF
--- a/eap/eap71-tx-recovery-s2i.json
+++ b/eap/eap71-tx-recovery-s2i.json
@@ -159,6 +159,30 @@
     ],
     "objects": [
         {
+            "apiVersion": "v1",
+            "kind": "ServiceAccount",
+            "metadata": {
+                "name": "${APPLICATION_NAME}-sa"
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "RoleBinding",
+            "metadata": {
+                "name": "${APPLICATION_NAME}-role-binding"
+            },
+            "subjects": [
+                {
+                    "kind": "ServiceAccount",
+                    "name": "${APPLICATION_NAME}-sa"
+                }
+            ],
+            "roleRef": {
+                "kind": "Role",
+                "name": "view"
+            }
+        },
+        {
             "kind": "Service",
             "apiVersion": "v1",
             "spec": {
@@ -354,6 +378,7 @@
                         }
                     },
                     "spec": {
+                        "serviceAccountName": "${APPLICATION_NAME}-sa",
                         "terminationGracePeriodSeconds": 75,
                         "containers": [
                             {
@@ -503,6 +528,7 @@
                         }
                     },
                     "spec": {
+                        "serviceAccountName": "${APPLICATION_NAME}-sa",
                         "terminationGracePeriodSeconds": 75,
                         "containers": [
                             {


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-2261

Adding new system role with permission to query api to get list of pods. This is needed for case the recovery of transaction is done via apy querying as discussed at CLOUD-2261 and at document https://docs.google.com/document/d/1JdOTMP6pdexJ__KYlw9hgwR6DOCHTtYCQy7PqyMk8OU/edit

/cc @rcernich 