### PR TITLE
[CLOUD-2437] Templates changes related with JGroups ASYM_ENCRYPT support

### DIFF
--- a/sso/README.md
+++ b/sso/README.md
@@ -4,20 +4,22 @@ This project contains OpenShift v3 application templates which support Red Hat S
 ## Structure
 Several templates are provided:
 
-|     Template Name                      |                       Description                                      |
-| ---------------------------------------|----------------------------------------------------------------------- |
-| **_sso72-https.json_**                 | RH-SSO 7.2/Keycloak template backed by internal H2 database.           |
-| **_sso72-x509-https.json_**            | RH-SSO 7.2/Keycloak template with auto-generated HTTPS and JGroups     |
-|                                        | keystores, and RH-SSO truststore, backed by internal H2 database.      |
-| **_sso72-postgresql.json_**            | RH-SSO 7.2/Keycloak template backed by ephemeral PostgreSQL database.  |
-| **_sso72-postgresql-persistent.json_** | RH-SSO 7.2/Keycloak template backed by persistent PostgreSQL database. |
-| **_sso72-x509-_**                      | RH-SSO 7.2/Keycloak template with auto-generated HTTPS and JGroups     |
-| **_postgresql-persistent.json_**       | keystores, and RH-SSO truststore, backed by persistent PostgreSQL      |
-|                                        | database.                                                              |
-| **_sso72-mysql.json_**                 | RH-SSO 7.2/Keycloak template backed by ephemeral MySQL database.       |
-| **_sso72-mysql-persistent.json_**      | RH-SSO 7.2/Keycloak template backed by persistent MySQL database.      |
-| **_sso72-x509-_**                      | RH-SSO 7.2/Keycloak template with auto-generated HTTPS and JGroups     |
-| **_mysql-persistent.json_**            | keystores, and RH-SSO truststore, backed by persistent MySQL database. |
+|     Template Name                      |                       Description                                        |
+| ---------------------------------------|------------------------------------------------------------------------- |
+| **_sso72-https.json_**                 | RH-SSO 7.2/Keycloak template backed by internal H2 database.             |
+| **_sso72-x509-https.json_**            | RH-SSO 7.2/Keycloak template with auto-generated HTTPS keystore and      |
+|                                        | RH-SSO truststore, backed by internal H2 database. The ASYM\_ENCRYPT     |
+|                                        | JGroups protocol is used for encryption of cluster traffic.              |
+| **_sso72-postgresql.json_**            | RH-SSO 7.2/Keycloak template backed by ephemeral PostgreSQL database.    |
+| **_sso72-postgresql-persistent.json_** | RH-SSO 7.2/Keycloak template backed by persistent PostgreSQL database.   |
+| **_sso72-x509-_**                      | RH-SSO 7.2/Keycloak template with auto-generated HTTPS keystore and      |
+| **_postgresql-persistent.json_**       | RH-SSO truststore, backed by persistent PostgreSQL database. The         |
+|                                        | ASYM\_ENCRYPT JGroups protocol is used for encryption of cluster traffic.|
+| **_sso72-mysql.json_**                 | RH-SSO 7.2/Keycloak template backed by ephemeral MySQL database.         |
+| **_sso72-mysql-persistent.json_**      | RH-SSO 7.2/Keycloak template backed by persistent MySQL database.        |
+| **_sso72-x509-_**                      | RH-SSO 7.2/Keycloak template with auto-generated HTTPS keystore and      |
+| **_mysql-persistent.json_**            | RH-SSO truststore, backed by persistent MySQL database. The              |
+|                                        | ASYM\_ENCRYPT JGroups protocol is used for encryption of cluster traffic.|
 
 
 The templates are configured with the following basic parameters:

--- a/sso/sso72-x509-https.json
+++ b/sso/sso72-x509-https.json
@@ -154,7 +154,6 @@
                 },
                 "annotations": {
                     "service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
-                    "service.alpha.openshift.io/serving-cert-secret-name": "sso-x509-jgroups-secret",
                     "description": "The JGroups ping port for clustering."
                 }
             }
@@ -242,11 +241,6 @@
                                         "name": "sso-x509-https-volume",
                                         "mountPath": "/etc/x509/https",
                                         "readOnly": true
