### PR TITLE
CLOUD-2088 - update EAP 6.4 templates and imagestreams to 1.4.18 for release 1.9.0

### DIFF
--- a/eap/eap64-amq-persistent-s2i.json
+++ b/eap/eap64-amq-persistent-s2i.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-eap",
             "tags": "eap,javaee,java,jboss",
-            "version": "1.4.17",
+            "version": "1.4.18",
             "openshift.io/display-name": "JBoss EAP 6.4 + A-MQ (with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example EAP 6 A-MQ application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "eap64-amq-persistent-s2i",
-        "xpaas": "1.4.17"
+        "xpaas": "1.4.18"
     },
     "message": "A new EAP 6 and A-MQ persistent based application with SSL support has been created in your project. The username/password for accessing the A-MQ service is ${MQ_USERNAME}/${MQ_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "parameters": [
@@ -478,7 +478,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "jboss-eap64-openshift:1.8"
+                            "name": "jboss-eap64-openshift:1.9"
                         }
                     }
                 },

--- a/eap/eap64-amq-s2i.json
+++ b/eap/eap64-amq-s2i.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-eap",
             "tags": "eap,javaee,java,jboss,hidden",
-            "version": "1.4.17",
+            "version": "1.4.18",
             "openshift.io/display-name": "JBoss EAP 6.4 + A-MQ (Ephemeral with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example EAP 6 A-MQ application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "eap64-amq-s2i",
-        "xpaas": "1.4.17"
+        "xpaas": "1.4.18"
     },
     "message": "A new EAP 6 and A-MQ based application with SSL support has been created in your project. The username/password for accessing the A-MQ service is ${MQ_USERNAME}/${MQ_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "parameters": [
@@ -464,7 +464,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "jboss-eap64-openshift:1.8"
+                            "name": "jboss-eap64-openshift:1.9"
                         }
                     }
                 },

--- a/eap/eap64-basic-s2i.json
+++ b/eap/eap64-basic-s2i.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-eap",
             "tags": "eap,javaee,java,jboss",
-            "version": "1.4.17",
+            "version": "1.4.18",
             "openshift.io/display-name": "JBoss EAP 6.4 (no https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example EAP 6 application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "eap64-basic-s2i",
-        "xpaas": "1.4.17"
+        "xpaas": "1.4.18"
     },
     "message": "A new EAP 6 based application has been created in your project.",
     "parameters": [
@@ -252,7 +252,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "jboss-eap64-openshift:1.8"
+                            "name": "jboss-eap64-openshift:1.9"
                         }
                     }
                 },

--- a/eap/eap64-https-s2i.json
+++ b/eap/eap64-https-s2i.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-eap",
             "tags": "eap,javaee,java,jboss,hidden",
-            "version": "1.4.17",
+            "version": "1.4.18",
             "openshift.io/display-name": "JBoss EAP 6.4 (with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example EAP 6 application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "eap64-https-s2i",
-        "xpaas": "1.4.17"
+        "xpaas": "1.4.18"
     },
     "message": "A new EAP 6 based application with SSL support has been created in your project. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "parameters": [
@@ -369,7 +369,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "jboss-eap64-openshift:1.8"
+                            "name": "jboss-eap64-openshift:1.9"
                         }
                     }
                 },

--- a/eap/eap64-image-stream.json
+++ b/eap/eap64-image-stream.json
@@ -17,11 +17,11 @@
                 "annotations": {
                     "openshift.io/display-name": "Red Hat JBoss EAP 6.4",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "1.4.17"
+                    "version": "1.4.18"
                 }
             },
             "labels": {
-                "xpaas": "1.4.17"
+                "xpaas": "1.4.18"
             },
             "spec": {
                 "tags": [
@@ -212,6 +212,27 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.redhat.io/jboss-eap-6/eap64-openshift:1.8"
+                        }
+                    },
+                    {
+                        "name": "1.9",
+                        "annotations": {
+                            "description": "JBoss EAP 6.4 S2I images.",
+                            "iconClass": "icon-eap",
+                            "tags": "builder,eap,javaee,java,jboss,hidden",
+                            "supports": "eap:6.4,javaee:6,java:8",
+                            "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
+                            "sampleContextDir": "kitchensink",
+                            "sampleRef": "6.4.x",
+                            "version": "1.9",
+                            "openshift.io/display-name": "Red Hat JBoss EAP 6.4"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/jboss-eap-6/eap64-openshift:1.9"
                         }
                     }
                 ]

