### PR TITLE
CLOUD-2401 [EAP7] Align image import instructions and image name / version tags

### DIFF
--- a/eap/eap64-image-stream.json
+++ b/eap/eap64-image-stream.json
@@ -26,6 +26,24 @@
             "spec": {
                 "tags": [
                     {
+                        "name": "latest",
+                        "annotations": {
+                            "description": "JBoss EAP 6.4 S2I image (latest).",
+                            "iconClass": "icon-eap",
+                            "tags": "builder,eap,javaee,java,jboss,hidden",
+                            "supports": "eap:6.4,javaee:6,java:8",
+                            "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
+                            "sampleContextDir": "kitchensink",
+                            "sampleRef": "6.4.x",
+                            "version": "latest",
+                            "openshift.io/display-name": "Red Hat JBoss EAP 6.4"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/jboss-eap-6/eap64-openshift:latest"
+                        }
+                    },
+                    {
                         "name": "1.1",
                         "annotations": {
                             "description": "JBoss EAP 6.4 S2I images.",

--- a/eap/eap71-image-stream.json
+++ b/eap/eap71-image-stream.json
@@ -26,6 +26,24 @@
             "spec": {
                 "tags": [
                     {
+                        "name": "latest",
+                        "annotations": {
+                            "description": "JBoss EAP 7.1 S2I image (latest).",
+                            "iconClass": "icon-eap",
+                            "tags": "builder,eap,javaee,java,jboss,hidden",
+                            "supports": "eap:7.1,javaee:7,java:8",
+                            "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
+                            "sampleContextDir": "kitchensink",
+                            "sampleRef": "7.1.0.GA",
+                            "version": "latest",
+                            "openshift.io/display-name": "Red Hat JBoss EAP 7.1"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/jboss-eap-7/eap71-openshift:latest"
+                        }
+                    },
+                    {
                         "name": "1.1",
                         "annotations": {
                             "description": "JBoss EAP 7.1 S2I image.",


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-2401

This adds a :latest IS tag that points to the :latest docker image