### PR TITLE
[CLOUD-2261] adding permisssion to list pods for eap txn recovery template for EAP64

### DIFF
--- a/eap/eap64-tx-recovery-s2i.json
+++ b/eap/eap64-tx-recovery-s2i.json
@@ -152,6 +152,30 @@
     ],
     "objects": [
         {
+            "apiVersion": "v1",
+            "kind": "ServiceAccount",
+            "metadata": {
+                "name": "${APPLICATION_NAME}-sa"
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "RoleBinding",
+            "metadata": {
+                "name": "${APPLICATION_NAME}-role-binding"
+            },
+            "subjects": [
+                {
+                    "kind": "ServiceAccount",
+                    "name": "${APPLICATION_NAME}-sa"
+                }
+            ],
+            "roleRef": {
+                "kind": "Role",
+                "name": "view"
+            }
+        },
+        {
             "kind": "Service",
             "apiVersion": "v1",
             "spec": {
@@ -343,6 +367,7 @@
                         }
                     },
                     "spec": {
+                        "serviceAccountName": "${APPLICATION_NAME}-sa",
                         "terminationGracePeriodSeconds": 60,
                         "containers": [
                             {
@@ -492,6 +517,7 @@
                         }
                     },
                     "spec": {
+                        "serviceAccountName": "${APPLICATION_NAME}-sa",
                         "terminationGracePeriodSeconds": 60,
                         "containers": [
                             {


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-2261

There is a missing `View` role for the tx-recovery template for eap 6.4 which is needed for the fix of CLOUD-2261.
The follow-up to the PR: https://github.com/jboss-openshift/application-templates/pull/447

/cc @rcernich 