### PR TITLE
CLOUD-2249: Provide short image-stream name and simple tag names

### DIFF
--- a/openjdk/openjdk18-image-stream.json
+++ b/openjdk/openjdk18-image-stream.json
@@ -65,7 +65,7 @@
                             "openshift.io/display-name": "Red Hat OpenJDK 8",
                             "description": "Build and run Java applications using Maven and OpenJDK 8.",
                             "iconClass": "icon-rh-openjdk",
-                            "tags": "builder,java,openjdk",
+                            "tags": "builder,java,openjdk,hidden",
                             "supports": "java:8",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
                             "sampleContextDir": "undertow-servlet",
@@ -82,7 +82,7 @@
                             "openshift.io/display-name": "Red Hat OpenJDK 8",
                             "description": "Build and run Java applications using Maven and OpenJDK 8.",
                             "iconClass": "icon-rh-openjdk",
-                            "tags": "builder,java,openjdk",
+                            "tags": "builder,java,openjdk,hidden",
                             "supports": "java:8",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
                             "sampleContextDir": "undertow-servlet",
@@ -91,6 +91,59 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.3"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "java",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat OpenJDK 8",
+                    "openshift.io/provider-display-name": "Red Hat, Inc.",
+                    "version": "1.4.11"
+                }
+            },
+            "labels": {
+                "xpaas": "1.4.11"
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "8",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java:8,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "8"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:latest"
+                        }
+                    },
+                    {
+                        "name": "latest",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java:8,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "latest"
+                        },
+                        "from": {
+                            "kind": "ImageStreamTag",
+                            "name": "java:8"
                         }
                     }
                 ]


### PR DESCRIPTION
There is not good backwards compatible way to replace a imagestream name. We've gotten feedback it would be good to have a consistent experience for tools that use image-stream names, such as:

`oc new-app php:7.0 .`

Most developers know what this is and can quickly apply it to other frameworks, this PR allows for an example like:

`oc new-app java:8.0 .`

This has the burden of needing to update the tags/references in another section but probably worth the overhead for ease of use.