--- a/eap/eap64-mongodb-persistent-s2i.json
+++ b/eap/eap64-mongodb-persistent-s2i.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-eap",
             "tags": "eap,javaee,java,jboss,hidden",
-            "version": "1.4.17",
+            "version": "1.4.18",
             "openshift.io/display-name": "JBoss EAP 6.4 + MongoDB (with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example EAP 6 application with a MongoDB database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "eap64-mongodb-persistent-s2i",
-        "xpaas": "1.4.17"
+        "xpaas": "1.4.18"
     },
     "message": "A new EAP 6 and MongoDB persistent based application with SSL support has been created in your project. The username/password for accessing the MongoDB database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD} (Admin password is \"${DB_ADMIN_PASSWORD}\"). Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "parameters": [
@@ -483,7 +483,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "jboss-eap64-openshift:1.8"
+                            "name": "jboss-eap64-openshift:1.9"
                         }
                     }
                 },

--- a/eap/eap64-mongodb-s2i.json
+++ b/eap/eap64-mongodb-s2i.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-eap",
             "tags": "eap,javaee,java,jboss,hidden",
-            "version": "1.4.17",
+            "version": "1.4.18",
             "openshift.io/display-name": "JBoss EAP 6.4 + MongoDB (Ephemeral with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example EAP 6 application with a MongoDB database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "eap64-mongodb-s2i",
-        "xpaas": "1.4.17"
+        "xpaas": "1.4.18"
     },
     "message": "A new EAP 6 and MongoDB based application with SSL support has been created in your project. The username/password for accessing the MongoDB database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD} (Admin password is \"${DB_ADMIN_PASSWORD}\"). Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "parameters": [
@@ -476,7 +476,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "jboss-eap64-openshift:1.8"
+                            "name": "jboss-eap64-openshift:1.9"
                         }
                     }
                 },

--- a/eap/eap64-mysql-persistent-s2i.json
+++ b/eap/eap64-mysql-persistent-s2i.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-eap",
             "tags": "eap,javaee,java,jboss",
-            "version": "1.4.17",
+            "version": "1.4.18",
             "openshift.io/display-name": "JBoss EAP 6.4 + MySQL (with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example EAP 6 application with a MySQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "eap64-mysql-persistent-s2i",
-        "xpaas": "1.4.17"
+        "xpaas": "1.4.18"
     },
     "message": "A new EAP 6 and MySQL persistent based application with SSL support has been created in your project. The username/password for accessing the MySQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "parameters": [
@@ -487,7 +487,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "jboss-eap64-openshift:1.8"
+                            "name": "jboss-eap64-openshift:1.9"
                         }
                     }
                 },

--- a/eap/eap64-mysql-s2i.json
+++ b/eap/eap64-mysql-s2i.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-eap",
             "tags": "eap,javaee,java,jboss,hidden",
-            "version": "1.4.17",
+            "version": "1.4.18",
             "openshift.io/display-name": "JBoss EAP 6.4 + MySQL (Ephemeral with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example EAP 6 application with a MySQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "eap64-mysql-s2i",
-        "xpaas": "1.4.17"
+        "xpaas": "1.4.18"
     },
     "message": "A new EAP 6 and MySQL based application with SSL support has been created in your project. The username/password for accessing the MySQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "parameters": [
@@ -480,7 +480,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "jboss-eap64-openshift:1.8"
+                            "name": "jboss-eap64-openshift:1.9"
                         }
                     }
                 },

--- a/eap/eap64-postgresql-persistent-s2i.json
+++ b/eap/eap64-postgresql-persistent-s2i.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-eap",
             "tags": "eap,javaee,java,jboss",
-            "version": "1.4.17",
+            "version": "1.4.18",
             "openshift.io/display-name": "Red Hat JBoss EAP 6.4 + PostgreSQL (Persistent with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example EAP 6 application with a PostgreSQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "eap64-postgresql-persistent-s2i",
