### PR TITLE
CLOUD-2654 Introduce simple 'java' image stream name and tagging

### DIFF
--- a/openjdk/openjdk18-image-stream.json
+++ b/openjdk/openjdk18-image-stream.json
@@ -65,7 +65,7 @@
                             "openshift.io/display-name": "Red Hat OpenJDK 8",
                             "description": "Build and run Java applications using Maven and OpenJDK 8.",
                             "iconClass": "icon-rh-openjdk",
-                            "tags": "builder,java,openjdk",
+                            "tags": "builder,java,openjdk,hidden",
                             "supports": "java:8",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
                             "sampleContextDir": "undertow-servlet",
@@ -82,7 +82,7 @@
                             "openshift.io/display-name": "Red Hat OpenJDK 8",
                             "description": "Build and run Java applications using Maven and OpenJDK 8.",
                             "iconClass": "icon-rh-openjdk",
-                            "tags": "builder,java,openjdk",
+                            "tags": "builder,java,openjdk,hidden",
                             "supports": "java:8",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
                             "sampleContextDir": "undertow-servlet",
@@ -91,6 +91,59 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.3"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "java",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat OpenJDK 8",
+                    "openshift.io/provider-display-name": "Red Hat, Inc.",
+                    "version": "1.4.14"
+                }
+            },
+            "labels": {
+                "xpaas": "1.4.14"
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "8",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java:8,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "8"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:latest"
+                        }
+                    },
+                    {
+                        "name": "latest",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java:8,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "latest"
+                        },
+                        "from": {
+                            "kind": "ImageStreamTag",
+                            "name": "java:8"
                         }
                     }
                 ]

--- a/openjdk/openjdk18-web-basic-s2i.json
+++ b/openjdk/openjdk18-web-basic-s2i.json
@@ -160,7 +160,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "redhat-openjdk18-openshift:1.3"
+                            "name": "java:8"
                         }
                     }
                 },


### PR DESCRIPTION
supersedes #452.

@sspeiche, I simply rebased your change, updated the image stream to use the new image stream name, and added the jira id to the commit message (created a new jira for this change to separate it from the other changes).