### PR TITLE
[CLOUD-2453][KEYCLOAK-7098] Add database connectivity check

### DIFF
--- a/sso/sso72-mysql-persistent.json
+++ b/sso/sso72-mysql-persistent.json
@@ -473,6 +473,11 @@
                                 "name": "${APPLICATION_NAME}",
                                 "image": "${APPLICATION_NAME}",
                                 "imagePullPolicy": "Always",
+                                "command": [
+                                    "/usr/bin/sh",
+                                    "-c",
+                                    "printf -v LOGDELIM '#%.0s' {0..5}; echo \"${LOGDELIM} Running database connectivity check ${LOGDELIM}\"; echo; echo \"Ensure a persistent volume is available for the \"${APPLICATION_NAME}-mysql-claim\" or a storage class is set.\"; until nc -w 3 -z ${APPLICATION_NAME}-mysql 3306; do echo \"Waiting for the \"${APPLICATION_NAME}-mysql\" service to become available..\"; sleep 5; done; echo \"Database connectivity check succeeded.\"; echo; echo \"${LOGDELIM} Starting the RH-SSO server ${LOGDELIM}\"; echo; /opt/eap/bin/openshift-launch.sh"
+                                ],
                                 "resources": {
                                     "limits": {
                                         "memory": "${MEMORY_LIMIT}"
@@ -498,7 +503,7 @@
                                 "livenessProbe": {
                                     "exec": {
                                         "command": [
-                                            "/bin/bash",
+                                            "/usr/bin/bash",
                                             "-c",
                                             "/opt/eap/bin/livenessProbe.sh"
                                         ]
@@ -508,7 +513,7 @@
                                 "readinessProbe": {
                                     "exec": {
                                         "command": [
-                                            "/bin/bash",
+                                            "/usr/bin/bash",
                                             "-c",
                                             "/opt/eap/bin/readinessProbe.sh"
                                         ]
@@ -749,7 +754,7 @@
                                     "timeoutSeconds": 1,
                                     "initialDelaySeconds": 5,
                                     "exec": {
-                                        "command": [ "/bin/sh", "-i", "-c",
+                                        "command": [ "/usr/bin/sh", "-i", "-c",
                                             "MYSQL_PWD=\"$MYSQL_PASSWORD\" mysql -h 127.0.0.1 -u $MYSQL_USER -D $MYSQL_DATABASE -e 'SELECT 1'"]
                                     }
                                 },

--- a/sso/sso72-postgresql-persistent.json
+++ b/sso/sso72-postgresql-persistent.json
@@ -455,6 +455,11 @@
                                 "name": "${APPLICATION_NAME}",
                                 "image": "${APPLICATION_NAME}",
                                 "imagePullPolicy": "Always",
+                                "command": [
+                                    "/usr/bin/sh",
+                                    "-c",
+                                    "printf -v LOGDELIM '#%.0s' {0..5}; echo \"${LOGDELIM} Running database connectivity check ${LOGDELIM}\"; echo; echo \"Ensure a persistent volume is available for the \"${APPLICATION_NAME}-postgresql-claim\" or a storage class is set.\"; until nc -w 3 -z ${APPLICATION_NAME}-postgresql 5432; do echo \"Waiting for the \"${APPLICATION_NAME}-postgresql\" service to become available..\"; sleep 5; done; echo \"Database connectivity check succeeded.\"; echo; echo \"${LOGDELIM} Starting the RH-SSO server ${LOGDELIM}\"; echo; /opt/eap/bin/openshift-launch.sh"
+                                ],
                                 "resources": {
                                     "limits": {
                                         "memory": "${MEMORY_LIMIT}"
@@ -480,7 +485,7 @@
                                 "livenessProbe": {
                                     "exec": {
                                         "command": [
-                                            "/bin/bash",
+                                            "/usr/bin/bash",
                                             "-c",
                                             "/opt/eap/bin/livenessProbe.sh"
                                         ]
@@ -490,7 +495,7 @@
                                 "readinessProbe": {
                                     "exec": {
                                         "command": [
-                                            "/bin/bash",
+                                            "/usr/bin/bash",
                                             "-c",
                                             "/opt/eap/bin/readinessProbe.sh"
                                         ]
@@ -731,7 +736,7 @@
                                     "timeoutSeconds": 1,
                                     "initialDelaySeconds": 5,
                                     "exec": {
-                                        "command": [ "/bin/sh", "-i", "-c", "psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'"]
+                                        "command": [ "/usr/bin/sh", "-i", "-c", "psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'"]
                                     }
                                 },
                                 "livenessProbe": {

--- a/sso/sso72-x509-mysql-persistent.json
+++ b/sso/sso72-x509-mysql-persistent.json
@@ -331,6 +331,11 @@
                                 "name": "${APPLICATION_NAME}",
                                 "image": "${APPLICATION_NAME}",
                                 "imagePullPolicy": "Always",
+                                "command": [
+                                    "/usr/bin/sh",
+                                    "-c",
+                                    "printf -v LOGDELIM '#%.0s' {0..5}; echo \"${LOGDELIM} Running database connectivity check ${LOGDELIM}\"; echo; echo \"Ensure a persistent volume is available for the \"${APPLICATION_NAME}-mysql-claim\" or a storage class is set.\"; until nc -w 3 -z ${APPLICATION_NAME}-mysql 3306; do echo \"Waiting for the \"${APPLICATION_NAME}-mysql\" service to become available..\"; sleep 5; done; echo \"Database connectivity check succeeded.\"; echo; echo \"${LOGDELIM} Starting the RH-SSO server ${LOGDELIM}\"; echo; /opt/eap/bin/openshift-launch.sh"
+                                ],
                                 "resources": {
                                     "limits": {
                                         "memory": "${MEMORY_LIMIT}"
@@ -351,7 +356,7 @@
                                 "livenessProbe": {
                                     "exec": {
                                         "command": [
-                                            "/bin/bash",
+                                            "/usr/bin/bash",
                                             "-c",
                                             "/opt/eap/bin/livenessProbe.sh"
                                         ]
@@ -361,7 +366,7 @@
                                 "readinessProbe": {
                                     "exec": {
                                         "command": [
-                                            "/bin/bash",
+                                            "/usr/bin/bash",
                                             "-c",
                                             "/opt/eap/bin/readinessProbe.sh"
                                         ]
@@ -548,7 +553,7 @@
                                     "timeoutSeconds": 1,
                                     "initialDelaySeconds": 5,
                                     "exec": {
-                                        "command": [ "/bin/sh", "-i", "-c",
+                                        "command": [ "/usr/bin/sh", "-i", "-c",
                                             "MYSQL_PWD=\"$MYSQL_PASSWORD\" mysql -h 127.0.0.1 -u $MYSQL_USER -D $MYSQL_DATABASE -e 'SELECT 1'"]
                                     }
                                 },

--- a/sso/sso72-x509-postgresql-persistent.json
+++ b/sso/sso72-x509-postgresql-persistent.json
@@ -313,6 +313,11 @@
                                 "name": "${APPLICATION_NAME}",
                                 "image": "${APPLICATION_NAME}",
                                 "imagePullPolicy": "Always",
+                                "command": [
+                                    "/usr/bin/sh",
+                                    "-c",
+                                    "printf -v LOGDELIM '#%.0s' {0..5}; echo \"${LOGDELIM} Running database connectivity check ${LOGDELIM}\"; echo; echo \"Ensure a persistent volume is available for the \"${APPLICATION_NAME}-postgresql-claim\" or a storage class is set.\"; until nc -w 3 -z ${APPLICATION_NAME}-postgresql 5432; do echo \"Waiting for the \"${APPLICATION_NAME}-postgresql\" service to become available..\"; sleep 5; done; echo \"Database connectivity check succeeded.\"; echo; echo \"${LOGDELIM} Starting the RH-SSO server ${LOGDELIM}\"; echo; /opt/eap/bin/openshift-launch.sh"
+                                ],
                                 "resources": {
                                     "limits": {
                                         "memory": "${MEMORY_LIMIT}"
@@ -333,7 +338,7 @@
                                 "livenessProbe": {
                                     "exec": {
                                         "command": [
-                                            "/bin/bash",
+                                            "/usr/bin/bash",
                                             "-c",
                                             "/opt/eap/bin/livenessProbe.sh"
                                         ]
@@ -343,7 +348,7 @@
                                 "readinessProbe": {
                                     "exec": {
                                         "command": [
-                                            "/bin/bash",
+                                            "/usr/bin/bash",
                                             "-c",
                                             "/opt/eap/bin/readinessProbe.sh"
                                         ]
@@ -530,7 +535,7 @@
                                     "timeoutSeconds": 1,
                                     "initialDelaySeconds": 5,
                                     "exec": {
-                                        "command": [ "/bin/sh", "-i", "-c", "psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'"]
+                                        "command": [ "/usr/bin/sh", "-i", "-c", "psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'"]
                                     }
                                 },
                                 "livenessProbe": {


### PR DESCRIPTION
prior launching the RH-SSO server when deploying the RH-SSO pod from persistent DB templates

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>