-                                    },
-                                    {
-                                        "name": "sso-x509-jgroups-volume",
-                                        "mountPath": "/etc/x509/jgroups",
-                                        "readOnly": true
                                     }
                                 ],
                                 "livenessProbe": {
@@ -324,6 +318,10 @@
                                         "value": "${JGROUPS_CLUSTER_PASSWORD}"
                                     },
                                     {
+                                        "name": "JGROUPS_ENCRYPT_PROTOCOL",
+                                        "value": "ASYM_ENCRYPT"
+                                    },
+                                    {
                                         "name": "SSO_ADMIN_USERNAME",
                                         "value": "${SSO_ADMIN_USERNAME}"
                                     },
@@ -351,12 +349,6 @@
                                 "name": "sso-x509-https-volume",
                                 "secret": {
                                     "secretName": "sso-x509-https-secret"
-                                }
-                            },
-                            {
-                                "name": "sso-x509-jgroups-volume",
-                                "secret": {
-                                    "secretName": "sso-x509-jgroups-secret"
                                 }
                             }
                         ]

--- a/sso/sso72-x509-mysql-persistent.json
+++ b/sso/sso72-x509-mysql-persistent.json
@@ -253,7 +253,6 @@
                 },
                 "annotations": {
                     "service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
-                    "service.alpha.openshift.io/serving-cert-secret-name": "sso-x509-jgroups-secret",
                     "description": "The JGroups ping port for clustering."
                 }
             }
@@ -340,11 +339,6 @@
                                     {
                                         "name": "sso-x509-https-volume",
                                         "mountPath": "/etc/x509/https",
-                                        "readOnly": true
-                                    },
-                                    {
-                                        "name": "sso-x509-jgroups-volume",
-                                        "mountPath": "/etc/x509/jgroups",
                                         "readOnly": true
                                     }
                                 ],
@@ -447,6 +441,10 @@
                                         "value": "${JGROUPS_CLUSTER_PASSWORD}"
                                     },
                                     {
+                                        "name": "JGROUPS_ENCRYPT_PROTOCOL",
+                                        "value": "ASYM_ENCRYPT"
+                                    },
+                                    {
                                         "name": "SSO_ADMIN_USERNAME",
                                         "value": "${SSO_ADMIN_USERNAME}"
                                     },
@@ -474,12 +472,6 @@
                                 "name": "sso-x509-https-volume",
                                 "secret": {
                                     "secretName": "sso-x509-https-secret"
-                                }
-                            },
-                            {
-                                "name": "sso-x509-jgroups-volume",
-                                "secret": {
-                                    "secretName": "sso-x509-jgroups-secret"
                                 }
                             }
                         ]

--- a/sso/sso72-x509-postgresql-persistent.json
+++ b/sso/sso72-x509-postgresql-persistent.json
@@ -235,7 +235,6 @@
                 },
                 "annotations": {
                     "service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
-                    "service.alpha.openshift.io/serving-cert-secret-name": "sso-x509-jgroups-secret",
                     "description": "The JGroups ping port for clustering."
                 }
             }
@@ -322,11 +321,6 @@
                                     {
                                         "name": "sso-x509-https-volume",
                                         "mountPath": "/etc/x509/https",
-                                        "readOnly": true
-                                    },
-                                    {
-                                        "name": "sso-x509-jgroups-volume",
-                                        "mountPath": "/etc/x509/jgroups",
                                         "readOnly": true
                                     }
                                 ],
@@ -429,6 +423,10 @@
                                         "value": "${JGROUPS_CLUSTER_PASSWORD}"
                                     },
                                     {
+                                        "name": "JGROUPS_ENCRYPT_PROTOCOL",
+                                        "value": "ASYM_ENCRYPT"
+                                    },
+                                    {
                                         "name": "SSO_ADMIN_USERNAME",
                                         "value": "${SSO_ADMIN_USERNAME}"
                                     },
@@ -456,12 +454,6 @@
                                 "name": "sso-x509-https-volume",
                                 "secret": {
                                     "secretName": "sso-x509-https-secret"
-                                }
-                            },
-                            {
-                                "name": "sso-x509-jgroups-volume",
-                                "secret": {
-                                    "secretName": "sso-x509-jgroups-secret"
                                 }
                             }
                         ]


### PR DESCRIPTION
Drop the:

- JGroups secret auto-generation, and
- associated JGroups volume and volumeMount

from x509 templates. These are not needed, since JGroups auto-generates its own private/public key pair.

Update README.md

Enable JGroups ASYM_ENCRYPT for RH-SSO x509 templates by default.

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>