-        "xpaas": "1.4.17"
+        "xpaas": "1.4.18"
     },
     "message": "A new EAP 6 and PostgreSQL persistent based application with SSL support has been created in your project. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "parameters": [
@@ -469,7 +469,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "jboss-eap64-openshift:1.8"
+                            "name": "jboss-eap64-openshift:1.9"
                         }
                     }
                 },

--- a/eap/eap64-postgresql-s2i.json
+++ b/eap/eap64-postgresql-s2i.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-eap",
             "tags": "eap,javaee,java,jboss,hidden",
-            "version": "1.4.17",
+            "version": "1.4.18",
             "openshift.io/display-name": "JBoss EAP 6.4 + PostgreSQL (Ephemeral with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example EAP 6 application with a PostgreSQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "eap64-postgresql-s2i",
-        "xpaas": "1.4.17"
+        "xpaas": "1.4.18"
     },
     "message": "A new EAP 6 and PostgreSQL based application with SSL support has been created in your project. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "parameters": [
@@ -462,7 +462,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "jboss-eap64-openshift:1.8"
+                            "name": "jboss-eap64-openshift:1.9"
                         }
                     }
                 },

--- a/eap/eap64-sso-s2i.json
+++ b/eap/eap64-sso-s2i.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-eap",
             "tags": "eap,javaee,java,jboss,hidden",
-            "version": "1.4.17",
+            "version": "1.4.18",
             "openshift.io/display-name": "JBoss EAP 6.4 + Single Sign-On (with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example EAP 6 Single Sign-On application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "eap64-sso-s2i",
-        "xpaas": "1.4.17"
+        "xpaas": "1.4.18"
     },
     "message": "A new EAP 6 based application with SSL and SSO support has been created in your project. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "parameters": [
@@ -487,7 +487,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "jboss-eap64-openshift:1.8"
+                            "name": "jboss-eap64-openshift:1.9"
                         },
                         "env": [
                             {

--- a/eap/eap64-third-party-db-s2i.json
+++ b/eap/eap64-third-party-db-s2i.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-eap",
             "tags": "eap,javaee,java,jboss,hidden",
-            "version": "1.4.17",
+            "version": "1.4.18",
             "openshift.io/display-name": "Red Hat JBoss EAP 6.4 (with https, DB drivers)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example EAP 6 DB application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "eap64-third-party-db-s2i",
-        "xpaas": "1.4.17"
+        "xpaas": "1.4.18"
     },
     "message": "A new EAP 6 based application with SSL support has been created in your project. Please be sure to create the following secrets:\"${CONFIGURATION_NAME}\" containing the datasource configuration details required by the deployed application(s);  \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "parameters": [
@@ -416,7 +416,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "jboss-eap64-openshift:1.8"
+                            "name": "jboss-eap64-openshift:1.9"
                         }
                     }
                 },

--- a/eap/eap64-tx-recovery-postgresql-s2i.json
+++ b/eap/eap64-tx-recovery-postgresql-s2i.json
@@ -504,7 +504,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "jboss-eap64-openshift:1.8"
+                            "name": "jboss-eap64-openshift:1.9"
                         }
                     }
                 },

--- a/eap/eap64-tx-recovery-s2i.json
+++ b/eap/eap64-tx-recovery-s2i.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-eap",
             "tags": "eap,javaee,java,jboss",
-            "version": "1.4.17",
+            "version": "1.4.18",
             "openshift.io/display-name": "JBoss EAP 6.4 (tx recovery)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example EAP 6 application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "eap64-tx-recovery-s2i",
-        "xpaas": "1.4.17"
+        "xpaas": "1.4.18"
     },
     "message": "A new EAP 6 based application has been created in your project.",
     "parameters": [
@@ -290,7 +290,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "jboss-eap64-openshift:1.8"
+                            "name": "jboss-eap64-openshift:1.9"
                         }
                     }
                 },


### PR DESCRIPTION
Signed-off-by: Ken Wills <kwills@redhat.com>
https://issues.jboss.org/browse/CLOUD-3088