### PR TITLE
Removed EAP 7.1 tech preview tag

### DIFF
--- a/eap/eap71-image-stream.json
+++ b/eap/eap71-image-stream.json
@@ -26,42 +26,6 @@
             "spec": {
                 "tags": [
                     {
-                        "name": "TP",
-                        "annotations": {
-                            "description": "The latest available build of the JBoss EAP 7.1 S2I image.",
-                            "iconClass": "icon-eap",
-                            "tags": "builder,eap,javaee,java,jboss,hidden",
-                            "supports": "eap:7.1,javaee:7,java:8,xpass:1.0",
-                            "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
-                            "sampleContextDir": "kitchensink",
-                            "sampleRef": "7.1.0.GA",
-                            "version": "TP",
-                            "openshift.io/display-name": "Red Hat JBoss EAP 7.1 (Tech Preview)"
-                        },
-                        "from": {
-                          "kind": "ImageStreamTag",
-                          "name": "1.1"
-                        }
-                    },
-                    {
-                        "name": "1.0-TP",
-                        "annotations": {
-                            "description": "JBoss EAP 7.1 Tech Preview.",
-                            "iconClass": "icon-eap",
-                            "tags": "builder,eap,javaee,java,jboss,hidden",
-                            "supports": "eap:7.1,javaee:7,java:8",
-                            "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
-                            "sampleContextDir": "kitchensink",
-                            "sampleRef": "7.1.0.GA",
-                            "version": "1.0",
-                            "openshift.io/display-name": "Red Hat JBoss EAP 7.1 (Tech Preview)"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-eap-7-tech-preview/eap71-openshift:1.0"
-                        }
-                    },
-                    {
                         "name": "1.1",
                         "annotations": {
                             "description": "JBoss EAP 7.1 S2I image.",


### PR DESCRIPTION
The tech preview image no longer exists in registry.access, so remove the TP tag to prevent errors.